### PR TITLE
Include repo name in worktree path

### DIFF
--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -56,8 +56,9 @@ tmux pane, and tracks the run state. Must be run inside a tmux session.`,
 			return err
 		}
 
+		repoName := filepath.Base(root)
 		branch := "agent/" + id
-		worktree := filepath.Join(cfg.WorktreeBase, id)
+		worktree := filepath.Join(cfg.WorktreeBase, repoName, id)
 		defaultBranch := cfg.DefaultBranch
 
 		fmt.Printf("Launching agent %s...\n", id)
@@ -76,7 +77,6 @@ tmux pane, and tracks the run state. Must be run inside a tmux session.`,
 		fmt.Printf("  branch:   %s\n", branch)
 
 		// Build system prompt
-		repoName := filepath.Base(root)
 		sysPrompt, err := config.RenderPrompt(root, config.PromptVars{
 			RunID:    id,
 			Issue:    issue,

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -50,7 +50,8 @@ clean on the default branch. Must be run inside a tmux session.`,
 		}
 		id := "session-" + baseID
 		branch := "session/" + id
-		worktree := filepath.Join(cfg.WorktreeBase, id)
+		repoName := filepath.Base(root)
+		worktree := filepath.Join(cfg.WorktreeBase, repoName, id)
 		defaultBranch := cfg.DefaultBranch
 
 		fmt.Printf("Creating coordinator session %s...\n", id)


### PR DESCRIPTION
## Summary
- Nests worktrees under the repo name so paths become `/tmp/klaus-sessions/<repo>/<id>` instead of `/tmp/klaus-sessions/<id>`
- Makes the project immediately visible in Claude Code's working directory display
- Applies to both session and agent worktrees

## Test plan
- [ ] Run `klaus session` and verify worktree is created at `<worktree_base>/<repo>/session-<id>`
- [ ] Run `klaus launch` and verify worktree is created at `<worktree_base>/<repo>/<id>`
- [ ] Verify `klaus cleanup` still works with the new paths