### PR TITLE
Use os.TempDir() for portable worktree base default

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Klaus works out of the box with sensible defaults. To customize, run `klaus init
 **`.klaus/config.json`** — Override defaults:
 ```json
 {
-  "worktree_base": "/tmp/klaus",
+  "worktree_base": "/tmp/klaus-sessions",
   "default_budget": "5.00",
   "data_ref": "refs/klaus/data",
   "default_branch": "main"

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -21,7 +21,7 @@ User prompt
   → klaus launch "<prompt>" --issue N --budget N
   → Generate run ID (YYYYMMDD-HHMM-XXXX)
   → git fetch origin main
-  → git worktree add /tmp/klaus/<id> -b agent/<id> origin/main
+  → git worktree add /tmp/klaus-sessions/<id> -b agent/<id> origin/main
   → Write state file to .git/klaus/runs/<id>.json
   → Build claude command with stream-json output
   → tmux split-window: claude | tee <log> | klaus _format-stream; klaus _finalize <id>
@@ -52,7 +52,7 @@ State + Log files (local .git/klaus/)
   "prompt": "Add bluetooth config",
   "issue": "42",
   "branch": "agent/20260210-1430-a3f2",
-  "worktree": "/tmp/klaus/20260210-1430-a3f2",
+  "worktree": "/tmp/klaus-sessions/20260210-1430-a3f2",
   "tmux_pane": "%5",
   "budget": "5.00",
   "log_file": "/path/to/.git/klaus/logs/20260210-1430-a3f2.jsonl",
@@ -68,7 +68,7 @@ State + Log files (local .git/klaus/)
 `.klaus/config.json`:
 ```json
 {
-  "worktree_base": "/tmp/klaus",
+  "worktree_base": "/tmp/klaus-sessions",
   "default_budget": "5.00",
   "data_ref": "refs/klaus/data",
   "default_branch": "main"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,7 +20,7 @@ type Config struct {
 // Defaults returns a Config with default values.
 func Defaults() Config {
 	return Config{
-		WorktreeBase:  "/tmp/klaus",
+		WorktreeBase:  filepath.Join(os.TempDir(), "klaus-sessions"),
 		DefaultBudget: "5.00",
 		DataRef:       "refs/klaus/data",
 		DefaultBranch: "main",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,10 +8,12 @@ import (
 	"testing"
 )
 
+var wantWorktreeBase = filepath.Join(os.TempDir(), "klaus-sessions")
+
 func TestDefaults(t *testing.T) {
 	cfg := Defaults()
-	if cfg.WorktreeBase != "/tmp/klaus" {
-		t.Errorf("WorktreeBase = %q, want /tmp/klaus", cfg.WorktreeBase)
+	if cfg.WorktreeBase != wantWorktreeBase {
+		t.Errorf("WorktreeBase = %q, want %q", cfg.WorktreeBase, wantWorktreeBase)
 	}
 	if cfg.DefaultBudget != "5.00" {
 		t.Errorf("DefaultBudget = %q, want 5.00", cfg.DefaultBudget)
@@ -30,8 +32,8 @@ func TestLoadNoFile(t *testing.T) {
 		t.Fatalf("Load() error: %v", err)
 	}
 	// Should return defaults
-	if cfg.WorktreeBase != "/tmp/klaus" {
-		t.Errorf("WorktreeBase = %q, want /tmp/klaus", cfg.WorktreeBase)
+	if cfg.WorktreeBase != wantWorktreeBase {
+		t.Errorf("WorktreeBase = %q, want %q", cfg.WorktreeBase, wantWorktreeBase)
 	}
 }
 
@@ -167,8 +169,8 @@ func TestInit(t *testing.T) {
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		t.Fatalf("parsing config: %v", err)
 	}
-	if cfg.WorktreeBase != "/tmp/klaus" {
-		t.Errorf("config WorktreeBase = %q, want /tmp/klaus", cfg.WorktreeBase)
+	if cfg.WorktreeBase != wantWorktreeBase {
+		t.Errorf("config WorktreeBase = %q, want %q", cfg.WorktreeBase, wantWorktreeBase)
 	}
 
 	// Verify prompt.md exists

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -54,7 +54,7 @@ func TestSaveLoadRoundtrip(t *testing.T) {
 		Prompt:     "Add bluetooth config",
 		Issue:      &issue,
 		Branch:     "agent/20260210-1430-a3f2",
-		Worktree:   "/tmp/klaus/20260210-1430-a3f2",
+		Worktree:   "/tmp/klaus-sessions/20260210-1430-a3f2",
 		TmuxPane:   &pane,
 		Budget:     &budget,
 		LogFile:    &logFile,
@@ -100,7 +100,7 @@ func TestSaveLoadNullFields(t *testing.T) {
 		ID:        "20260210-1430-b1c2",
 		Prompt:    "Fix something",
 		Branch:    "agent/20260210-1430-b1c2",
-		Worktree:  "/tmp/klaus/20260210-1430-b1c2",
+		Worktree:  "/tmp/klaus-sessions/20260210-1430-b1c2",
 		CreatedAt: "2026-02-10T14:30:00-08:00",
 	}
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `/tmp/klaus` default with `filepath.Join(os.TempDir(), "klaus-sessions")`
- Fixes the binary collision (`/tmp/klaus` conflicts with the klaus binary) and makes the default portable across platforms where temp dirs differ (`$TMPDIR` on macOS, nix shells, etc.)
- Updates tests to assert against the dynamic path instead of hardcoded strings
- Updates docs to reflect the new `klaus-sessions` directory name

Supersedes #2 (includes the rename to `klaus-sessions` plus the portability fix from the review comment).

## Test plan
- [x] All existing tests pass
- [ ] Run `klaus session` and verify worktree is created under `os.TempDir()/klaus-sessions/<repo>/`
- [ ] Verify works on macOS where `$TMPDIR` != `/tmp`