### PR TITLE
Notify cosmo repo on push to main

### DIFF
--- a/.github/workflows/notify-cosmo.yml
+++ b/.github/workflows/notify-cosmo.yml
@@ -1,0 +1,16 @@
+name: Notify Cosmo
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to cosmo
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+        with:
+          token: ${{ secrets.COSMO_DISPATCH_TOKEN }}
+          repository: patflynn/cosmo
+          event-type: klaus-updated


### PR DESCRIPTION
## Summary

- Add `notify-cosmo.yml` workflow that sends a `repository_dispatch` event to `patflynn/cosmo` when main is updated
- This triggers cosmo's `update-klaus.yml` workflow to auto-update the klaus flake input

## Prerequisites

- `COSMO_DISPATCH_TOKEN` secret must be configured in this repo (fine-grained PAT scoped to `patflynn/cosmo` with `contents: write` + `pull-requests: write`)

## Test plan

- [ ] Merge this PR, then push a commit to main
- [ ] Verify a PR is auto-created in `patflynn/cosmo` updating the klaus flake input