### PR TITLE
Default 'klaus' with no arguments to start a session

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -16,8 +16,14 @@ var rootCmd = &cobra.Command{
 	Long: `klaus orchestrates parallel Claude Code agents using git worktrees and tmux panes.
 
 It launches autonomous agents in isolated worktrees, manages their lifecycle,
-streams and formats their output, and tracks run state.`,
+streams and formats their output, and tracks run state.
+
+Running 'klaus' with no arguments starts an interactive coordinator session
+(equivalent to 'klaus session').`,
 	Version: version,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return sessionCmd.RunE(sessionCmd, args)
+	},
 }
 
 func Execute() error {


### PR DESCRIPTION
## Summary
- Adds `RunE` to `rootCmd` in `internal/cmd/root.go` that delegates to `sessionCmd.RunE`, so running `klaus` with no arguments is equivalent to `klaus session`.
- Updates the `Long` description to document this default behavior.

## Test plan
- [x] `go build ./...` compiles cleanly
- [ ] Run `klaus` with no arguments inside a tmux session and verify it starts an interactive coordinator session
- [ ] Run `klaus session` and verify behavior is unchanged

Run: 20260220-0852-1785