### PR TITLE
Add session-specific system prompt via --append-system-prompt

### DIFF
--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -81,13 +81,23 @@ clean on the default branch. Must be run inside a tmux session.`,
 			return fmt.Errorf("saving state: %w", err)
 		}
 
+		// Render session system prompt
+		sessionPrompt, err := config.RenderSessionPrompt(root, config.PromptVars{
+			RunID:    id,
+			Branch:   branch,
+			RepoName: repoName,
+		})
+		if err != nil {
+			return fmt.Errorf("rendering session prompt: %w", err)
+		}
+
 		fmt.Println()
 		fmt.Println("Starting interactive Claude Code session...")
 		fmt.Println("  Use 'klaus launch' from inside to spawn workers.")
 		fmt.Println()
 
 		// Run claude interactively in the worktree
-		claude := exec.Command("claude")
+		claude := exec.Command("claude", "--append-system-prompt", sessionPrompt)
 		claude.Dir = worktree
 		claude.Stdin = os.Stdin
 		claude.Stdout = os.Stdout

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -152,6 +152,68 @@ func TestRenderPromptCustomTemplate(t *testing.T) {
 	}
 }
 
+func TestRenderSessionPromptDefault(t *testing.T) {
+	dir := t.TempDir() // no .klaus/session-prompt.md
+
+	vars := PromptVars{
+		RunID:    "session-20260210-1430-a3f2",
+		Branch:   "session/session-20260210-1430-a3f2",
+		RepoName: "test-repo",
+	}
+
+	prompt, err := RenderSessionPrompt(dir, vars)
+	if err != nil {
+		t.Fatalf("RenderSessionPrompt() error: %v", err)
+	}
+
+	if !strings.Contains(prompt, "session-20260210-1430-a3f2") {
+		t.Error("prompt should contain session ID")
+	}
+	if !strings.Contains(prompt, "session/session-20260210-1430-a3f2") {
+		t.Error("prompt should contain branch name")
+	}
+	if !strings.Contains(prompt, "test-repo") {
+		t.Error("prompt should contain repo name")
+	}
+	if !strings.Contains(prompt, "klaus launch") {
+		t.Error("prompt should contain klaus launch instruction")
+	}
+	if !strings.Contains(prompt, "klaus status") {
+		t.Error("prompt should contain klaus status instruction")
+	}
+	if !strings.Contains(prompt, "klaus logs") {
+		t.Error("prompt should contain klaus logs instruction")
+	}
+	if !strings.Contains(prompt, "klaus cleanup") {
+		t.Error("prompt should contain klaus cleanup instruction")
+	}
+}
+
+func TestRenderSessionPromptCustomTemplate(t *testing.T) {
+	dir := t.TempDir()
+	klausDir := filepath.Join(dir, ".klaus")
+	os.MkdirAll(klausDir, 0o755)
+
+	tmpl := "Session {{.RunID}} on branch {{.Branch}} for {{.RepoName}}"
+	os.WriteFile(filepath.Join(klausDir, "session-prompt.md"), []byte(tmpl), 0o644)
+
+	vars := PromptVars{
+		RunID:    "session-abc",
+		Branch:   "session/session-abc",
+		RepoName: "myrepo",
+	}
+
+	prompt, err := RenderSessionPrompt(dir, vars)
+	if err != nil {
+		t.Fatalf("RenderSessionPrompt() error: %v", err)
+	}
+
+	want := "Session session-abc on branch session/session-abc for myrepo"
+	if prompt != want {
+		t.Errorf("prompt = %q, want %q", prompt, want)
+	}
+}
+
 func TestInit(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary
- Adds a `defaultSessionPromptTemplate` and `RenderSessionPrompt` function to `internal/config/config.go` that renders a coordinator system prompt from `.klaus/session-prompt.md` (falling back to a built-in default)
- Updates `internal/cmd/session.go` to pass the rendered prompt to `claude` via `--append-system-prompt`, giving the session coordinator context about available `klaus` commands and the delegation workflow
- Adds tests for both default and custom session prompt rendering

## Test plan
- [x] `go build ./...` compiles successfully
- [x] `go test ./...` all tests pass
- [x] `TestRenderSessionPromptDefault` verifies template variable substitution and presence of all key instructions
- [x] `TestRenderSessionPromptCustomTemplate` verifies custom `.klaus/session-prompt.md` overrides the default

Run: 20260220-0857-2f3f