### PR TITLE
Skip permissions for coordinator session worktree

### DIFF
--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -97,7 +97,7 @@ clean on the default branch. Must be run inside a tmux session.`,
 		fmt.Println()
 
 		// Run claude interactively in the worktree
-		claude := exec.Command("claude", "--append-system-prompt", sessionPrompt)
+		claude := exec.Command("claude", "--dangerously-skip-permissions", "--append-system-prompt", sessionPrompt)
 		claude.Dir = worktree
 		claude.Stdin = os.Stdin
 		claude.Stdout = os.Stdout


### PR DESCRIPTION
## Summary
- Adds `--dangerously-skip-permissions` to the coordinator session's Claude invocation
- Eliminates the repeated workspace trust dialog when starting new sessions in fresh worktrees
- Consistent with the intended use of running klaus in isolated VMs

## Test plan
- [ ] Run `klaus session` and verify Claude starts without the trust prompt
- [ ] Verify agent launches from within the session still work as before