### PR TITLE
Write .claude/settings.json into worktrees with correct statusline

### DIFF
--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -75,6 +76,10 @@ tmux pane, and tracks the run state. Must be run inside a tmux session.`,
 		}
 		fmt.Printf("  worktree: %s\n", worktree)
 		fmt.Printf("  branch:   %s\n", branch)
+
+		if err := config.WriteClaudeSettings(worktree, repoName); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not write .claude/settings.json: %v\n", err)
+		}
 
 		// Build system prompt
 		sysPrompt, err := config.RenderPrompt(root, config.PromptVars{

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -67,6 +67,10 @@ clean on the default branch. Must be run inside a tmux session.`,
 		fmt.Printf("  worktree: %s\n", worktree)
 		fmt.Printf("  branch:   %s\n", branch)
 
+		if err := config.WriteClaudeSettings(worktree, repoName); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not write .claude/settings.json: %v\n", err)
+		}
+
 		// Write state
 		createdAt := time.Now().Format(time.RFC3339)
 		state := &run.State{


### PR DESCRIPTION
## Summary
- Adds `WriteClaudeSettings` helper in `internal/config/config.go` that writes a `.claude/settings.json` with a `statusLine` script showing `<repo> (<branch>)`
- Calls it from both `session.go` and `launch.go` after worktree creation, merging into any existing settings file
- Fixes the Claude Code statusline showing worktree session IDs instead of the project name

## Test plan
- [ ] `go build ./...` passes
- [ ] Start a klaus session and verify statusline shows `klaus (session/...)` instead of the worktree directory name
- [ ] Launch an agent and verify its statusline shows `klaus (agent/...)`
- [ ] Verify that if `.claude/settings.json` already exists on the branch, existing keys are preserved