### PR TITLE
Fix statusLine to use object format

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -180,7 +180,10 @@ func WriteClaudeSettings(worktreeDir, repoName string) error {
 		settings = make(map[string]any)
 	}
 
-	settings["statusLine"] = statusLine
+	settings["statusLine"] = map[string]any{
+		"type":    "command",
+		"command": statusLine,
+	}
 
 	out, err := json.MarshalIndent(settings, "", "  ")
 	if err != nil {


### PR DESCRIPTION
## Summary
- `statusLine` in worktree `.claude/settings.json` was written as a plain string, but Claude Code expects an object with `type` and `command` keys
- This caused the entire settings file to be skipped with a validation error

## Test plan
- [ ] Launch a session and verify `.claude/settings.json` contains `statusLine` as `{"type": "command", "command": "..."}` 
- [ ] Confirm no settings validation error on startup