### PR TITLE
Auto-detect Nix projects after worktree creation

### DIFF
--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -3,13 +3,13 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/patflynn/klaus/internal/config"
 	"github.com/patflynn/klaus/internal/git"
+	"github.com/patflynn/klaus/internal/nix"
 	"github.com/patflynn/klaus/internal/run"
 	"github.com/patflynn/klaus/internal/tmux"
 	"github.com/spf13/cobra"
@@ -83,14 +83,7 @@ tmux pane, and tracks the run state. Must be run inside a tmux session.`,
 		}
 
 		// Set up Nix dev environment if flake.nix exists
-		if _, err := os.Stat(filepath.Join(worktree, "flake.nix")); err == nil {
-			fmt.Println("  nix project detected, setting up dev environment...")
-			nixCmd := exec.Command("nix", "develop", "--command", "true")
-			nixCmd.Dir = worktree
-			if err := nixCmd.Run(); err != nil {
-				fmt.Fprintf(os.Stderr, "warning: nix develop failed: %v\n", err)
-			}
-		}
+		nix.SetupDevEnvironment(worktree)
 
 		// Build system prompt
 		sysPrompt, err := config.RenderPrompt(root, config.PromptVars{

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/patflynn/klaus/internal/config"
 	"github.com/patflynn/klaus/internal/git"
+	"github.com/patflynn/klaus/internal/nix"
 	"github.com/patflynn/klaus/internal/run"
 	"github.com/patflynn/klaus/internal/tmux"
 	"github.com/spf13/cobra"
@@ -72,14 +73,7 @@ clean on the default branch. Must be run inside a tmux session.`,
 		}
 
 		// Set up Nix dev environment if flake.nix exists
-		if _, err := os.Stat(filepath.Join(worktree, "flake.nix")); err == nil {
-			fmt.Println("  nix project detected, setting up dev environment...")
-			nixCmd := exec.Command("nix", "develop", "--command", "true")
-			nixCmd.Dir = worktree
-			if err := nixCmd.Run(); err != nil {
-				fmt.Fprintf(os.Stderr, "warning: nix develop failed: %v\n", err)
-			}
-		}
+		nix.SetupDevEnvironment(worktree)
 
 		// Write state
 		createdAt := time.Now().Format(time.RFC3339)

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -1,0 +1,25 @@
+package nix
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// SetupDevEnvironment checks if flake.nix exists in the given directory
+// and runs 'nix develop --command true' to set up the dev environment.
+// If the nix command fails, a warning is printed to stderr with the
+// combined output.
+func SetupDevEnvironment(dir string) {
+	if _, err := os.Stat(filepath.Join(dir, "flake.nix")); err != nil {
+		return
+	}
+	fmt.Println("  nix project detected, setting up dev environment...")
+	nixCmd := exec.Command("nix", "develop", "--command", "true")
+	nixCmd.Dir = dir
+	output, err := nixCmd.CombinedOutput()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: nix develop failed: %v\n%s", err, string(output))
+	}
+}


### PR DESCRIPTION
## Summary
- After worktree creation in both `launch.go` and `session.go`, check if `flake.nix` exists in the worktree directory
- If detected, run `nix develop --command true` to set up the Nix dev environment
- Failures produce a warning to stderr but do not abort the operation

## Test plan
- [ ] Verify `klaus launch` in a Nix-flake repo logs "nix project detected" and runs `nix develop`
- [ ] Verify `klaus session` in a Nix-flake repo does the same
- [ ] Verify non-Nix repos are unaffected (no message, no error)
- [ ] Verify that if `nix develop` fails, only a warning is printed and the run continues

Run: 20260302-2046-4cf2
Fixes #13