### PR TITLE
Add merge readiness to status and enhance watch loop

### DIFF
--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -125,7 +124,7 @@ func extractPRNumber(s *run.State) string {
 
 // getPRCI checks CI status by running "gh pr checks" and summarizing pass/fail/pending.
 func getPRCI(prNumber string) string {
-	cmd := exec.Command("gh", "pr", "checks", prNumber)
+	cmd := exec.Command("gh", "pr", "checks", "--", prNumber)
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	err := cmd.Run()
@@ -164,7 +163,7 @@ func getPRCI(prNumber string) string {
 
 // getPRConflicts checks if a PR has merge conflicts.
 func getPRConflicts(prNumber string) string {
-	cmd := exec.Command("gh", "pr", "view", prNumber, "--json", "mergeable", "-q", ".mergeable")
+	cmd := exec.Command("gh", "pr", "view", "--", prNumber, "--json", "mergeable", "-q", ".mergeable")
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {
@@ -179,11 +178,11 @@ func getPRConflicts(prNumber string) string {
 
 // getPRReviewDecision fetches the review decision for a PR.
 func getPRReviewDecision(prNumber string) string {
-	cmd := exec.Command("gh", "pr", "view", prNumber, "--json", "reviewDecision", "-q", ".reviewDecision")
+	cmd := exec.Command("gh", "pr", "view", "--", prNumber, "--json", "reviewDecision", "-q", ".reviewDecision")
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {
-		return ""
+		return "unknown"
 	}
 	return strings.TrimSpace(stdout.String())
 }
@@ -196,88 +195,16 @@ func computeMergeStatus(ci, conflicts, reviewDecision string) string {
 	if ci == "failing" {
 		return "blocked"
 	}
-	if ci == "pending" {
+	if strings.EqualFold(reviewDecision, "CHANGES_REQUESTED") {
+		return "blocked"
+	}
+	if ci == "pending" || reviewDecision == "unknown" {
 		return "pending"
 	}
-	switch strings.ToUpper(reviewDecision) {
-	case "CHANGES_REQUESTED":
-		return "blocked"
-	case "APPROVED":
-		return "ready"
-	}
-	if ci == "passing" && conflicts == "none" {
+	if ci == "passing" && conflicts == "none" && (strings.EqualFold(reviewDecision, "APPROVED") || reviewDecision == "") {
 		return "ready"
 	}
 	return "pending"
-}
-
-// getRepoOwnerAndName returns owner/repo by querying gh.
-func getRepoOwnerAndName() (string, string, error) {
-	cmd := exec.Command("gh", "repo", "view", "--json", "owner,name", "-q", ".owner.login + \"/\" + .name")
-	var stdout bytes.Buffer
-	cmd.Stdout = &stdout
-	if err := cmd.Run(); err != nil {
-		return "", "", err
-	}
-	parts := strings.SplitN(strings.TrimSpace(stdout.String()), "/", 2)
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("unexpected repo format")
-	}
-	return parts[0], parts[1], nil
-}
-
-// ghAPIGet runs gh api with the given path and returns parsed JSON.
-func ghAPIGet(path string) ([]byte, error) {
-	cmd := exec.Command("gh", "api", path)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("gh api %s: %w: %s", path, err, strings.TrimSpace(stderr.String()))
-	}
-	return stdout.Bytes(), nil
-}
-
-// ghAPIPost runs gh api with POST method and field arguments.
-func ghAPIPost(path string, fields map[string]string) error {
-	args := []string{"api", path, "-X", "POST"}
-	for k, v := range fields {
-		args = append(args, "-f", k+"="+v)
-	}
-	cmd := exec.Command("gh", args...)
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("gh api POST %s: %w: %s", path, err, strings.TrimSpace(stderr.String()))
-	}
-	return nil
-}
-
-// prReviewComment represents a single PR review comment from the GitHub API.
-type prReviewComment struct {
-	ID   int64  `json:"id"`
-	Body string `json:"body"`
-	Path string `json:"path"`
-}
-
-// fetchPRReviewComments fetches review comments for a PR.
-func fetchPRReviewComments(owner, repo, prNumber string) ([]prReviewComment, error) {
-	path := fmt.Sprintf("repos/%s/%s/pulls/%s/comments", owner, repo, prNumber)
-	data, err := ghAPIGet(path)
-	if err != nil {
-		return nil, err
-	}
-	var comments []prReviewComment
-	if err := json.Unmarshal(data, &comments); err != nil {
-		return nil, fmt.Errorf("parsing review comments: %w", err)
-	}
-	return comments, nil
-}
-
-// replyToReviewComment posts a reply to a specific PR review comment.
-func replyToReviewComment(owner, repo, prNumber string, commentID int64, body string) error {
-	path := fmt.Sprintf("repos/%s/%s/pulls/%s/comments/%d/replies", owner, repo, prNumber, commentID)
-	return ghAPIPost(path, map[string]string{"body": body})
 }
 
 func truncate(s string, max int) string {

--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/patflynn/klaus/internal/config"
 	"github.com/patflynn/klaus/internal/git"
+	gh "github.com/patflynn/klaus/internal/github"
 	"github.com/patflynn/klaus/internal/run"
 	"github.com/patflynn/klaus/internal/tmux"
 	"github.com/spf13/cobra"
@@ -101,18 +103,27 @@ Must be run inside a tmux session.`,
 
 		logFile := filepath.Join(run.LogDir(commonDir), id+".jsonl")
 
-		// Gather review comments context
+		// Gather review comments context, filtering to trusted reviewers only
 		reviewContext := ""
-		owner, repoNameGH, ghErr := getRepoOwnerAndName()
+		owner, repoNameGH, ghErr := gh.GetRepoOwnerAndName()
 		if ghErr == nil {
-			comments, err := fetchPRReviewComments(owner, repoNameGH, prNumber)
+			comments, err := gh.FetchPRReviewComments(owner, repoNameGH, prNumber)
 			if err == nil && len(comments) > 0 {
+				trusted := buildTrustedSet(cfg, owner, repoNameGH)
 				var sb strings.Builder
 				sb.WriteString("\n\nExisting PR review comments:\n")
+				included := 0
 				for _, c := range comments {
+					if !trusted[c.User.Login] {
+						log.Printf("skipping review comment %d from untrusted user %q", c.ID, c.User.Login)
+						continue
+					}
 					sb.WriteString(fmt.Sprintf("- [comment %d] %s: %s\n", c.ID, c.Path, truncate(c.Body, 200)))
+					included++
 				}
-				reviewContext = sb.String()
+				if included > 0 {
+					reviewContext = sb.String()
+				}
 			}
 		}
 
@@ -188,9 +199,27 @@ Must be run inside a tmux session.`,
 	},
 }
 
+// buildTrustedSet returns a set of usernames trusted for review comments.
+// It combines configured TrustedReviewers with repo collaborators.
+func buildTrustedSet(cfg config.Config, owner, repo string) map[string]bool {
+	trusted := make(map[string]bool)
+	for _, u := range cfg.TrustedReviewers {
+		trusted[u] = true
+	}
+	collabs, err := gh.FetchCollaborators(owner, repo)
+	if err != nil {
+		log.Printf("warning: could not fetch collaborators: %v", err)
+	} else {
+		for _, u := range collabs {
+			trusted[u] = true
+		}
+	}
+	return trusted
+}
+
 // getPRBranch returns the head branch name for a PR using the gh CLI.
 func getPRBranch(prNumber string) (string, error) {
-	cmd := exec.Command("gh", "pr", "view", prNumber, "--json", "headRefName", "-q", ".headRefName")
+	cmd := exec.Command("gh", "pr", "view", "--", prNumber, "--json", "headRefName", "-q", ".headRefName")
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,19 +11,21 @@ import (
 
 // Config holds the klaus configuration.
 type Config struct {
-	WorktreeBase  string `json:"worktree_base"`
-	DefaultBudget string `json:"default_budget"`
-	DataRef       string `json:"data_ref"`
-	DefaultBranch string `json:"default_branch"`
+	WorktreeBase     string   `json:"worktree_base"`
+	DefaultBudget    string   `json:"default_budget"`
+	DataRef          string   `json:"data_ref"`
+	DefaultBranch    string   `json:"default_branch"`
+	TrustedReviewers []string `json:"trusted_reviewers"`
 }
 
 // Defaults returns a Config with default values.
 func Defaults() Config {
 	return Config{
-		WorktreeBase:  filepath.Join(os.TempDir(), "klaus-sessions"),
-		DefaultBudget: "5.00",
-		DataRef:       "refs/klaus/data",
-		DefaultBranch: "main",
+		WorktreeBase:     filepath.Join(os.TempDir(), "klaus-sessions"),
+		DefaultBudget:    "5.00",
+		DataRef:          "refs/klaus/data",
+		DefaultBranch:    "main",
+		TrustedReviewers: []string{"gemini-code-assist[bot]"},
 	}
 }
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -1,0 +1,101 @@
+package github
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// GetRepoOwnerAndName returns owner/repo by querying gh.
+func GetRepoOwnerAndName() (string, string, error) {
+	cmd := exec.Command("gh", "repo", "view", "--json", "owner,name", "-q", ".owner.login + \"/\" + .name")
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "", "", err
+	}
+	parts := strings.SplitN(strings.TrimSpace(stdout.String()), "/", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("unexpected repo format")
+	}
+	return parts[0], parts[1], nil
+}
+
+// APIGet runs gh api with the given path and returns parsed JSON.
+func APIGet(path string) ([]byte, error) {
+	cmd := exec.Command("gh", "api", path)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("gh api %s: %w: %s", path, err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
+}
+
+// APIPost runs gh api with POST method and field arguments.
+func APIPost(path string, fields map[string]string) error {
+	args := []string{"api", path, "-X", "POST"}
+	for k, v := range fields {
+		args = append(args, "-f", k+"="+v)
+	}
+	cmd := exec.Command("gh", args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("gh api POST %s: %w: %s", path, err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+// PRReviewComment represents a single PR review comment from the GitHub API.
+type PRReviewComment struct {
+	ID     int64  `json:"id"`
+	Body   string `json:"body"`
+	Path   string `json:"path"`
+	User   commentUser `json:"user"`
+}
+
+type commentUser struct {
+	Login string `json:"login"`
+}
+
+// FetchPRReviewComments fetches review comments for a PR.
+func FetchPRReviewComments(owner, repo, prNumber string) ([]PRReviewComment, error) {
+	path := fmt.Sprintf("repos/%s/%s/pulls/%s/comments", owner, repo, prNumber)
+	data, err := APIGet(path)
+	if err != nil {
+		return nil, err
+	}
+	var comments []PRReviewComment
+	if err := json.Unmarshal(data, &comments); err != nil {
+		return nil, fmt.Errorf("parsing review comments: %w", err)
+	}
+	return comments, nil
+}
+
+// ReplyToReviewComment posts a reply to a specific PR review comment.
+func ReplyToReviewComment(owner, repo, prNumber string, commentID int64, body string) error {
+	path := fmt.Sprintf("repos/%s/%s/pulls/%s/comments/%d/replies", owner, repo, prNumber, commentID)
+	return APIPost(path, map[string]string{"body": body})
+}
+
+// FetchCollaborators returns the list of collaborator logins for a repo.
+func FetchCollaborators(owner, repo string) ([]string, error) {
+	cmd := exec.Command("gh", "api", fmt.Sprintf("repos/%s/%s/collaborators", owner, repo), "--jq", ".[].login")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("fetching collaborators: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	var logins []string
+	for _, line := range strings.Split(strings.TrimSpace(stdout.String()), "\n") {
+		if line != "" {
+			logins = append(logins, line)
+		}
+	}
+	return logins, nil
+}


### PR DESCRIPTION
## Summary

- **Status command**: Added CI, CONFLICTS, and MERGE columns for runs that have PRs. For each PR, shells out to `gh` to fetch CI check status (`gh pr checks`), mergeable state (`gh pr view --json mergeable`), and review decision (`gh pr view --json reviewDecision`). Shows "passing/failing/pending", "none/yes", and "ready/blocked/pending" respectively.

- **Watch loop - conflict handling**: Updated the watch prompt template to instruct the agent to check for merge conflicts (`gh pr view --json mergeable`), rebase onto `origin/main` if conflicting, and force-push after verifying the build. The watch command also checks initial conflict status and includes it in the agent's prompt.

- **Watch loop - review comments**: The watch command now fetches existing PR review comments via `gh api` and includes them in the agent's prompt context. The watch prompt template instructs the agent to address review comments alongside CI failures, and to reply to addressed comments with the fix commit SHA using `gh api .../replies`.

## Test plan

- [ ] Run `klaus status` with existing runs that have PRs — verify new CI/CONFLICTS/MERGE columns appear
- [ ] Run `klaus status` with runs that have no PR — verify columns show "-"
- [ ] Run `klaus watch <pr>` on a PR with review comments — verify comments appear in agent prompt
- [ ] Run `klaus watch <pr>` on a PR with merge conflicts — verify conflict note in prompt
- [ ] Verify `go build ./...` passes

Run: 20260306-1654-f72b
Fixes #21