### PR TITLE
Fix status display for merged and closed PRs

### DIFF
--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -53,9 +53,18 @@ var statusCmd = &cobra.Command{
 
 			ci, conflicts, merge := "-", "-", "-"
 			if prNum := extractPRNumber(s); prNum != "" {
-				ci = getPRCI(prNum)
-				conflicts = getPRConflicts(prNum)
-				merge = computeMergeStatus(ci, conflicts, getPRReviewDecision(prNum))
+				prState := getPRState(prNum)
+				switch prState {
+				case "MERGED":
+					status = "merged"
+					merge = "merged"
+				case "CLOSED":
+					status = "closed"
+				default:
+					ci = getPRCI(prNum)
+					conflicts = getPRConflicts(prNum)
+					merge = computeMergeStatus(ci, conflicts, getPRReviewDecision(prNum))
+				}
 			}
 
 			fmt.Fprintf(os.Stdout, "%-22s  %-10s  %-8s  %-6s  %-20s  %-6s  %-10s  %-10s  %-10s  %s\n",
@@ -185,6 +194,21 @@ func getPRReviewDecision(prNumber string) string {
 		return "unknown"
 	}
 	return strings.TrimSpace(stdout.String())
+}
+
+// getPRState returns the PR state (e.g. "OPEN", "MERGED", "CLOSED") by calling gh.
+func getPRState(prNumber string) string {
+	cmd := exec.Command("gh", "pr", "view", "--", prNumber, "--json", "state", "-q", ".state")
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "UNKNOWN"
+	}
+	val := strings.TrimSpace(stdout.String())
+	if val == "" {
+		return "UNKNOWN"
+	}
+	return strings.ToUpper(val)
 }
 
 // computeMergeStatus determines overall merge readiness.

--- a/internal/cmd/status_test.go
+++ b/internal/cmd/status_test.go
@@ -23,6 +23,8 @@ func TestComputeMergeStatus(t *testing.T) {
 		{"review unknown", "passing", "none", "unknown", "pending"},
 		{"ci failing and conflicts", "failing", "yes", "", "blocked"},
 		{"changes requested case insensitive", "passing", "none", "changes_requested", "blocked"},
+		{"unknown CI unknown review", "unknown", "none", "unknown", "pending"},
+		{"unknown CI no conflicts", "unknown", "none", "", "pending"},
 	}
 
 	for _, tt := range tests {
@@ -46,6 +48,8 @@ func TestExtractPRNumber(t *testing.T) {
 		{"valid URL", strPtr("https://github.com/owner/repo/pull/42"), "42"},
 		{"URL with trailing number", strPtr("https://github.com/owner/repo/pull/123"), "123"},
 		{"no slash in URL", strPtr("nourl"), ""},
+		{"single segment URL", strPtr("42"), ""},
+		{"trailing slash stripped", strPtr("https://github.com/owner/repo/pull/99"), "99"},
 	}
 
 	for _, tt := range tests {
@@ -53,7 +57,61 @@ func TestExtractPRNumber(t *testing.T) {
 			s := &run.State{PRURL: tt.prURL}
 			got := extractPRNumber(s)
 			if got != tt.want {
-				t.Errorf("extractPRNumber() = %q, want %q", got, tt.want)
+				t.Errorf("extractPRNumber(%v) = %q, want %q", tt.prURL, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatPR(t *testing.T) {
+	tests := []struct {
+		name  string
+		prURL *string
+		want  string
+	}{
+		{"nil URL", nil, "-"},
+		{"typical URL", strPtr("https://github.com/owner/repo/pull/22"), "#22"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &run.State{PRURL: tt.prURL}
+			got := formatPR(s)
+			if got != tt.want {
+				t.Errorf("formatPR() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetermineStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		s    *run.State
+		want string
+	}{
+		{
+			name: "no PR URL returns exited",
+			s:    &run.State{},
+			want: "exited",
+		},
+		{
+			name: "with PR URL returns pr-created",
+			s:    &run.State{PRURL: strPtr("https://github.com/owner/repo/pull/1")},
+			want: "pr-created",
+		},
+		{
+			name: "session type with missing worktree returns ended",
+			s:    &run.State{Type: "session", Worktree: "/nonexistent/path/that/does/not/exist"},
+			want: "ended",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := determineStatus(tt.s)
+			if got != tt.want {
+				t.Errorf("determineStatus() = %q, want %q", got, tt.want)
 			}
 		})
 	}
@@ -68,6 +126,7 @@ func TestTruncate(t *testing.T) {
 		{"short", 10, "short"},
 		{"exactly10!", 10, "exactly10!"},
 		{"this is a longer string", 10, "this is a ..."},
+		{"this is a long string", 10, "this is a ..."},
 	}
 
 	for _, tt := range tests {
@@ -80,4 +139,29 @@ func TestTruncate(t *testing.T) {
 	}
 }
 
-func strPtr(s string) *string { return &s }
+func TestFormatCost(t *testing.T) {
+	cost := 1.5
+	budget := "5"
+	tests := []struct {
+		name string
+		s    *run.State
+		want string
+	}{
+		{"no cost or budget", &run.State{}, "-"},
+		{"with cost", &run.State{CostUSD: &cost}, "$1.50"},
+		{"with budget only", &run.State{Budget: &budget}, "<$5"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatCost(tt.s)
+			if got != tt.want {
+				t.Errorf("formatCost() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
## Summary
- Add `getPRState` helper to query PR state (`MERGED`/`CLOSED`/`OPEN`) via `gh pr view --json state`
- When PR is merged: show status as `merged`, CI/CONFLICTS as `-`, MERGE as `merged`
- When PR is closed: show status as `closed`, CI/CONFLICTS/MERGE as `-`
- Only fetch CI/conflicts/merge info for PRs that are still open
- Add comprehensive unit tests for `computeMergeStatus`, `extractPRNumber`, `formatPR`, `determineStatus`, `truncate`, and `formatCost`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all new tests green)
- [ ] Manual: run `klaus status` on a repo with merged PRs and verify they show `merged` status

Run: 20260306-1719-5b71
Fixes #27