### PR TITLE
Require tests in agent prompts and backfill test coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,9 @@
 ## Commits & PRs
 - Do NOT include `Co-Authored-By` lines mentioning Claude or Anthropic in commits
 - Do NOT mention AI in commit messages or PR descriptions
+
+## Testing
+- All new functions and commands must have corresponding tests in *_test.go files
+- Run `go test ./...` before committing
+- Tests should cover happy path and error cases
+- PRs without tests for new code will not be merged

--- a/internal/cmd/status_test.go
+++ b/internal/cmd/status_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/patflynn/klaus/internal/run"
+)
+
+func TestComputeMergeStatus(t *testing.T) {
+	tests := []struct {
+		name           string
+		ci             string
+		conflicts      string
+		reviewDecision string
+		want           string
+	}{
+		{"all green approved", "passing", "none", "APPROVED", "ready"},
+		{"all green no review", "passing", "none", "", "ready"},
+		{"ci failing", "failing", "none", "APPROVED", "blocked"},
+		{"conflicts", "passing", "yes", "APPROVED", "blocked"},
+		{"changes requested", "passing", "none", "CHANGES_REQUESTED", "blocked"},
+		{"ci pending", "pending", "none", "APPROVED", "pending"},
+		{"review unknown", "passing", "none", "unknown", "pending"},
+		{"ci failing and conflicts", "failing", "yes", "", "blocked"},
+		{"changes requested case insensitive", "passing", "none", "changes_requested", "blocked"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeMergeStatus(tt.ci, tt.conflicts, tt.reviewDecision)
+			if got != tt.want {
+				t.Errorf("computeMergeStatus(%q, %q, %q) = %q, want %q",
+					tt.ci, tt.conflicts, tt.reviewDecision, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractPRNumber(t *testing.T) {
+	tests := []struct {
+		name  string
+		prURL *string
+		want  string
+	}{
+		{"nil URL", nil, ""},
+		{"valid URL", strPtr("https://github.com/owner/repo/pull/42"), "42"},
+		{"URL with trailing number", strPtr("https://github.com/owner/repo/pull/123"), "123"},
+		{"no slash in URL", strPtr("nourl"), ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &run.State{PRURL: tt.prURL}
+			got := extractPRNumber(s)
+			if got != tt.want {
+				t.Errorf("extractPRNumber() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		input string
+		max   int
+		want  string
+	}{
+		{"short", 10, "short"},
+		{"exactly10!", 10, "exactly10!"},
+		{"this is a longer string", 10, "this is a ..."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := truncate(tt.input, tt.max)
+			if got != tt.want {
+				t.Errorf("truncate(%q, %d) = %q, want %q", tt.input, tt.max, got, tt.want)
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string { return &s }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,6 +103,12 @@ const defaultPromptTemplate = `You are an autonomous agent working on this repos
    Run: {{.RunID}}{{if .Issue}}
    Fixes #{{.Issue}}{{end}}
 
+## Testing
+- Write unit tests for all new functions and commands.
+- Tests should cover the happy path and key error cases.
+- Run the project's test suite before creating a PR.
+- If tests fail, fix them before proceeding.
+
 ## Conventions
 - Never commit directly to the default branch — always use a PR branch.
 `
@@ -131,6 +137,12 @@ klaus launch --issue <number> "<prompt>"
 - Check on running agents: ` + "`klaus status`" + `
 - View agent output: ` + "`klaus logs <run-id>`" + `
 - Clean up finished runs: ` + "`klaus cleanup <run-id>`" + `
+
+## Testing
+- Ensure launched agents write unit tests for all new functions and commands.
+- Tests should cover the happy path and key error cases.
+- Run the project's test suite before creating a PR.
+- If tests fail, fix them before proceeding.
 `
 
 // RenderSessionPrompt renders the session coordinator system prompt.
@@ -221,6 +233,12 @@ Replace ` + "`<commit-sha>`" + ` with the actual commit hash from your push.
 
 After pushing, wait for CI to restart (check with ` + "`gh pr checks {{.PR}}`" + `),
 then monitor again. Continue until all checks pass.
+
+## Testing
+- Write unit tests for all new functions and commands.
+- Tests should cover the happy path and key error cases.
+- Run the project's test suite before creating a PR.
+- If tests fail, fix them before proceeding.
 
 ## Guidelines
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -214,6 +214,90 @@ func TestRenderSessionPromptCustomTemplate(t *testing.T) {
 	}
 }
 
+func TestRenderWatchPromptDefault(t *testing.T) {
+	dir := t.TempDir() // no .klaus/watch-prompt.md
+
+	vars := PromptVars{
+		RunID:  "watch-20260210-1430-a3f2",
+		Branch: "agent/watch-20260210-1430-a3f2",
+		PR:     "99",
+	}
+
+	prompt, err := RenderWatchPrompt(dir, vars)
+	if err != nil {
+		t.Fatalf("RenderWatchPrompt() error: %v", err)
+	}
+
+	if !strings.Contains(prompt, "PR #99") {
+		t.Error("prompt should contain PR number")
+	}
+	if !strings.Contains(prompt, "gh pr checks 99") {
+		t.Error("prompt should contain gh pr checks command with PR number")
+	}
+	if !strings.Contains(prompt, "watch-20260210-1430-a3f2") {
+		t.Error("prompt should contain run ID")
+	}
+	if !strings.Contains(prompt, "## Testing") {
+		t.Error("prompt should contain testing section")
+	}
+}
+
+func TestRenderWatchPromptCustomTemplate(t *testing.T) {
+	dir := t.TempDir()
+	klausDir := filepath.Join(dir, ".klaus")
+	os.MkdirAll(klausDir, 0o755)
+
+	tmpl := "Watch PR #{{.PR}} run {{.RunID}}"
+	os.WriteFile(filepath.Join(klausDir, "watch-prompt.md"), []byte(tmpl), 0o644)
+
+	vars := PromptVars{
+		RunID: "watch-abc",
+		PR:    "55",
+	}
+
+	prompt, err := RenderWatchPrompt(dir, vars)
+	if err != nil {
+		t.Fatalf("RenderWatchPrompt() error: %v", err)
+	}
+
+	want := "Watch PR #55 run watch-abc"
+	if prompt != want {
+		t.Errorf("prompt = %q, want %q", prompt, want)
+	}
+}
+
+func TestRenderPromptFromFileReadError(t *testing.T) {
+	dir := t.TempDir()
+	klausDir := filepath.Join(dir, ".klaus")
+	os.MkdirAll(klausDir, 0o755)
+
+	// Create a directory where a file is expected, causing a read error
+	os.MkdirAll(filepath.Join(klausDir, "prompt.md"), 0o755)
+
+	vars := PromptVars{RunID: "test-123"}
+	_, err := RenderPrompt(dir, vars)
+	if err == nil {
+		t.Error("expected error when prompt.md is a directory")
+	}
+}
+
+func TestRenderPromptDefaultContainsTesting(t *testing.T) {
+	dir := t.TempDir()
+
+	vars := PromptVars{RunID: "test-123"}
+	prompt, err := RenderPrompt(dir, vars)
+	if err != nil {
+		t.Fatalf("RenderPrompt() error: %v", err)
+	}
+
+	if !strings.Contains(prompt, "## Testing") {
+		t.Error("default prompt should contain testing section")
+	}
+	if !strings.Contains(prompt, "unit tests") {
+		t.Error("default prompt should mention unit tests")
+	}
+}
+
 func TestInit(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -206,6 +206,28 @@ func TestParseRepoRef(t *testing.T) {
 			input:   "/repo",
 			wantErr: true,
 		},
+		{
+			input:   "../evil/repo",
+			wantErr: true,
+		},
+		{
+			input:   "owner/../etc",
+			wantErr: true,
+		},
+		{
+			input:   "https://github.com/../etc/passwd",
+			wantErr: true,
+		},
+		{
+			input:   "git@github.com:../evil.git",
+			wantErr: true,
+		},
+		{
+			input:     "http://github.com/owner/repo",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantURL:   "https://github.com/owner/repo.git",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Add a `## Testing` section to all three default agent prompt templates (agent, session coordinator, watch) so every launched agent is instructed to write and run tests
- Add a `## Testing` section to `CLAUDE.md` documenting the project testing policy
- Backfill tests for recently landed untested code: `ParseRepoRef` path traversal rejection, `RenderWatchPrompt`, `renderPromptFromFile` error handling, `computeMergeStatus`, `extractPRNumber`, and `truncate`

## Test plan
- [x] `go test ./...` passes with all new and existing tests
- [ ] Verify new agent launches include testing instructions in their prompt
- [ ] Verify `CLAUDE.md` testing section is picked up by agents

Run: 20260306-1720-176a
Fixes #23