### PR TITLE
Improve tmux UI for better situational awareness

### DIFF
--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -178,7 +178,7 @@ worktree in that clone.`,
 			return fmt.Errorf("creating tmux pane: %w", err)
 		}
 
-		tmux.SetPaneTitle(paneID, "agent:"+id)
+		tmux.SetPaneTitle(paneID, FormatPaneTitle(id, issue, prompt))
 		if err := tmux.RebalanceLayout(currentPane); err != nil {
 			return fmt.Errorf("rebalancing tmux layout: %w", err)
 		}
@@ -232,6 +232,33 @@ func buildClaudeCommand(sysPrompt, budget, prompt string) string {
 func shellQuote(s string) string {
 	// Use single quotes, escaping any existing single quotes
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+// FormatPaneTitle builds a compact pane title for an agent.
+// Format: "agent:<short-id> #<issue> <short-desc>"
+// Short ID is the last 4 characters of the run ID.
+// Short desc is the first 20 characters of the prompt.
+func FormatPaneTitle(id, issue, prompt string) string {
+	shortID := id
+	if len(id) > 4 {
+		shortID = id[len(id)-4:]
+	}
+
+	title := "agent:" + shortID
+
+	if issue != "" {
+		title += " #" + issue
+	}
+
+	desc := strings.TrimSpace(prompt)
+	if len(desc) > 20 {
+		desc = desc[:20]
+	}
+	if desc != "" {
+		title += " " + desc
+	}
+
+	return title
 }
 
 func stringPtr(s string) *string {

--- a/internal/cmd/launch_test.go
+++ b/internal/cmd/launch_test.go
@@ -1,0 +1,87 @@
+package cmd
+
+import "testing"
+
+func TestFormatPaneTitle(t *testing.T) {
+	tests := []struct {
+		name   string
+		id     string
+		issue  string
+		prompt string
+		want   string
+	}{
+		{
+			name:   "full context",
+			id:     "20260306-1720-176a",
+			issue:  "23",
+			prompt: "fix the failing tests in pkg/auth",
+			want:   "agent:176a #23 fix the failing test",
+		},
+		{
+			name:   "no issue",
+			id:     "20260306-1720-176a",
+			issue:  "",
+			prompt: "refactor the config loader",
+			want:   "agent:176a refactor the config ",
+		},
+		{
+			name:   "short prompt",
+			id:     "20260306-1720-176a",
+			issue:  "5",
+			prompt: "fix typo",
+			want:   "agent:176a #5 fix typo",
+		},
+		{
+			name:   "short id",
+			id:     "abcd",
+			issue:  "1",
+			prompt: "test",
+			want:   "agent:abcd #1 test",
+		},
+		{
+			name:   "very short id",
+			id:     "ab",
+			issue:  "",
+			prompt: "test",
+			want:   "agent:ab test",
+		},
+		{
+			name:   "empty prompt",
+			id:     "20260306-1720-176a",
+			issue:  "10",
+			prompt: "",
+			want:   "agent:176a #10",
+		},
+		{
+			name:   "whitespace prompt",
+			id:     "20260306-1720-176a",
+			issue:  "",
+			prompt: "   ",
+			want:   "agent:176a",
+		},
+		{
+			name:   "exactly 20 char prompt",
+			id:     "20260306-1720-176a",
+			issue:  "",
+			prompt: "12345678901234567890",
+			want:   "agent:176a 12345678901234567890",
+		},
+		{
+			name:   "21 char prompt truncated",
+			id:     "20260306-1720-176a",
+			issue:  "",
+			prompt: "123456789012345678901",
+			want:   "agent:176a 12345678901234567890",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatPaneTitle(tt.id, tt.issue, tt.prompt)
+			if got != tt.want {
+				t.Errorf("FormatPaneTitle(%q, %q, %q) = %q, want %q",
+					tt.id, tt.issue, tt.prompt, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -99,6 +99,15 @@ clean on the default branch. Must be run inside a tmux session.`,
 			return fmt.Errorf("rendering session prompt: %w", err)
 		}
 
+		// Configure tmux window for better situational awareness
+		currentPane := os.Getenv("TMUX_PANE")
+		if currentPane != "" {
+			tmux.SetWindowOption(currentPane, "automatic-rename", "off")
+			tmux.RenameWindow(currentPane, repoName)
+			tmux.SetWindowOption(currentPane, "pane-border-status", "top")
+			tmux.SetWindowOption(currentPane, "pane-border-format", "#{pane_title}")
+		}
+
 		fmt.Println()
 		fmt.Println("Starting interactive Claude Code session...")
 		fmt.Println("  Use 'klaus launch' from inside to spawn workers.")

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -74,6 +74,18 @@ func KillPane(paneID string) error {
 	return err
 }
 
+// SetWindowOption sets a tmux window option for the window containing target pane.
+func SetWindowOption(target, option, value string) error {
+	_, err := runTmux("set-option", "-w", "-t", target, option, value)
+	return err
+}
+
+// RenameWindow renames the tmux window containing the target pane.
+func RenameWindow(target, name string) error {
+	_, err := runTmux("rename-window", "-t", target, name)
+	return err
+}
+
 // BuildArgs returns the tmux command arguments for a given operation.
 // Exported for testing command construction without actually running tmux.
 func BuildArgs(op string, args ...string) []string {

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -57,6 +57,34 @@ func TestRebalanceLayoutEmptyPane(t *testing.T) {
 	}
 }
 
+func TestBuildArgsSetWindowOption(t *testing.T) {
+	args := BuildArgs("set-option", "-w", "-t", "%0", "automatic-rename", "off")
+	want := []string{"set-option", "-w", "-t", "%0", "automatic-rename", "off"}
+
+	if len(args) != len(want) {
+		t.Fatalf("len(args) = %d, want %d", len(args), len(want))
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Errorf("args[%d] = %q, want %q", i, args[i], want[i])
+		}
+	}
+}
+
+func TestBuildArgsRenameWindow(t *testing.T) {
+	args := BuildArgs("rename-window", "-t", "%0", "my-repo")
+	want := []string{"rename-window", "-t", "%0", "my-repo"}
+
+	if len(args) != len(want) {
+		t.Fatalf("len(args) = %d, want %d", len(args), len(want))
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Errorf("args[%d] = %q, want %q", i, args[i], want[i])
+		}
+	}
+}
+
 func TestInSessionOutsideTmux(t *testing.T) {
 	// When running tests outside tmux, TMUX env var is typically not set
 	// This test documents the behavior — it may pass or fail depending on env


### PR DESCRIPTION
## Summary
- Add `SetWindowOption` and `RenameWindow` tmux helpers for window configuration
- Disable automatic-rename and set window name to the repo name when starting a session
- Enable pane-border-status with `#{pane_title}` so each pane's identity is always visible
- Format agent pane titles as `agent:<short-id> #<issue> <desc>` (e.g., `agent:176a #23 fix the failing test`) instead of the full run ID for quick visual identification
- Add tests for new tmux helpers and pane title formatting logic

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (11 tests including new ones)
- [ ] Manual: run `klaus session` and verify window is renamed to repo name
- [ ] Manual: run `klaus launch` and verify pane titles show short format

Run: 20260306-1726-2fd7
Fixes #32