### PR TITLE
Fix argument separator placement in gh commands

### DIFF
--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -131,9 +131,14 @@ func extractPRNumber(s *run.State) string {
 	return ""
 }
 
+// ghPRChecksArgs returns the arguments for "gh pr checks" with correct flag placement.
+func ghPRChecksArgs(prNumber string) []string {
+	return []string{"pr", "checks", "--", prNumber}
+}
+
 // getPRCI checks CI status by running "gh pr checks" and summarizing pass/fail/pending.
 func getPRCI(prNumber string) string {
-	cmd := exec.Command("gh", "pr", "checks", "--", prNumber)
+	cmd := exec.Command("gh", ghPRChecksArgs(prNumber)...)
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	err := cmd.Run()
@@ -170,9 +175,14 @@ func getPRCI(prNumber string) string {
 	return "unknown"
 }
 
+// ghPRConflictsArgs returns the arguments for "gh pr view" to check merge conflicts.
+func ghPRConflictsArgs(prNumber string) []string {
+	return []string{"pr", "view", "--json", "mergeable", "-q", ".mergeable", "--", prNumber}
+}
+
 // getPRConflicts checks if a PR has merge conflicts.
 func getPRConflicts(prNumber string) string {
-	cmd := exec.Command("gh", "pr", "view", "--", prNumber, "--json", "mergeable", "-q", ".mergeable")
+	cmd := exec.Command("gh", ghPRConflictsArgs(prNumber)...)
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {
@@ -185,9 +195,14 @@ func getPRConflicts(prNumber string) string {
 	return "none"
 }
 
+// ghPRReviewDecisionArgs returns the arguments for "gh pr view" to fetch review decision.
+func ghPRReviewDecisionArgs(prNumber string) []string {
+	return []string{"pr", "view", "--json", "reviewDecision", "-q", ".reviewDecision", "--", prNumber}
+}
+
 // getPRReviewDecision fetches the review decision for a PR.
 func getPRReviewDecision(prNumber string) string {
-	cmd := exec.Command("gh", "pr", "view", "--", prNumber, "--json", "reviewDecision", "-q", ".reviewDecision")
+	cmd := exec.Command("gh", ghPRReviewDecisionArgs(prNumber)...)
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {
@@ -196,9 +211,14 @@ func getPRReviewDecision(prNumber string) string {
 	return strings.TrimSpace(stdout.String())
 }
 
+// ghPRStateArgs returns the arguments for "gh pr view" to fetch PR state.
+func ghPRStateArgs(prNumber string) []string {
+	return []string{"pr", "view", "--json", "state", "-q", ".state", "--", prNumber}
+}
+
 // getPRState returns the PR state (e.g. "OPEN", "MERGED", "CLOSED") by calling gh.
 func getPRState(prNumber string) string {
-	cmd := exec.Command("gh", "pr", "view", "--", prNumber, "--json", "state", "-q", ".state")
+	cmd := exec.Command("gh", ghPRStateArgs(prNumber)...)
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {

--- a/internal/cmd/status_test.go
+++ b/internal/cmd/status_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/patflynn/klaus/internal/run"
@@ -157,6 +158,64 @@ func TestFormatCost(t *testing.T) {
 			got := formatCost(tt.s)
 			if got != tt.want {
 				t.Errorf("formatCost() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGHCommandArgOrder(t *testing.T) {
+	// Verify that all gh command builders place flags BEFORE the "--" separator
+	// and the PR number AFTER it. This prevents the bug where flags after "--"
+	// are treated as positional arguments by gh.
+	tests := []struct {
+		name string
+		fn   func(string) []string
+		want []string
+	}{
+		{
+			name: "getPRState args",
+			fn:   ghPRStateArgs,
+			want: []string{"pr", "view", "--json", "state", "-q", ".state", "--", "42"},
+		},
+		{
+			name: "getPRCI args",
+			fn:   ghPRChecksArgs,
+			want: []string{"pr", "checks", "--", "42"},
+		},
+		{
+			name: "getPRConflicts args",
+			fn:   ghPRConflictsArgs,
+			want: []string{"pr", "view", "--json", "mergeable", "-q", ".mergeable", "--", "42"},
+		},
+		{
+			name: "getPRReviewDecision args",
+			fn:   ghPRReviewDecisionArgs,
+			want: []string{"pr", "view", "--json", "reviewDecision", "-q", ".reviewDecision", "--", "42"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.fn("42")
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("args = %v, want %v", got, tt.want)
+			}
+
+			// Verify structural invariant: all flags appear before "--"
+			separatorIdx := -1
+			for i, arg := range got {
+				if arg == "--" {
+					separatorIdx = i
+					break
+				}
+			}
+			if separatorIdx == -1 {
+				t.Fatal("missing '--' separator")
+			}
+			for i := separatorIdx + 1; i < len(got); i++ {
+				if got[i][0] == '-' {
+					t.Errorf("flag %q found after '--' separator at index %d", got[i], i)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Moved all flags (`--json`, `-q`) before the `--` separator in `getPRState`, `getPRConflicts`, and `getPRReviewDecision` gh commands
- Previously flags after `--` were treated as positional arguments, causing gh to silently fail
- Extracted argument-building into testable `ghPR*Args` helper functions
- Added `TestGHCommandArgOrder` verifying correct flag/separator ordering with a structural invariant check

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (new test `TestGHCommandArgOrder` included)
- [x] Verified all flags appear before `--` and PR number appears after

Run: 20260306-1737-6b22
Fixes #40