### PR TITLE
Fix -- separator placement in watch.go getPRBranch

### DIFF
--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -219,7 +219,7 @@ func buildTrustedSet(cfg config.Config, owner, repo string) map[string]bool {
 
 // getPRBranch returns the head branch name for a PR using the gh CLI.
 func getPRBranch(prNumber string) (string, error) {
-	cmd := exec.Command("gh", "pr", "view", "--", prNumber, "--json", "headRefName", "-q", ".headRefName")
+	cmd := exec.Command("gh", "pr", "view", "--json", "headRefName", "-q", ".headRefName", "--", prNumber)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr


### PR DESCRIPTION
## Summary
- Fix the `--` separator placement in `getPRBranch()` in `watch.go` so flags (`--json`, `-q`) are not treated as positional arguments
- Same bug pattern as the status.go fix — `--` must come after all flags and before the PR number

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Manual: run `klaus watch` on a repo with an open PR and verify branch detection works

Run: 20260306-1740-ef2a
Fixes #40