### PR TITLE
Pre-trust worktree directories to skip workspace trust dialog

### DIFF
--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -72,6 +72,10 @@ clean on the default branch. Must be run inside a tmux session.`,
 			fmt.Fprintf(os.Stderr, "warning: could not write .claude/settings.json: %v\n", err)
 		}
 
+		if err := config.PreTrustWorktree(worktree); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not pre-trust worktree: %v\n", err)
+		}
+
 		// Set up Nix dev environment if flake.nix exists
 		nix.SetupDevEnvironment(worktree)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
 )
 
@@ -311,6 +312,50 @@ func WriteClaudeSettings(worktreeDir, repoName string) error {
 		return fmt.Errorf("writing settings: %w", err)
 	}
 
+	return nil
+}
+
+// PreTrustWorktree creates a Claude Code project entry for the given directory
+// so that the workspace trust dialog is not shown when launching Claude
+// interactively. Claude Code stores per-project data in
+// ~/.claude/projects/<encoded-path>/ and shows a trust dialog for directories
+// without an existing project entry.
+func PreTrustWorktree(worktreeDir string) error {
+	absPath, err := filepath.Abs(worktreeDir)
+	if err != nil {
+		return fmt.Errorf("resolving worktree path: %w", err)
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("finding home dir: %w", err)
+	}
+
+	// Claude Code encodes paths by replacing path separators with hyphens.
+	encoded := strings.ReplaceAll(absPath, string(filepath.Separator), "-")
+	projectDir := filepath.Join(homeDir, ".claude", "projects", encoded)
+
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		return fmt.Errorf("creating project dir: %w", err)
+	}
+
+	indexPath := filepath.Join(projectDir, "sessions-index.json")
+	if _, err := os.Stat(indexPath); err == nil {
+		return nil // already exists
+	}
+
+	index := map[string]any{
+		"version":      1,
+		"entries":      []any{},
+		"originalPath": absPath,
+	}
+	data, err := json.MarshalIndent(index, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling sessions index: %w", err)
+	}
+	if err := os.WriteFile(indexPath, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("writing sessions index: %w", err)
+	}
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -298,6 +298,54 @@ func TestRenderPromptDefaultContainsTesting(t *testing.T) {
 	}
 }
 
+func TestPreTrustWorktree(t *testing.T) {
+	// Use a temp dir as both the worktree and the home dir
+	homeDir := t.TempDir()
+	worktreeDir := t.TempDir()
+
+	t.Setenv("HOME", homeDir)
+
+	if err := PreTrustWorktree(worktreeDir); err != nil {
+		t.Fatalf("PreTrustWorktree() error: %v", err)
+	}
+
+	// Check that the project directory was created
+	encoded := strings.ReplaceAll(worktreeDir, string(filepath.Separator), "-")
+	indexPath := filepath.Join(homeDir, ".claude", "projects", encoded, "sessions-index.json")
+
+	data, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("reading sessions-index.json: %v", err)
+	}
+
+	var index map[string]any
+	if err := json.Unmarshal(data, &index); err != nil {
+		t.Fatalf("parsing sessions-index.json: %v", err)
+	}
+
+	if v, ok := index["version"].(float64); !ok || v != 1 {
+		t.Errorf("version = %v, want 1", index["version"])
+	}
+	if p, ok := index["originalPath"].(string); !ok || p != worktreeDir {
+		t.Errorf("originalPath = %v, want %s", index["originalPath"], worktreeDir)
+	}
+}
+
+func TestPreTrustWorktreeIdempotent(t *testing.T) {
+	homeDir := t.TempDir()
+	worktreeDir := t.TempDir()
+
+	t.Setenv("HOME", homeDir)
+
+	// Call twice — second call should not error
+	if err := PreTrustWorktree(worktreeDir); err != nil {
+		t.Fatalf("first PreTrustWorktree() error: %v", err)
+	}
+	if err := PreTrustWorktree(worktreeDir); err != nil {
+		t.Fatalf("second PreTrustWorktree() error: %v", err)
+	}
+}
+
 func TestInit(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary
- Each `klaus session` creates a worktree at a unique path that Claude Code has never seen, triggering the workspace trust dialog every time
- `--dangerously-skip-permissions` only bypasses tool permission checks, not the separate workspace trust dialog
- Fix: pre-create the Claude Code project entry (`~/.claude/projects/<encoded-path>/sessions-index.json`) before launching Claude, which is the marker for previously opened workspaces

## Test plan
- [x] Unit tests for `PreTrustWorktree` (creation and idempotency)
- [x] Full test suite passes
- [ ] Manual: run `klaus session` and verify no trust dialog appears