### PR TITLE
Add .envrc for direnv-based Go development environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,6 @@
+# Go
+use go go1.24.0
+layout go
+
+# Add local bin to PATH for built binaries
+PATH_add bin


### PR DESCRIPTION
Sets up Go 1.24.0 via direnv with layout go and adds the local bin directory to PATH for built binaries.

https://claude.ai/code/session_01E9xj2Uiz6MExR8HWQ6nYbk