### PR TITLE
Extract state storage behind StateStore interface

### DIFF
--- a/internal/cmd/cleanup.go
+++ b/internal/cmd/cleanup.go
@@ -29,19 +29,21 @@ Use --all to clean up all runs.`,
 			return err
 		}
 
+		store := run.NewGitDirStore(commonDir)
+
 		if all {
-			return cleanupAll(root, commonDir)
+			return cleanupAll(root, store)
 		}
 
 		if len(args) != 1 {
 			return fmt.Errorf("usage: klaus cleanup <run-id> or klaus cleanup --all")
 		}
-		return cleanupOne(root, commonDir, args[0])
+		return cleanupOne(root, store, args[0])
 	},
 }
 
-func cleanupAll(root, commonDir string) error {
-	states, err := run.List(commonDir)
+func cleanupAll(root string, store run.StateStore) error {
+	states, err := store.List()
 	if err != nil {
 		return err
 	}
@@ -50,15 +52,15 @@ func cleanupAll(root, commonDir string) error {
 		return nil
 	}
 	for _, s := range states {
-		if err := cleanupOne(root, commonDir, s.ID); err != nil {
+		if err := cleanupOne(root, store, s.ID); err != nil {
 			fmt.Printf("  warning: failed to clean up %s: %v\n", s.ID, err)
 		}
 	}
 	return nil
 }
 
-func cleanupOne(root, commonDir, id string) error {
-	state, err := run.Load(commonDir, id)
+func cleanupOne(root string, store run.StateStore, id string) error {
+	state, err := store.Load(id)
 	if err != nil {
 		return fmt.Errorf("no run found with id: %s", id)
 	}
@@ -93,7 +95,7 @@ func cleanupOne(root, commonDir, id string) error {
 	}
 
 	// Remove state file
-	if err := run.Delete(commonDir, id); err == nil {
+	if err := store.Delete(id); err == nil {
 		fmt.Println("  removed state file")
 	}
 

--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -35,7 +35,8 @@ Keyboard shortcuts:
 			return fmt.Errorf("not inside a git repository")
 		}
 
-		p := tea.NewProgram(newDashboardModel(commonDir), tea.WithAltScreen())
+		store := run.NewGitDirStore(commonDir)
+		p := tea.NewProgram(newDashboardModel(store), tea.WithAltScreen())
 		_, err = p.Run()
 		return err
 	},
@@ -81,26 +82,26 @@ type repoGroup struct {
 
 // dashboardModel is the bubbletea model for the dashboard.
 type dashboardModel struct {
-	commonDir string
-	states    []*run.State
-	ghStatus  map[string]*prStatus // keyed by PR number
-	width     int
-	height    int
-	err       error
-	watcher   *fsnotify.Watcher
+	store    run.StateStore
+	states   []*run.State
+	ghStatus map[string]*prStatus // keyed by PR number
+	width    int
+	height   int
+	err      error
+	watcher  *fsnotify.Watcher
 }
 
-func newDashboardModel(commonDir string) dashboardModel {
+func newDashboardModel(store run.StateStore) dashboardModel {
 	return dashboardModel{
-		commonDir: commonDir,
-		ghStatus:  make(map[string]*prStatus),
+		store:    store,
+		ghStatus: make(map[string]*prStatus),
 	}
 }
 
 func (m dashboardModel) Init() tea.Cmd {
 	return tea.Batch(
-		loadStatesCmd(m.commonDir),
-		startWatcherCmd(m.commonDir),
+		loadStatesCmd(m.store),
+		startWatcherCmd(m.store),
 		tickCmd(),
 	)
 }
@@ -116,7 +117,7 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		case "r":
 			return m, tea.Batch(
-				loadStatesCmd(m.commonDir),
+				loadStatesCmd(m.store),
 				fetchGHStatusCmd(m.states),
 			)
 		}
@@ -135,7 +136,7 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case fsEventMsg:
-		return m, tea.Batch(loadStatesCmd(m.commonDir), watchFSCmd(m.watcher))
+		return m, tea.Batch(loadStatesCmd(m.store), watchFSCmd(m.watcher))
 
 	case tickMsg:
 		return m, tea.Batch(
@@ -319,9 +320,9 @@ func renderBareAgentLine(s *run.State) string {
 
 // Commands for the bubbletea event loop.
 
-func loadStatesCmd(commonDir string) tea.Cmd {
+func loadStatesCmd(store run.StateStore) tea.Cmd {
 	return func() tea.Msg {
-		states, err := run.List(commonDir)
+		states, err := store.List()
 		if err != nil {
 			return errMsg{err: err}
 		}
@@ -357,9 +358,9 @@ func tickAfterCmd() tea.Cmd {
 	})
 }
 
-func startWatcherCmd(commonDir string) tea.Cmd {
+func startWatcherCmd(store run.StateStore) tea.Cmd {
 	return func() tea.Msg {
-		stateDir := run.StateDir(commonDir)
+		stateDir := store.StateDir()
 		// Ensure the directory exists before watching
 		os.MkdirAll(stateDir, 0o755)
 

--- a/internal/cmd/dashboard_test.go
+++ b/internal/cmd/dashboard_test.go
@@ -325,7 +325,8 @@ func TestLoadStatesFromDir(t *testing.T) {
 		}
 	}
 
-	loaded, err := run.List(tmpDir)
+	store := run.NewGitDirStore(tmpDir)
+	loaded, err := store.List()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cmd/hidden.go
+++ b/internal/cmd/hidden.go
@@ -39,14 +39,15 @@ var finalizeCmd = &cobra.Command{
 			return err
 		}
 
-		state, err := run.Load(commonDir, id)
+		store := run.NewGitDirStore(commonDir)
+		state, err := store.Load(id)
 		if err != nil {
 			return nil // silently ignore if state not found
 		}
 
 		// Parse log for cost/duration/PR URL
 		if state.LogFile != nil {
-			if err := finalizeFromLog(commonDir, state); err != nil {
+			if err := finalizeFromLog(store, state); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: finalize: %v\n", err)
 			}
 		}
@@ -62,12 +63,12 @@ var finalizeCmd = &cobra.Command{
 			return nil
 		}
 
-		syncRunToDataRef(root, commonDir, cfg.DataRef, state)
+		syncRunToDataRef(root, store, cfg.DataRef, state)
 		return nil
 	},
 }
 
-func finalizeFromLog(commonDir string, state *run.State) error {
+func finalizeFromLog(store run.StateStore, state *run.State) error {
 	f, err := os.Open(*state.LogFile)
 	if err != nil {
 		return err
@@ -113,7 +114,7 @@ func finalizeFromLog(commonDir string, state *run.State) error {
 		}
 	}
 
-	return run.Save(commonDir, state)
+	return store.Save(state)
 }
 
 func extractPRURL(text string) string {
@@ -153,7 +154,8 @@ var autoWatchCmd = &cobra.Command{
 			return err
 		}
 
-		state, err := run.Load(commonDir, filepath.Base(id))
+		store := run.NewGitDirStore(commonDir)
+		state, err := store.Load(filepath.Base(id))
 		if err != nil {
 			return fmt.Errorf("auto-watch: failed to load state for run %s: %w", id, err)
 		}
@@ -210,8 +212,8 @@ var autoWatchCmd = &cobra.Command{
 	},
 }
 
-func syncRunToDataRef(root, commonDir, dataRef string, state *run.State) {
-	stateFile := run.StateDir(commonDir) + "/" + state.ID + ".json"
+func syncRunToDataRef(root string, store run.StateStore, dataRef string, state *run.State) {
+	stateFile := store.StateDir() + "/" + state.ID + ".json"
 	files := map[string]string{
 		"runs/" + state.ID + ".json": stateFile,
 	}

--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -55,7 +55,8 @@ worktree in that clone.`,
 			budget = hostCfg.DefaultBudget
 		}
 
-		if err := run.EnsureDirs(hostCommonDir); err != nil {
+		store := run.NewGitDirStore(hostCommonDir)
+		if err := store.EnsureDirs(); err != nil {
 			return err
 		}
 
@@ -146,7 +147,7 @@ worktree in that clone.`,
 			return fmt.Errorf("rendering prompt: %w", err)
 		}
 
-		logFile := filepath.Join(run.LogDir(hostCommonDir), id+".jsonl")
+		logFile := filepath.Join(store.LogDir(), id+".jsonl")
 
 		// Build the claude command
 		claudeCmd := buildClaudeCommand(sysPrompt, budget, prompt)
@@ -194,7 +195,7 @@ worktree in that clone.`,
 			CloneDir:   cloneDirPtr,
 		}
 
-		if err := run.Save(hostCommonDir, state); err != nil {
+		if err := store.Save(state); err != nil {
 			return fmt.Errorf("saving state: %w", err)
 		}
 

--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -33,7 +33,8 @@ Modes:
 			return fmt.Errorf("not inside a git repository")
 		}
 
-		state, err := run.Load(commonDir, id)
+		store := run.NewGitDirStore(commonDir)
+		state, err := store.Load(id)
 		if err != nil {
 			return fmt.Errorf("no run found with id: %s", id)
 		}

--- a/internal/cmd/new.go
+++ b/internal/cmd/new.go
@@ -119,11 +119,12 @@ func runNew(cmd *cobra.Command, args []string) error {
 
 	// We need a .git dir for state tracking — the cloned repo has one
 	gitCommonDir := resolveGitCommonDir(repoDir)
-	if err := run.EnsureDirs(gitCommonDir); err != nil {
+	store := run.NewGitDirStore(gitCommonDir)
+	if err := store.EnsureDirs(); err != nil {
 		return err
 	}
 
-	logFile := filepath.Join(run.LogDir(gitCommonDir), id+".jsonl")
+	logFile := filepath.Join(store.LogDir(), id+".jsonl")
 
 	// Build claude command
 	sysPrompt := "You are scaffolding a new project. Follow all instructions carefully. Push directly to main when done."
@@ -165,7 +166,7 @@ func runNew(cmd *cobra.Command, args []string) error {
 		CreatedAt: createdAt,
 		Type:      "new",
 	}
-	if err := run.Save(gitCommonDir, state); err != nil {
+	if err := store.Save(state); err != nil {
 		return fmt.Errorf("saving state: %w", err)
 	}
 

--- a/internal/cmd/pushlog.go
+++ b/internal/cmd/pushlog.go
@@ -34,7 +34,8 @@ warnings. Use after reviewing the log and confirming it's safe.`,
 			return err
 		}
 
-		state, err := run.Load(commonDir, id)
+		store := run.NewGitDirStore(commonDir)
+		state, err := store.Load(id)
 		if err != nil {
 			return fmt.Errorf("no run found with id: %s", id)
 		}
@@ -49,7 +50,7 @@ warnings. Use after reviewing the log and confirming it's safe.`,
 
 		fmt.Printf("Force-pushing log for %s (bypassing sensitivity check)...\n", id)
 
-		stateFile := run.StateDir(commonDir) + "/" + id + ".json"
+		stateFile := store.StateDir() + "/" + id + ".json"
 		files := map[string]string{
 			"runs/" + id + ".json":  stateFile,
 			"logs/" + id + ".jsonl": *state.LogFile,

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -41,7 +41,8 @@ clean on the default branch. Must be run inside a tmux session.`,
 			return err
 		}
 
-		if err := run.EnsureDirs(commonDir); err != nil {
+		store := run.NewGitDirStore(commonDir)
+		if err := store.EnsureDirs(); err != nil {
 			return err
 		}
 
@@ -89,7 +90,7 @@ clean on the default branch. Must be run inside a tmux session.`,
 			Worktree:  worktree,
 			CreatedAt: createdAt,
 		}
-		if err := run.Save(commonDir, state); err != nil {
+		if err := store.Save(state); err != nil {
 			return fmt.Errorf("saving state: %w", err)
 		}
 

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -22,7 +22,8 @@ var statusCmd = &cobra.Command{
 			return fmt.Errorf("not inside a git repository")
 		}
 
-		states, err := run.List(commonDir)
+		store := run.NewGitDirStore(commonDir)
+		states, err := store.List()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -54,7 +54,8 @@ Must be run inside a tmux session.`,
 			budget = cfg.DefaultBudget
 		}
 
-		if err := run.EnsureDirs(commonDir); err != nil {
+		store := run.NewGitDirStore(commonDir)
+		if err := store.EnsureDirs(); err != nil {
 			return err
 		}
 
@@ -101,7 +102,7 @@ Must be run inside a tmux session.`,
 			return fmt.Errorf("rendering prompt: %w", err)
 		}
 
-		logFile := filepath.Join(run.LogDir(commonDir), id+".jsonl")
+		logFile := filepath.Join(store.LogDir(), id+".jsonl")
 
 		// Gather review comments context, filtering to trusted reviewers only
 		reviewContext := ""
@@ -186,7 +187,7 @@ Must be run inside a tmux session.`,
 			Type:      "watch",
 		}
 
-		if err := run.Save(commonDir, state); err != nil {
+		if err := store.Save(state); err != nil {
 			return fmt.Errorf("saving state: %w", err)
 		}
 

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -3,12 +3,7 @@ package run
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
-	"sort"
-	"strings"
 	"time"
 )
 
@@ -39,91 +34,4 @@ func GenID() (string, error) {
 		return "", fmt.Errorf("generating random bytes: %w", err)
 	}
 	return fmt.Sprintf("%s-%s", ts, hex.EncodeToString(b)), nil
-}
-
-// StateDir returns the path to the runs state directory inside .git/klaus/runs/.
-// It uses git's common dir so it works from worktrees too.
-func StateDir(gitCommonDir string) string {
-	return filepath.Join(gitCommonDir, "klaus", "runs")
-}
-
-// LogDir returns the path to the logs directory inside .git/klaus/logs/.
-func LogDir(gitCommonDir string) string {
-	return filepath.Join(gitCommonDir, "klaus", "logs")
-}
-
-// EnsureDirs creates the state and log directories if they don't exist.
-func EnsureDirs(gitCommonDir string) error {
-	if err := os.MkdirAll(StateDir(gitCommonDir), 0o755); err != nil {
-		return fmt.Errorf("creating state dir: %w", err)
-	}
-	if err := os.MkdirAll(LogDir(gitCommonDir), 0o755); err != nil {
-		return fmt.Errorf("creating log dir: %w", err)
-	}
-	return nil
-}
-
-// Save writes the run state to a JSON file in the state directory.
-func Save(gitCommonDir string, s *State) error {
-	dir := StateDir(gitCommonDir)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return err
-	}
-	data, err := json.MarshalIndent(s, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshaling state: %w", err)
-	}
-	path := filepath.Join(dir, s.ID+".json")
-	return os.WriteFile(path, data, 0o644)
-}
-
-// Load reads a run state from its JSON file.
-func Load(gitCommonDir, id string) (*State, error) {
-	path := filepath.Join(StateDir(gitCommonDir), id+".json")
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("reading state file: %w", err)
-	}
-	var s State
-	if err := json.Unmarshal(data, &s); err != nil {
-		return nil, fmt.Errorf("parsing state file: %w", err)
-	}
-	return &s, nil
-}
-
-// List returns all run states, sorted by creation time (newest first).
-func List(gitCommonDir string) ([]*State, error) {
-	dir := StateDir(gitCommonDir)
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("reading state dir: %w", err)
-	}
-
-	var states []*State
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
-			continue
-		}
-		id := strings.TrimSuffix(e.Name(), ".json")
-		s, err := Load(gitCommonDir, id)
-		if err != nil {
-			continue // skip corrupt files
-		}
-		states = append(states, s)
-	}
-
-	sort.Slice(states, func(i, j int) bool {
-		return states[i].CreatedAt > states[j].CreatedAt
-	})
-
-	return states, nil
-}
-
-// Delete removes a run's state file.
-func Delete(gitCommonDir, id string) error {
-	path := filepath.Join(StateDir(gitCommonDir), id+".json")
-	return os.Remove(path)
 }

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -38,8 +38,9 @@ func TestGenIDUniqueness(t *testing.T) {
 	}
 }
 
-func TestSaveLoadRoundtrip(t *testing.T) {
+func TestGitDirStoreSaveLoadRoundtrip(t *testing.T) {
 	tmpDir := t.TempDir()
+	store := NewGitDirStore(tmpDir)
 
 	issue := "42"
 	pane := "%5"
@@ -64,11 +65,11 @@ func TestSaveLoadRoundtrip(t *testing.T) {
 		PRURL:      &prURL,
 	}
 
-	if err := Save(tmpDir, original); err != nil {
+	if err := store.Save(original); err != nil {
 		t.Fatalf("Save() error: %v", err)
 	}
 
-	loaded, err := Load(tmpDir, original.ID)
+	loaded, err := store.Load(original.ID)
 	if err != nil {
 		t.Fatalf("Load() error: %v", err)
 	}
@@ -93,8 +94,9 @@ func TestSaveLoadRoundtrip(t *testing.T) {
 	}
 }
 
-func TestSaveLoadNullFields(t *testing.T) {
+func TestGitDirStoreSaveLoadNullFields(t *testing.T) {
 	tmpDir := t.TempDir()
+	store := NewGitDirStore(tmpDir)
 
 	original := &State{
 		ID:        "20260210-1430-b1c2",
@@ -104,11 +106,11 @@ func TestSaveLoadNullFields(t *testing.T) {
 		CreatedAt: "2026-02-10T14:30:00-08:00",
 	}
 
-	if err := Save(tmpDir, original); err != nil {
+	if err := store.Save(original); err != nil {
 		t.Fatalf("Save() error: %v", err)
 	}
 
-	loaded, err := Load(tmpDir, original.ID)
+	loaded, err := store.Load(original.ID)
 	if err != nil {
 		t.Fatalf("Load() error: %v", err)
 	}
@@ -127,8 +129,9 @@ func TestSaveLoadNullFields(t *testing.T) {
 	}
 }
 
-func TestList(t *testing.T) {
+func TestGitDirStoreList(t *testing.T) {
 	tmpDir := t.TempDir()
+	store := NewGitDirStore(tmpDir)
 
 	states := []*State{
 		{ID: "20260210-1430-aaaa", Prompt: "first", Branch: "b1", Worktree: "/tmp/1", CreatedAt: "2026-02-10T14:30:00Z"},
@@ -137,12 +140,12 @@ func TestList(t *testing.T) {
 	}
 
 	for _, s := range states {
-		if err := Save(tmpDir, s); err != nil {
+		if err := store.Save(s); err != nil {
 			t.Fatalf("Save() error: %v", err)
 		}
 	}
 
-	result, err := List(tmpDir)
+	result, err := store.List()
 	if err != nil {
 		t.Fatalf("List() error: %v", err)
 	}
@@ -160,9 +163,10 @@ func TestList(t *testing.T) {
 	}
 }
 
-func TestListEmpty(t *testing.T) {
+func TestGitDirStoreListEmpty(t *testing.T) {
 	tmpDir := t.TempDir()
-	result, err := List(tmpDir)
+	store := NewGitDirStore(tmpDir)
+	result, err := store.List()
 	if err != nil {
 		t.Fatalf("List() error: %v", err)
 	}
@@ -171,8 +175,9 @@ func TestListEmpty(t *testing.T) {
 	}
 }
 
-func TestDelete(t *testing.T) {
+func TestGitDirStoreDelete(t *testing.T) {
 	tmpDir := t.TempDir()
+	store := NewGitDirStore(tmpDir)
 
 	s := &State{
 		ID:        "20260210-1430-dddd",
@@ -182,22 +187,84 @@ func TestDelete(t *testing.T) {
 		CreatedAt: "2026-02-10T14:30:00Z",
 	}
 
-	if err := Save(tmpDir, s); err != nil {
+	if err := store.Save(s); err != nil {
 		t.Fatalf("Save() error: %v", err)
 	}
 
 	// Verify file exists
-	path := filepath.Join(StateDir(tmpDir), s.ID+".json")
+	path := filepath.Join(store.StateDir(), s.ID+".json")
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("state file should exist: %v", err)
 	}
 
-	if err := Delete(tmpDir, s.ID); err != nil {
+	if err := store.Delete(s.ID); err != nil {
 		t.Fatalf("Delete() error: %v", err)
 	}
 
 	// Verify file is gone
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Error("state file should not exist after Delete()")
+	}
+}
+
+func TestGitDirStoreEnsureDirs(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewGitDirStore(tmpDir)
+
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs() error: %v", err)
+	}
+
+	// Verify both directories were created
+	if _, err := os.Stat(store.StateDir()); err != nil {
+		t.Errorf("StateDir should exist: %v", err)
+	}
+	if _, err := os.Stat(store.LogDir()); err != nil {
+		t.Errorf("LogDir should exist: %v", err)
+	}
+}
+
+func TestGitDirStoreDirPaths(t *testing.T) {
+	store := NewGitDirStore("/repo/.git")
+	if got := store.StateDir(); got != filepath.Join("/repo/.git", "klaus", "runs") {
+		t.Errorf("StateDir() = %q, want /repo/.git/klaus/runs", got)
+	}
+	if got := store.LogDir(); got != filepath.Join("/repo/.git", "klaus", "logs") {
+		t.Errorf("LogDir() = %q, want /repo/.git/klaus/logs", got)
+	}
+}
+
+func TestGitDirStoreListSkipsCorruptFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewGitDirStore(tmpDir)
+
+	// Save a valid state
+	valid := &State{
+		ID:        "20260210-1430-aaaa",
+		Prompt:    "valid",
+		Branch:    "b1",
+		Worktree:  "/tmp/1",
+		CreatedAt: "2026-02-10T14:30:00Z",
+	}
+	if err := store.Save(valid); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	// Write a corrupt file
+	corrupt := filepath.Join(store.StateDir(), "20260210-1430-bbbb.json")
+	if err := os.WriteFile(corrupt, []byte("not json"), 0o644); err != nil {
+		t.Fatalf("writing corrupt file: %v", err)
+	}
+
+	result, err := store.List()
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Fatalf("List() returned %d items, want 1 (skipping corrupt)", len(result))
+	}
+	if result[0].ID != "20260210-1430-aaaa" {
+		t.Errorf("result[0].ID = %q, want 20260210-1430-aaaa", result[0].ID)
 	}
 }

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -1,0 +1,110 @@
+package run
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// StateStore defines the interface for persisting run state.
+type StateStore interface {
+	Save(s *State) error
+	Load(id string) (*State, error)
+	List() ([]*State, error)
+	Delete(id string) error
+	LogDir() string
+	StateDir() string
+	EnsureDirs() error
+}
+
+// GitDirStore implements StateStore using the .git/klaus/ directory structure.
+type GitDirStore struct {
+	gitCommonDir string
+}
+
+// NewGitDirStore creates a new GitDirStore rooted at the given git common directory.
+func NewGitDirStore(gitCommonDir string) *GitDirStore {
+	return &GitDirStore{gitCommonDir: gitCommonDir}
+}
+
+func (s *GitDirStore) StateDir() string {
+	return filepath.Join(s.gitCommonDir, "klaus", "runs")
+}
+
+func (s *GitDirStore) LogDir() string {
+	return filepath.Join(s.gitCommonDir, "klaus", "logs")
+}
+
+func (s *GitDirStore) EnsureDirs() error {
+	if err := os.MkdirAll(s.StateDir(), 0o755); err != nil {
+		return fmt.Errorf("creating state dir: %w", err)
+	}
+	if err := os.MkdirAll(s.LogDir(), 0o755); err != nil {
+		return fmt.Errorf("creating log dir: %w", err)
+	}
+	return nil
+}
+
+func (s *GitDirStore) Save(st *State) error {
+	dir := s.StateDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling state: %w", err)
+	}
+	path := filepath.Join(dir, st.ID+".json")
+	return os.WriteFile(path, data, 0o644)
+}
+
+func (s *GitDirStore) Load(id string) (*State, error) {
+	path := filepath.Join(s.StateDir(), id+".json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading state file: %w", err)
+	}
+	var st State
+	if err := json.Unmarshal(data, &st); err != nil {
+		return nil, fmt.Errorf("parsing state file: %w", err)
+	}
+	return &st, nil
+}
+
+func (s *GitDirStore) List() ([]*State, error) {
+	dir := s.StateDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading state dir: %w", err)
+	}
+
+	var states []*State
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		id := strings.TrimSuffix(e.Name(), ".json")
+		st, err := s.Load(id)
+		if err != nil {
+			continue // skip corrupt files
+		}
+		states = append(states, st)
+	}
+
+	sort.Slice(states, func(i, j int) bool {
+		return states[i].CreatedAt > states[j].CreatedAt
+	})
+
+	return states, nil
+}
+
+func (s *GitDirStore) Delete(id string) error {
+	path := filepath.Join(s.StateDir(), id+".json")
+	return os.Remove(path)
+}


### PR DESCRIPTION
## Summary
- Define a `StateStore` interface in `internal/run/store.go` with `Save`, `Load`, `List`, `Delete`, `LogDir`, `StateDir`, and `EnsureDirs` methods
- Implement `GitDirStore` using the existing file-based logic (same paths: `.git/klaus/runs/` and `.git/klaus/logs/`)
- Update all callers across `internal/cmd/` (launch, watch, session, status, logs, cleanup, finalize, auto-watch, dashboard, new, push-log) to use the interface
- Remove old package-level functions from `internal/run/run.go`, keeping only `State` struct and `GenID()`

## Test plan
- [x] All existing tests updated to use `GitDirStore` instead of removed package-level functions
- [x] Added integration tests: `EnsureDirs`, `DirPaths`, `ListSkipsCorruptFiles`
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)

Run: 20260307-1215-f2a6
Fixes #50