### PR TITLE
Move session state to ~/.klaus/sessions/

### DIFF
--- a/internal/cmd/cleanup.go
+++ b/internal/cmd/cleanup.go
@@ -19,25 +19,29 @@ Use --all to clean up all runs.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		all, _ := cmd.Flags().GetBool("all")
 
-		root, err := git.RepoRoot()
-		if err != nil {
-			return fmt.Errorf("not inside a git repository")
-		}
-
-		commonDir, err := git.CommonDir()
-		if err != nil {
-			return err
-		}
-
-		store := run.NewGitDirStore(commonDir)
+		root, _ := git.RepoRoot() // may be empty outside a repo
 
 		if all {
-			return cleanupAll(root, store)
+			store, err := sessionStoreOrAll()
+			if err != nil {
+				return err
+			}
+			if store != nil {
+				return cleanupAll(root, store)
+			}
+			// No session env — could scan all, but require explicit session
+			return fmt.Errorf("KLAUS_SESSION_ID not set; specify a run ID or run inside a session")
 		}
 
 		if len(args) != 1 {
 			return fmt.Errorf("usage: klaus cleanup <run-id> or klaus cleanup --all")
 		}
+
+		state, store, err := loadStateFromEnvOrAll(args[0])
+		if err != nil {
+			return err
+		}
+		_ = state // cleanupOne will re-load
 		return cleanupOne(root, store, args[0])
 	},
 }

--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -11,7 +11,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/fsnotify/fsnotify"
-	"github.com/patflynn/klaus/internal/git"
 	"github.com/patflynn/klaus/internal/run"
 	"github.com/spf13/cobra"
 )
@@ -30,12 +29,13 @@ Keyboard shortcuts:
   q  quit
   r  force refresh`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		commonDir, err := git.CommonDir()
+		store, err := sessionStoreOrAll()
 		if err != nil {
-			return fmt.Errorf("not inside a git repository")
+			return err
 		}
-
-		store := run.NewGitDirStore(commonDir)
+		if store == nil {
+			return fmt.Errorf("KLAUS_SESSION_ID not set; run inside a klaus session")
+		}
 		p := tea.NewProgram(newDashboardModel(store), tea.WithAltScreen())
 		_, err = p.Run()
 		return err

--- a/internal/cmd/hidden.go
+++ b/internal/cmd/hidden.go
@@ -34,12 +34,11 @@ var finalizeCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		id := args[0]
 
-		commonDir, err := git.CommonDir()
+		store, err := sessionStore()
 		if err != nil {
-			return err
+			return nil // silently ignore if session not set
 		}
 
-		store := run.NewGitDirStore(commonDir)
 		state, err := store.Load(id)
 		if err != nil {
 			return nil // silently ignore if state not found
@@ -52,7 +51,7 @@ var finalizeCmd = &cobra.Command{
 			}
 		}
 
-		// Sync to data ref
+		// Sync to data ref — still uses the git repo
 		root, err := git.RepoRoot()
 		if err != nil {
 			return nil
@@ -149,12 +148,11 @@ var autoWatchCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		id := args[0]
 
-		commonDir, err := git.CommonDir()
+		store, err := sessionStore()
 		if err != nil {
-			return err
+			return fmt.Errorf("auto-watch: %w", err)
 		}
 
-		store := run.NewGitDirStore(commonDir)
 		state, err := store.Load(filepath.Base(id))
 		if err != nil {
 			return fmt.Errorf("auto-watch: failed to load state for run %s: %w", id, err)
@@ -171,10 +169,11 @@ var autoWatchCmd = &cobra.Command{
 			return nil
 		}
 
-		// Derive main repo root from common dir
-		mainRoot := filepath.Dir(commonDir)
-
-		gitRoot := mainRoot
+		// Determine git root for worktree/branch cleanup
+		gitRoot, err := git.RepoRoot()
+		if err != nil {
+			return fmt.Errorf("auto-watch: not inside a git repository")
+		}
 		if state.CloneDir != nil {
 			gitRoot = *state.CloneDir
 		}

--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -41,11 +41,6 @@ worktree in that clone.`,
 			return fmt.Errorf("not inside a git repository")
 		}
 
-		hostCommonDir, err := git.CommonDir()
-		if err != nil {
-			return err
-		}
-
 		hostCfg, err := config.Load(hostRoot)
 		if err != nil {
 			return err
@@ -55,7 +50,10 @@ worktree in that clone.`,
 			budget = hostCfg.DefaultBudget
 		}
 
-		store := run.NewGitDirStore(hostCommonDir)
+		store, err := sessionStore()
+		if err != nil {
+			return err
+		}
 		if err := store.EnsureDirs(); err != nil {
 			return err
 		}

--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/patflynn/klaus/internal/git"
 	"github.com/patflynn/klaus/internal/run"
 	"github.com/patflynn/klaus/internal/stream"
 	"github.com/patflynn/klaus/internal/tmux"
@@ -28,15 +27,9 @@ Modes:
 		raw, _ := cmd.Flags().GetBool("raw")
 		replay, _ := cmd.Flags().GetBool("replay")
 
-		commonDir, err := git.CommonDir()
+		state, _, err := loadStateFromEnvOrAll(id)
 		if err != nil {
-			return fmt.Errorf("not inside a git repository")
-		}
-
-		store := run.NewGitDirStore(commonDir)
-		state, err := store.Load(id)
-		if err != nil {
-			return fmt.Errorf("no run found with id: %s", id)
+			return err
 		}
 
 		if raw {

--- a/internal/cmd/pushlog.go
+++ b/internal/cmd/pushlog.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/patflynn/klaus/internal/config"
 	"github.com/patflynn/klaus/internal/git"
-	"github.com/patflynn/klaus/internal/run"
 	"github.com/spf13/cobra"
 )
 
@@ -24,20 +23,14 @@ warnings. Use after reviewing the log and confirming it's safe.`,
 			return fmt.Errorf("not inside a git repository")
 		}
 
-		commonDir, err := git.CommonDir()
-		if err != nil {
-			return err
-		}
-
 		cfg, err := config.Load(root)
 		if err != nil {
 			return err
 		}
 
-		store := run.NewGitDirStore(commonDir)
-		state, err := store.Load(id)
+		state, store, err := loadStateFromEnvOrAll(id)
 		if err != nil {
-			return fmt.Errorf("no run found with id: %s", id)
+			return err
 		}
 
 		if state.LogFile == nil {

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -15,6 +15,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const klausSessionIDEnv = "KLAUS_SESSION_ID"
+
 var sessionCmd = &cobra.Command{
 	Use:   "session",
 	Short: "Start an interactive coordinator session",
@@ -31,18 +33,8 @@ clean on the default branch. Must be run inside a tmux session.`,
 			return fmt.Errorf("not inside a git repository")
 		}
 
-		commonDir, err := git.CommonDir()
-		if err != nil {
-			return err
-		}
-
 		cfg, err := config.Load(root)
 		if err != nil {
-			return err
-		}
-
-		store := run.NewGitDirStore(commonDir)
-		if err := store.EnsureDirs(); err != nil {
 			return err
 		}
 
@@ -51,6 +43,14 @@ clean on the default branch. Must be run inside a tmux session.`,
 			return err
 		}
 		id := "session-" + baseID
+
+		store, err := run.NewHomeDirStore(id)
+		if err != nil {
+			return err
+		}
+		if err := store.EnsureDirs(); err != nil {
+			return err
+		}
 		branch := "session/" + id
 		repoName := filepath.Base(root)
 		worktree := filepath.Join(cfg.WorktreeBase, repoName, id)
@@ -118,12 +118,13 @@ clean on the default branch. Must be run inside a tmux session.`,
 		fmt.Println("  Use 'klaus launch' from inside to spawn workers.")
 		fmt.Println()
 
-		// Run claude interactively in the worktree
+		// Run claude interactively in the worktree, passing session ID to children
 		claude := exec.Command("claude", "--dangerously-skip-permissions", "--append-system-prompt", sessionPrompt)
 		claude.Dir = worktree
 		claude.Stdin = os.Stdin
 		claude.Stdout = os.Stdout
 		claude.Stderr = os.Stderr
+		claude.Env = append(os.Environ(), klausSessionIDEnv+"="+id)
 		claude.Run() // ignore error — user may exit normally
 
 		fmt.Println()

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/patflynn/klaus/internal/git"
 	"github.com/patflynn/klaus/internal/run"
 	"github.com/patflynn/klaus/internal/tmux"
 	"github.com/spf13/cobra"
@@ -17,13 +16,7 @@ var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show all runs and their current state",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		commonDir, err := git.CommonDir()
-		if err != nil {
-			return fmt.Errorf("not inside a git repository")
-		}
-
-		store := run.NewGitDirStore(commonDir)
-		states, err := store.List()
+		states, _, err := listStatesFromEnvOrAll()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/store_helper.go
+++ b/internal/cmd/store_helper.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/patflynn/klaus/internal/run"
+)
+
+const sessionIDEnv = "KLAUS_SESSION_ID"
+
+// sessionStore returns a HomeDirStore for the current session (from KLAUS_SESSION_ID env var).
+func sessionStore() (run.StateStore, error) {
+	sessionID := os.Getenv(sessionIDEnv)
+	if sessionID == "" {
+		return nil, fmt.Errorf("KLAUS_SESSION_ID is not set (are you inside a klaus session?)")
+	}
+	store, err := run.NewHomeDirStore(sessionID)
+	if err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+// sessionStoreOrAll returns a store for the current session if KLAUS_SESSION_ID is set,
+// otherwise returns nil (callers should use ListAllSessions to scan all sessions).
+func sessionStoreOrAll() (run.StateStore, error) {
+	sessionID := os.Getenv(sessionIDEnv)
+	if sessionID == "" {
+		return nil, nil
+	}
+	store, err := run.NewHomeDirStore(sessionID)
+	if err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+// listStatesFromEnvOrAll lists states from the current session if KLAUS_SESSION_ID
+// is set, otherwise lists states from all sessions under ~/.klaus/sessions/.
+func listStatesFromEnvOrAll() ([]*run.State, run.StateStore, error) {
+	store, err := sessionStoreOrAll()
+	if err != nil {
+		return nil, nil, err
+	}
+	if store != nil {
+		states, err := store.List()
+		return states, store, err
+	}
+	// No session env set — scan all sessions
+	states, err := run.ListAllSessions()
+	return states, nil, err
+}
+
+// loadStateFromEnvOrAll loads a specific run state. If KLAUS_SESSION_ID is set,
+// looks only in that session. Otherwise scans all sessions.
+func loadStateFromEnvOrAll(id string) (*run.State, run.StateStore, error) {
+	store, err := sessionStoreOrAll()
+	if err != nil {
+		return nil, nil, err
+	}
+	if store != nil {
+		state, err := store.Load(id)
+		if err != nil {
+			return nil, nil, fmt.Errorf("no run found with id: %s", id)
+		}
+		return state, store, nil
+	}
+	// Scan all sessions
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolving home dir: %w", err)
+	}
+	return run.FindStateInSessions(home, id)
+}

--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -40,11 +40,6 @@ Must be run inside a tmux session.`,
 			return fmt.Errorf("not inside a git repository")
 		}
 
-		commonDir, err := git.CommonDir()
-		if err != nil {
-			return err
-		}
-
 		cfg, err := config.Load(root)
 		if err != nil {
 			return err
@@ -54,7 +49,10 @@ Must be run inside a tmux session.`,
 			budget = cfg.DefaultBudget
 		}
 
-		store := run.NewGitDirStore(commonDir)
+		store, err := sessionStore()
+		if err != nil {
+			return err
+		}
 		if err := store.EnsureDirs(); err != nil {
 			return err
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,23 +30,36 @@ func Defaults() Config {
 	}
 }
 
-// Load reads config from .klaus/config.json in the given repo root.
-// If the file doesn't exist, returns defaults.
+// Load reads config by layering: defaults → ~/.klaus/config.json → .klaus/config.json.
+// Repo-local config overrides global config.
 func Load(repoRoot string) (Config, error) {
 	cfg := Defaults()
-	path := filepath.Join(repoRoot, ".klaus", "config.json")
 
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return cfg, nil
+	// Layer 1: global config from ~/.klaus/config.json
+	if home, err := os.UserHomeDir(); err == nil {
+		globalPath := filepath.Join(home, ".klaus", "config.json")
+		if data, err := os.ReadFile(globalPath); err == nil {
+			if err := json.Unmarshal(data, &cfg); err != nil {
+				return cfg, fmt.Errorf("parsing global config: %w", err)
+			}
 		}
-		return cfg, fmt.Errorf("reading config: %w", err)
 	}
 
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return cfg, fmt.Errorf("parsing config: %w", err)
+	// Layer 2: repo-local config from .klaus/config.json (overrides global)
+	if repoRoot != "" {
+		localPath := filepath.Join(repoRoot, ".klaus", "config.json")
+		data, err := os.ReadFile(localPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return cfg, nil
+			}
+			return cfg, fmt.Errorf("reading config: %w", err)
+		}
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return cfg, fmt.Errorf("parsing config: %w", err)
+		}
 	}
+
 	return cfg, nil
 }
 

--- a/internal/run/homedir_store.go
+++ b/internal/run/homedir_store.go
@@ -1,0 +1,126 @@
+package run
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// HomeDirStore implements StateStore using ~/.klaus/sessions/{session-id}/.
+type HomeDirStore struct {
+	baseDir string // e.g. ~/.klaus/sessions/{session-id}
+}
+
+// NewHomeDirStore creates a new HomeDirStore for the given session ID.
+// It resolves ~/.klaus via os.UserHomeDir().
+func NewHomeDirStore(sessionID string) (*HomeDirStore, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolving home dir: %w", err)
+	}
+	baseDir := filepath.Join(home, ".klaus", "sessions", sessionID)
+	return &HomeDirStore{baseDir: baseDir}, nil
+}
+
+// NewHomeDirStoreFromPath creates a HomeDirStore with an explicit base directory.
+// Useful for testing.
+func NewHomeDirStoreFromPath(baseDir string) *HomeDirStore {
+	return &HomeDirStore{baseDir: baseDir}
+}
+
+func (s *HomeDirStore) StateDir() string {
+	return filepath.Join(s.baseDir, "runs")
+}
+
+func (s *HomeDirStore) LogDir() string {
+	return filepath.Join(s.baseDir, "logs")
+}
+
+func (s *HomeDirStore) BaseDir() string {
+	return s.baseDir
+}
+
+func (s *HomeDirStore) EnsureDirs() error {
+	if err := os.MkdirAll(s.StateDir(), 0o755); err != nil {
+		return fmt.Errorf("creating state dir: %w", err)
+	}
+	if err := os.MkdirAll(s.LogDir(), 0o755); err != nil {
+		return fmt.Errorf("creating log dir: %w", err)
+	}
+	return nil
+}
+
+func (s *HomeDirStore) Save(st *State) error {
+	return saveState(s.StateDir(), st)
+}
+
+func (s *HomeDirStore) Load(id string) (*State, error) {
+	return loadState(s.StateDir(), id)
+}
+
+func (s *HomeDirStore) List() ([]*State, error) {
+	return listStates(s.StateDir())
+}
+
+func (s *HomeDirStore) Delete(id string) error {
+	return deleteState(s.StateDir(), id)
+}
+
+// ListAllSessions scans ~/.klaus/sessions/ and returns a combined list of
+// all run states across all session directories.
+func ListAllSessions() ([]*State, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolving home dir: %w", err)
+	}
+	return listAllSessionsIn(filepath.Join(home, ".klaus", "sessions"))
+}
+
+func listAllSessionsIn(sessionsDir string) ([]*State, error) {
+	entries, err := os.ReadDir(sessionsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading sessions dir: %w", err)
+	}
+
+	var all []*State
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		store := NewHomeDirStoreFromPath(filepath.Join(sessionsDir, e.Name()))
+		states, err := store.List()
+		if err != nil {
+			continue
+		}
+		all = append(all, states...)
+	}
+	return all, nil
+}
+
+// FindStateInSessions searches across all session directories for a run with the given ID.
+// Returns the state and its store if found.
+func FindStateInSessions(homeDir string, id string) (*State, StateStore, error) {
+	sessionsDir := filepath.Join(homeDir, ".klaus", "sessions")
+	entries, err := os.ReadDir(sessionsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, fmt.Errorf("no run found with id: %s", id)
+		}
+		return nil, nil, fmt.Errorf("reading sessions dir: %w", err)
+	}
+
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		store := NewHomeDirStoreFromPath(filepath.Join(sessionsDir, e.Name()))
+		st, err := store.Load(id)
+		if err == nil {
+			return st, store, nil
+		}
+	}
+	return nil, nil, fmt.Errorf("no run found with id: %s", id)
+}

--- a/internal/run/homedir_store_test.go
+++ b/internal/run/homedir_store_test.go
@@ -1,0 +1,179 @@
+package run
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHomeDirStore_SaveLoadListDelete(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewHomeDirStoreFromPath(tmpDir)
+
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+
+	// Verify directories created
+	if _, err := os.Stat(store.StateDir()); err != nil {
+		t.Fatalf("StateDir not created: %v", err)
+	}
+	if _, err := os.Stat(store.LogDir()); err != nil {
+		t.Fatalf("LogDir not created: %v", err)
+	}
+
+	// Save
+	state := &State{
+		ID:        "20260307-1200-abcd",
+		Prompt:    "Fix the bug",
+		Branch:    "agent/20260307-1200-abcd",
+		Worktree:  "/tmp/worktree",
+		CreatedAt: "2026-03-07T12:00:00Z",
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Verify file exists on disk
+	stateFile := filepath.Join(store.StateDir(), state.ID+".json")
+	if _, err := os.Stat(stateFile); err != nil {
+		t.Fatalf("state file not on disk: %v", err)
+	}
+
+	// Load
+	loaded, err := store.Load(state.ID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.ID != state.ID {
+		t.Errorf("ID mismatch: got %q, want %q", loaded.ID, state.ID)
+	}
+	if loaded.Prompt != state.Prompt {
+		t.Errorf("Prompt mismatch: got %q, want %q", loaded.Prompt, state.Prompt)
+	}
+
+	// Save a second state
+	state2 := &State{
+		ID:        "20260307-1201-bcde",
+		Prompt:    "Add tests",
+		Branch:    "agent/20260307-1201-bcde",
+		Worktree:  "/tmp/worktree2",
+		CreatedAt: "2026-03-07T12:01:00Z",
+	}
+	if err := store.Save(state2); err != nil {
+		t.Fatalf("Save second: %v", err)
+	}
+
+	// List
+	states, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(states) != 2 {
+		t.Fatalf("List: got %d states, want 2", len(states))
+	}
+	// Sorted by CreatedAt descending
+	if states[0].ID != state2.ID {
+		t.Errorf("List order: first should be newest, got %q", states[0].ID)
+	}
+
+	// Delete
+	if err := store.Delete(state.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	// Verify deleted
+	_, err = store.Load(state.ID)
+	if err == nil {
+		t.Error("Load after Delete should fail")
+	}
+
+	states, err = store.List()
+	if err != nil {
+		t.Fatalf("List after delete: %v", err)
+	}
+	if len(states) != 1 {
+		t.Errorf("List after delete: got %d states, want 1", len(states))
+	}
+}
+
+func TestHomeDirStore_LoadNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewHomeDirStoreFromPath(tmpDir)
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+
+	_, err := store.Load("nonexistent")
+	if err == nil {
+		t.Error("Load nonexistent should return error")
+	}
+}
+
+func TestHomeDirStore_ListEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewHomeDirStoreFromPath(tmpDir)
+	// Don't create dirs — should return nil, nil
+	states, err := store.List()
+	if err != nil {
+		t.Fatalf("List on missing dir: %v", err)
+	}
+	if states != nil {
+		t.Errorf("List on missing dir: got %v, want nil", states)
+	}
+}
+
+func TestHomeDirStore_Paths(t *testing.T) {
+	store := NewHomeDirStoreFromPath("/home/user/.klaus/sessions/session-123")
+	if got := store.StateDir(); got != "/home/user/.klaus/sessions/session-123/runs" {
+		t.Errorf("StateDir: got %q", got)
+	}
+	if got := store.LogDir(); got != "/home/user/.klaus/sessions/session-123/logs" {
+		t.Errorf("LogDir: got %q", got)
+	}
+	if got := store.BaseDir(); got != "/home/user/.klaus/sessions/session-123" {
+		t.Errorf("BaseDir: got %q", got)
+	}
+}
+
+func TestFindStateInSessions(t *testing.T) {
+	tmpHome := t.TempDir()
+	sessionsDir := filepath.Join(tmpHome, ".klaus", "sessions")
+
+	// Create two session directories with states
+	session1Dir := filepath.Join(sessionsDir, "session-1")
+	store1 := NewHomeDirStoreFromPath(session1Dir)
+	if err := store1.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+	if err := store1.Save(&State{ID: "run-aaa", CreatedAt: "2026-03-07T10:00:00Z"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	session2Dir := filepath.Join(sessionsDir, "session-2")
+	store2 := NewHomeDirStoreFromPath(session2Dir)
+	if err := store2.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+	if err := store2.Save(&State{ID: "run-bbb", CreatedAt: "2026-03-07T11:00:00Z"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Find run-bbb (in session-2)
+	state, store, err := FindStateInSessions(tmpHome, "run-bbb")
+	if err != nil {
+		t.Fatalf("FindStateInSessions: %v", err)
+	}
+	if state.ID != "run-bbb" {
+		t.Errorf("got ID %q, want run-bbb", state.ID)
+	}
+	if store == nil {
+		t.Error("store should not be nil")
+	}
+
+	// Not found
+	_, _, err = FindStateInSessions(tmpHome, "run-zzz")
+	if err == nil {
+		t.Error("expected error for nonexistent run")
+	}
+}

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -9,6 +9,67 @@ import (
 	"strings"
 )
 
+// Shared helpers used by both GitDirStore and HomeDirStore.
+
+func saveState(dir string, st *State) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling state: %w", err)
+	}
+	path := filepath.Join(dir, st.ID+".json")
+	return os.WriteFile(path, data, 0o644)
+}
+
+func loadState(dir string, id string) (*State, error) {
+	path := filepath.Join(dir, id+".json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading state file: %w", err)
+	}
+	var st State
+	if err := json.Unmarshal(data, &st); err != nil {
+		return nil, fmt.Errorf("parsing state file: %w", err)
+	}
+	return &st, nil
+}
+
+func listStates(dir string) ([]*State, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading state dir: %w", err)
+	}
+
+	var states []*State
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		id := strings.TrimSuffix(e.Name(), ".json")
+		st, err := loadState(dir, id)
+		if err != nil {
+			continue // skip corrupt files
+		}
+		states = append(states, st)
+	}
+
+	sort.Slice(states, func(i, j int) bool {
+		return states[i].CreatedAt > states[j].CreatedAt
+	})
+
+	return states, nil
+}
+
+func deleteState(dir string, id string) error {
+	path := filepath.Join(dir, id+".json")
+	return os.Remove(path)
+}
+
 // StateStore defines the interface for persisting run state.
 type StateStore interface {
 	Save(s *State) error
@@ -49,62 +110,17 @@ func (s *GitDirStore) EnsureDirs() error {
 }
 
 func (s *GitDirStore) Save(st *State) error {
-	dir := s.StateDir()
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return err
-	}
-	data, err := json.MarshalIndent(st, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshaling state: %w", err)
-	}
-	path := filepath.Join(dir, st.ID+".json")
-	return os.WriteFile(path, data, 0o644)
+	return saveState(s.StateDir(), st)
 }
 
 func (s *GitDirStore) Load(id string) (*State, error) {
-	path := filepath.Join(s.StateDir(), id+".json")
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("reading state file: %w", err)
-	}
-	var st State
-	if err := json.Unmarshal(data, &st); err != nil {
-		return nil, fmt.Errorf("parsing state file: %w", err)
-	}
-	return &st, nil
+	return loadState(s.StateDir(), id)
 }
 
 func (s *GitDirStore) List() ([]*State, error) {
-	dir := s.StateDir()
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("reading state dir: %w", err)
-	}
-
-	var states []*State
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
-			continue
-		}
-		id := strings.TrimSuffix(e.Name(), ".json")
-		st, err := s.Load(id)
-		if err != nil {
-			continue // skip corrupt files
-		}
-		states = append(states, st)
-	}
-
-	sort.Slice(states, func(i, j int) bool {
-		return states[i].CreatedAt > states[j].CreatedAt
-	})
-
-	return states, nil
+	return listStates(s.StateDir())
 }
 
 func (s *GitDirStore) Delete(id string) error {
-	path := filepath.Join(s.StateDir(), id+".json")
-	return os.Remove(path)
+	return deleteState(s.StateDir(), id)
 }


### PR DESCRIPTION
## Summary
- Adds `HomeDirStore` implementation that stores run state at `~/.klaus/sessions/{session-id}/runs/` and logs at `~/.klaus/sessions/{session-id}/logs/`
- Session command sets `KLAUS_SESSION_ID` env var, inherited by all child processes (launch, finalize, auto-watch, watch)
- Commands that read state (status, logs, cleanup, dashboard) use `KLAUS_SESSION_ID` if set, otherwise scan all session directories
- Config loading now layers: defaults → `~/.klaus/config.json` (global) → `.klaus/config.json` (repo-local overrides)
- Orphan branch mechanism (`refs/klaus/data`) unchanged — finalized artifacts still sync there

## Test plan
- [x] HomeDirStore integration tests: Save/Load/List/Delete in temp directories
- [x] FindStateInSessions cross-session lookup test
- [x] All existing tests pass (`go test ./...`)
- [x] `go build ./...` succeeds

Run: 20260307-1223-df2a
Fixes #50