### PR TITLE
Allow klaus session without a git repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,14 @@ Three new tmux panes appear. Each agent works independently in its own worktree,
 
 ## What happens when you run `klaus session`
 
-1. A fresh git worktree is created from `origin/main`
+1. A fresh git worktree is created from `origin/main` (or a scratch workspace if not in a repo)
 2. Claude Code starts interactively in that worktree
 3. You talk to Claude as usual — it has `klaus` on PATH
 4. When Claude runs `klaus launch`, a new tmux pane splits off with an autonomous agent
 5. `klaus status` gives you and Claude a dashboard of all running agents
 6. When you're done, `klaus cleanup --all` tears everything down
+
+You can also run `klaus` outside a git repository. In this mode, the session uses a scratch workspace under `~/.klaus/sessions/` and loads configuration from `~/.klaus/config.json`. Use `klaus launch --repo owner/repo` to target specific repositories.
 
 The session is the experience. The other commands are infrastructure.
 
@@ -97,7 +99,7 @@ The status dashboard shows these columns for each run:
 
 ## Configuration
 
-Klaus works out of the box with sensible defaults. To customize, run `klaus init` to scaffold a `.klaus/` directory, or create the files yourself:
+Klaus works out of the box with sensible defaults. To customize, run `klaus init` to scaffold a `.klaus/` directory (or `~/.klaus/config.json` when outside a repo), or create the files yourself. Configuration layers: defaults → `~/.klaus/config.json` → `.klaus/config.json`.
 
 **`.klaus/config.json`** — Override defaults:
 ```json

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -10,21 +10,28 @@ import (
 
 var initCmd = &cobra.Command{
 	Use:   "init",
-	Short: "Initialize .klaus/ config in the current repo",
-	Long:  "Scaffolds a .klaus/ directory with default config.json and prompt.md template.",
+	Short: "Initialize klaus config",
+	Long: `Scaffolds a .klaus/ directory with default config.json and prompt.md template.
+
+If run inside a git repository, creates .klaus/ in the repo root.
+If run outside a git repository, creates ~/.klaus/config.json for global configuration.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		root, err := git.RepoRoot()
-		if err != nil {
-			return fmt.Errorf("not inside a git repository")
-		}
+		root, _ := git.RepoRoot()
 
-		if err := config.Init(root); err != nil {
-			return err
+		if root != "" {
+			if err := config.Init(root); err != nil {
+				return err
+			}
+			fmt.Println("Initialized .klaus/ directory:")
+			fmt.Println("  .klaus/config.json  — configuration")
+			fmt.Println("  .klaus/prompt.md    — system prompt template")
+		} else {
+			if err := config.InitGlobal(); err != nil {
+				return err
+			}
+			fmt.Println("Initialized global klaus config:")
+			fmt.Println("  ~/.klaus/config.json  — configuration")
 		}
-
-		fmt.Println("Initialized .klaus/ directory:")
-		fmt.Println("  .klaus/config.json  — configuration")
-		fmt.Println("  .klaus/prompt.md    — system prompt template")
 		return nil
 	},
 }

--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -35,10 +35,10 @@ worktree in that clone.`,
 			return fmt.Errorf("klaus launch must be run inside a tmux session")
 		}
 
-		// Host repo — always needed for state tracking
-		hostRoot, err := git.RepoRoot()
-		if err != nil {
-			return fmt.Errorf("not inside a git repository")
+		// Host repo — optional when --repo is specified
+		hostRoot, _ := git.RepoRoot()
+		if hostRoot == "" && repoRef == "" {
+			return fmt.Errorf("not in a git repo — use --repo owner/repo to specify a target")
 		}
 
 		hostCfg, err := config.Load(hostRoot)
@@ -151,11 +151,11 @@ worktree in that clone.`,
 		claudeCmd := buildClaudeCommand(sysPrompt, budget, prompt)
 
 		// Build the pane command: run claude, pipe through tee and formatter, then finalize.
-		// For cross-repo launches, finalize must run from the host repo context
-		// so that state is resolved from the host's .git/klaus/ directory.
+		// For cross-repo launches with a host repo, finalize must run from the
+		// host repo context so that data-ref sync works correctly.
 		selfBin := "klaus" // assumes klaus is in PATH
 		var finalizePrefix string
-		if targetRepo != nil {
+		if targetRepo != nil && hostRoot != "" {
 			finalizePrefix = fmt.Sprintf("cd %s && ", shellQuote(hostRoot))
 		}
 		noWatch, _ := cmd.Flags().GetBool("no-watch")

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -22,16 +22,19 @@ var sessionCmd = &cobra.Command{
 	Short: "Start an interactive coordinator session",
 	Long: `Creates an isolated worktree and starts an interactive Claude Code session.
 The coordinator runs here instead of the base repo, keeping the base repo
-clean on the default branch. Must be run inside a tmux session.`,
+clean on the default branch. Must be run inside a tmux session.
+
+If run outside a git repository, creates a scratch workspace and uses
+~/.klaus/config.json for configuration. Use 'klaus launch --repo owner/repo'
+from inside the session to target specific repositories.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if !tmux.InSession() {
 			return fmt.Errorf("klaus session must be run inside a tmux session")
 		}
 
-		root, err := git.RepoRoot()
-		if err != nil {
-			return fmt.Errorf("not inside a git repository")
-		}
+		// Git repo is optional — session can run without one
+		root, _ := git.RepoRoot()
+		inRepo := root != ""
 
 		cfg, err := config.Load(root)
 		if err != nil {
@@ -51,34 +54,48 @@ clean on the default branch. Must be run inside a tmux session.`,
 		if err := store.EnsureDirs(); err != nil {
 			return err
 		}
-		branch := "session/" + id
-		repoName := filepath.Base(root)
-		worktree := filepath.Join(cfg.WorktreeBase, repoName, id)
-		defaultBranch := cfg.DefaultBranch
 
-		fmt.Printf("Creating coordinator session %s...\n", id)
+		var branch, repoName, worktree string
 
-		if err := git.FetchBranch(root, defaultBranch); err != nil {
-			return fmt.Errorf("fetching %s: %w", defaultBranch, err)
-		}
+		if inRepo {
+			branch = "session/" + id
+			repoName = filepath.Base(root)
+			worktree = filepath.Join(cfg.WorktreeBase, repoName, id)
+			defaultBranch := cfg.DefaultBranch
 
-		startPoint := "origin/" + defaultBranch
-		if err := git.WorktreeAdd(root, worktree, branch, startPoint); err != nil {
-			return fmt.Errorf("creating worktree: %w", err)
-		}
-		fmt.Printf("  worktree: %s\n", worktree)
-		fmt.Printf("  branch:   %s\n", branch)
+			fmt.Printf("Creating coordinator session %s...\n", id)
 
-		if err := config.WriteClaudeSettings(worktree, repoName); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: could not write .claude/settings.json: %v\n", err)
+			if err := git.FetchBranch(root, defaultBranch); err != nil {
+				return fmt.Errorf("fetching %s: %w", defaultBranch, err)
+			}
+
+			startPoint := "origin/" + defaultBranch
+			if err := git.WorktreeAdd(root, worktree, branch, startPoint); err != nil {
+				return fmt.Errorf("creating worktree: %w", err)
+			}
+			fmt.Printf("  worktree: %s\n", worktree)
+			fmt.Printf("  branch:   %s\n", branch)
+
+			if err := config.WriteClaudeSettings(worktree, repoName); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: could not write .claude/settings.json: %v\n", err)
+			}
+
+			// Set up Nix dev environment if flake.nix exists
+			nix.SetupDevEnvironment(worktree)
+		} else {
+			// No repo — use a scratch workspace
+			worktree = filepath.Join(store.BaseDir(), "workspace")
+			if err := os.MkdirAll(worktree, 0o755); err != nil {
+				return fmt.Errorf("creating scratch workspace: %w", err)
+			}
+
+			fmt.Printf("Creating coordinator session %s (no repo)...\n", id)
+			fmt.Printf("  workspace: %s\n", worktree)
 		}
 
 		if err := config.PreTrustWorktree(worktree); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: could not pre-trust worktree: %v\n", err)
 		}
-
-		// Set up Nix dev environment if flake.nix exists
-		nix.SetupDevEnvironment(worktree)
 
 		// Write state
 		createdAt := time.Now().Format(time.RFC3339)
@@ -107,8 +124,12 @@ clean on the default branch. Must be run inside a tmux session.`,
 		// Configure tmux window for better situational awareness
 		currentPane := os.Getenv("TMUX_PANE")
 		if currentPane != "" {
+			windowTitle := repoName
+			if windowTitle == "" {
+				windowTitle = "klaus"
+			}
 			tmux.SetWindowOption(currentPane, "automatic-rename", "off")
-			tmux.RenameWindow(currentPane, repoName)
+			tmux.RenameWindow(currentPane, windowTitle)
 			tmux.SetWindowOption(currentPane, "pane-border-status", "top")
 			tmux.SetWindowOption(currentPane, "pane-border-format", "#{pane_title}")
 		}
@@ -129,7 +150,9 @@ clean on the default branch. Must be run inside a tmux session.`,
 
 		fmt.Println()
 		fmt.Printf("Session %s ended.\n", id)
-		fmt.Printf("  Worktree preserved at: %s\n", worktree)
+		if inRepo {
+			fmt.Printf("  Worktree preserved at: %s\n", worktree)
+		}
 		fmt.Printf("  To clean up: klaus cleanup %s\n", id)
 		return nil
 	},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,6 +105,31 @@ func Init(repoRoot string) error {
 	return nil
 }
 
+// InitGlobal scaffolds ~/.klaus/config.json with default configuration.
+// Used when running outside a git repository.
+func InitGlobal() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolving home dir: %w", err)
+	}
+	dir := filepath.Join(home, ".klaus")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating ~/.klaus dir: %w", err)
+	}
+
+	cfg := Defaults()
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	configPath := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(configPath, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("writing config: %w", err)
+	}
+
+	return nil
+}
+
 const defaultPromptTemplate = `You are an autonomous agent working on this repository.
 
 ## Workflow
@@ -134,9 +159,12 @@ const defaultPromptTemplate = `You are an autonomous agent working on this repos
 `
 
 const defaultSessionPromptTemplate = `You are a coordinator running inside a klaus session (session ID: {{.RunID}}).
-
+{{if .RepoName}}
 Your working directory is an isolated git worktree on branch {{.Branch}} for repo {{.RepoName}}.
-
+{{else}}
+Your working directory is a scratch workspace (no git repo). Use --repo owner/repo with
+klaus launch to target specific repositories.
+{{end}}
 ## Delegating work
 
 You should delegate implementation work to autonomous agents rather than doing it directly.
@@ -151,7 +179,12 @@ To delegate tasks referencing a GitHub issue:
 ` + "```" + `
 klaus launch --issue <number> "<prompt>"
 ` + "```" + `
-
+{{if not .RepoName}}
+When not in a git repo, you must specify a target repository:
+` + "```" + `
+klaus launch --repo owner/repo "<prompt>"
+` + "```" + `
+{{end}}
 ## Managing agents
 
 - Check on running agents: ` + "`klaus status`" + `
@@ -433,6 +466,10 @@ func LoadPrinciples(dir string) (string, error) {
 }
 
 func renderPromptFromFile(repoRoot, filename, defaultTemplate string, vars PromptVars) (string, error) {
+	if repoRoot == "" {
+		return renderTemplate(defaultTemplate, vars)
+	}
+
 	path := filepath.Join(repoRoot, ".klaus", filename)
 
 	data, err := os.ReadFile(path)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -377,3 +377,105 @@ func TestInit(t *testing.T) {
 		t.Error("prompt template should contain {{.RunID}}")
 	}
 }
+
+func TestLoadEmptyRepoRoot(t *testing.T) {
+	// When repoRoot is empty, Load should return defaults (plus any global config)
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load(\"\") error: %v", err)
+	}
+	// Should have valid defaults
+	if cfg.DefaultBudget == "" {
+		t.Error("DefaultBudget should not be empty")
+	}
+	if cfg.DefaultBranch == "" {
+		t.Error("DefaultBranch should not be empty")
+	}
+}
+
+func TestRenderSessionPromptNoRepo(t *testing.T) {
+	// When RepoName is empty, the no-repo variant of the session prompt is rendered
+	vars := PromptVars{
+		RunID: "session-20260307-1430-a3f2",
+	}
+
+	prompt, err := RenderSessionPrompt("", vars)
+	if err != nil {
+		t.Fatalf("RenderSessionPrompt() error: %v", err)
+	}
+
+	if !strings.Contains(prompt, "session-20260307-1430-a3f2") {
+		t.Error("prompt should contain session ID")
+	}
+	if !strings.Contains(prompt, "scratch workspace") {
+		t.Error("prompt should mention scratch workspace when no repo")
+	}
+	if !strings.Contains(prompt, "--repo owner/repo") {
+		t.Error("prompt should mention --repo flag when no repo")
+	}
+	if strings.Contains(prompt, "isolated git worktree on branch") {
+		t.Error("prompt should not mention git worktree when no repo")
+	}
+}
+
+func TestRenderSessionPromptWithRepo(t *testing.T) {
+	dir := t.TempDir()
+	vars := PromptVars{
+		RunID:    "session-20260307-1430-a3f2",
+		Branch:   "session/session-20260307-1430-a3f2",
+		RepoName: "my-project",
+	}
+
+	prompt, err := RenderSessionPrompt(dir, vars)
+	if err != nil {
+		t.Fatalf("RenderSessionPrompt() error: %v", err)
+	}
+
+	if !strings.Contains(prompt, "isolated git worktree on branch") {
+		t.Error("prompt should mention git worktree when in a repo")
+	}
+	if !strings.Contains(prompt, "my-project") {
+		t.Error("prompt should contain repo name")
+	}
+	if strings.Contains(prompt, "scratch workspace") {
+		t.Error("prompt should not mention scratch workspace when in a repo")
+	}
+}
+
+func TestRenderPromptEmptyRepoRoot(t *testing.T) {
+	// With empty repoRoot, should use default template
+	vars := PromptVars{RunID: "test-123"}
+	prompt, err := RenderPrompt("", vars)
+	if err != nil {
+		t.Fatalf("RenderPrompt(\"\") error: %v", err)
+	}
+	if !strings.Contains(prompt, "Run: test-123") {
+		t.Error("prompt should contain run ID from default template")
+	}
+}
+
+func TestInitGlobal(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	if err := InitGlobal(); err != nil {
+		t.Fatalf("InitGlobal() error: %v", err)
+	}
+
+	configPath := filepath.Join(homeDir, ".klaus", "config.json")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("reading global config: %v", err)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parsing global config: %v", err)
+	}
+	if cfg.WorktreeBase != wantWorktreeBase {
+		t.Errorf("config WorktreeBase = %q, want %q", cfg.WorktreeBase, wantWorktreeBase)
+	}
+	if cfg.DefaultBudget != "5.00" {
+		t.Errorf("config DefaultBudget = %q, want 5.00", cfg.DefaultBudget)
+	}
+}


### PR DESCRIPTION
## Summary
- `klaus session` no longer requires being inside a git repository
- When not in a repo, creates a scratch workspace under `~/.klaus/sessions/{id}/workspace/`
- Session prompt adapts to indicate no default repo and instructs use of `--repo owner/repo`
- `klaus launch` requires `--repo` flag when not in a git repo, with clear error message
- `klaus init` creates `~/.klaus/config.json` when run outside a repo
- `renderPromptFromFile` returns default template immediately when repoRoot is empty

## Test plan
- [x] New tests: `TestLoadEmptyRepoRoot`, `TestRenderSessionPromptNoRepo`, `TestRenderSessionPromptWithRepo`, `TestRenderPromptEmptyRepoRoot`, `TestInitGlobal`
- [x] All existing tests pass (`go test ./...`)
- [x] Build succeeds (`go build ./...`)
- [ ] Manual: run `klaus` outside a git repo in tmux — should get scratch workspace
- [ ] Manual: run `klaus launch "test"` outside a repo without `--repo` — should get clear error
- [ ] Manual: run `klaus init` outside a repo — should create `~/.klaus/config.json`

Run: 20260307-1233-823d
Fixes #50