### PR TITLE
Add project registry and klaus project CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ The coordinator session uses these — you generally don't run them directly:
 | `klaus logs <id>` | View agent output (live, replay, or raw) |
 | `klaus cleanup <id>\|--all` | Tear down worktrees, panes, and state |
 | `klaus push-log <id>` | Force-push a log held back for sensitivity |
+| `klaus project add <owner/repo>` | Register a project (clones if needed) |
+| `klaus project list` | Show registered projects |
+| `klaus project remove <name>` | Unregister a project |
+| `klaus project set-dir <path>` | Set the default projects directory |
 | `klaus new <project-name>` | Scaffold a new project using principles-based generation |
 | `klaus dashboard` | Live TUI dashboard for monitoring agents and PRs |
 | `klaus merge <pr>...` | Sequentially merge PRs with conflict resolution |
@@ -134,6 +138,19 @@ klaus merge --merge-method rebase --no-delete-branch 42
 ```
 
 Flags: `--dry-run`, `--merge-method` (squash/merge/rebase), `--no-delete-branch`.
+
+### `klaus project`
+
+Manage a persistent registry of projects. The registry maps short names to local paths and is stored in `~/.klaus/projects.json`.
+
+```bash
+klaus project add owner/repo              # clone into projects dir and register
+klaus project add owner/repo --path .     # register an existing local checkout
+klaus project add my-tool                 # search your GitHub repos by name
+klaus project list                        # show all registered projects
+klaus project remove my-tool              # unregister (does not delete the clone)
+klaus project set-dir ~/hack              # set the default clone directory
+```
 
 ### `klaus new`
 

--- a/internal/cmd/project.go
+++ b/internal/cmd/project.go
@@ -1,0 +1,285 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/patflynn/klaus/internal/project"
+	"github.com/spf13/cobra"
+)
+
+var projectCmd = &cobra.Command{
+	Use:   "project",
+	Short: "Manage the project registry",
+	Long: `Register, list, and remove projects from the klaus project registry.
+
+The registry maps project names to local paths and is stored in ~/.klaus/projects.json.
+
+  klaus project add owner/repo          Clone and register a project
+  klaus project add owner/repo --path . Register with explicit local path
+  klaus project list                    Show registered projects
+  klaus project remove <name>           Unregister a project
+  klaus project set-dir ~/hack          Set the default projects directory`,
+}
+
+var projectAddCmd = &cobra.Command{
+	Use:   "add <owner/repo | name>",
+	Short: "Clone and register a project",
+	Long: `Register a project in the klaus project registry.
+
+With owner/repo format, clones the repo into the projects directory and registers it.
+With just a name, searches your GitHub repos for a match.
+
+If --path is provided, registers the project at that path (must be an existing git repo).
+If the repo is already cloned at the expected path, it is registered without re-cloning.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runProjectAdd,
+}
+
+var projectListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Show registered projects",
+	Args:  cobra.NoArgs,
+	RunE:  runProjectList,
+}
+
+var projectRemoveCmd = &cobra.Command{
+	Use:   "remove <name>",
+	Short: "Unregister a project (does not delete the local clone)",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runProjectRemove,
+}
+
+var projectSetDirCmd = &cobra.Command{
+	Use:   "set-dir <path>",
+	Short: "Set the default projects directory",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runProjectSetDir,
+}
+
+func runProjectAdd(cmd *cobra.Command, args []string) error {
+	ref := args[0]
+	explicitPath, _ := cmd.Flags().GetString("path")
+
+	reg, err := project.Load()
+	if err != nil {
+		return err
+	}
+
+	var owner, repoName, cloneURL string
+
+	if strings.Contains(ref, "/") {
+		// owner/repo format
+		parts := strings.SplitN(ref, "/", 2)
+		owner = parts[0]
+		repoName = parts[1]
+		cloneURL = fmt.Sprintf("https://github.com/%s/%s.git", owner, repoName)
+	} else {
+		// Bare name — search GitHub repos
+		repoName = ref
+		ghOwner, ghURL, err := resolveGitHubRepo(ref)
+		if err != nil {
+			return err
+		}
+		owner = ghOwner
+		cloneURL = ghURL
+	}
+
+	if explicitPath != "" {
+		// Register with explicit path
+		expanded, err := project.ExpandHome(explicitPath)
+		if err != nil {
+			return err
+		}
+		absPath, err := filepath.Abs(expanded)
+		if err != nil {
+			return fmt.Errorf("resolving path: %w", err)
+		}
+
+		if !isGitRepo(absPath) {
+			return fmt.Errorf("%s is not a git repository", absPath)
+		}
+
+		if err := reg.Add(repoName, absPath); err != nil {
+			return err
+		}
+		if err := reg.Save(); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Registered %s → %s\n", repoName, absPath)
+		return nil
+	}
+
+	// Clone to projects_dir/<repo-name>
+	projDir, err := reg.ExpandedProjectsDir()
+	if err != nil {
+		return err
+	}
+	targetDir := filepath.Join(projDir, repoName)
+
+	if isGitRepo(targetDir) {
+		fmt.Fprintf(cmd.OutOrStdout(), "Already cloned at %s\n", targetDir)
+	} else {
+		fmt.Fprintf(cmd.OutOrStdout(), "Cloning %s/%s into %s...\n", owner, repoName, targetDir)
+		if err := gitClone(cloneURL, targetDir); err != nil {
+			return fmt.Errorf("cloning: %w", err)
+		}
+	}
+
+	if err := reg.Add(repoName, targetDir); err != nil {
+		return err
+	}
+	if err := reg.Save(); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Registered %s → %s\n", repoName, targetDir)
+	return nil
+}
+
+func runProjectList(cmd *cobra.Command, _ []string) error {
+	reg, err := project.Load()
+	if err != nil {
+		return err
+	}
+
+	projects := reg.List()
+	if len(projects) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No projects registered. Use 'klaus project add' to register one.")
+		return nil
+	}
+
+	for name, localPath := range projects {
+		remote := gitRemoteURL(localPath)
+		if remote != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "%-20s %s  (%s)\n", name, localPath, remote)
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "%-20s %s\n", name, localPath)
+		}
+	}
+	return nil
+}
+
+func runProjectRemove(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	reg, err := project.Load()
+	if err != nil {
+		return err
+	}
+
+	if err := reg.Remove(name); err != nil {
+		return err
+	}
+	if err := reg.Save(); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Removed %s from registry (local clone was not deleted)\n", name)
+	return nil
+}
+
+func runProjectSetDir(cmd *cobra.Command, args []string) error {
+	dir := args[0]
+
+	expanded, err := project.ExpandHome(dir)
+	if err != nil {
+		return err
+	}
+	absDir, err := filepath.Abs(expanded)
+	if err != nil {
+		return fmt.Errorf("resolving path: %w", err)
+	}
+
+	reg, err := project.Load()
+	if err != nil {
+		return err
+	}
+
+	reg.SetProjectsDir(absDir)
+	if err := reg.Save(); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Projects directory set to %s\n", absDir)
+	return nil
+}
+
+// ghRepoEntry represents a repo from gh repo list JSON output.
+type ghRepoEntry struct {
+	Name          string `json:"name"`
+	NameWithOwner string `json:"nameWithOwner"`
+	URL           string `json:"url"`
+}
+
+// resolveGitHubRepo searches the user's GitHub repos for a name match.
+// Returns (owner, cloneURL, error).
+var resolveGitHubRepo = func(name string) (string, string, error) {
+	out, err := exec.Command("gh", "repo", "list", "--json", "name,nameWithOwner,url", "--limit", "200").Output()
+	if err != nil {
+		return "", "", fmt.Errorf("running gh repo list: %w", err)
+	}
+
+	var repos []ghRepoEntry
+	if err := json.Unmarshal(out, &repos); err != nil {
+		return "", "", fmt.Errorf("parsing gh output: %w", err)
+	}
+
+	var matches []ghRepoEntry
+	for _, r := range repos {
+		if r.Name == name {
+			matches = append(matches, r)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return "", "", fmt.Errorf("no GitHub repo found matching %q. Use owner/repo format to be explicit", name)
+	case 1:
+		parts := strings.SplitN(matches[0].NameWithOwner, "/", 2)
+		return parts[0], matches[0].URL + ".git", nil
+	default:
+		var names []string
+		for _, m := range matches {
+			names = append(names, m.NameWithOwner)
+		}
+		return "", "", fmt.Errorf("multiple repos match %q: %s. Use owner/repo format to be specific", name, strings.Join(names, ", "))
+	}
+}
+
+// isGitRepo checks whether the given directory exists and contains a .git directory.
+func isGitRepo(dir string) bool {
+	info, err := os.Stat(filepath.Join(dir, ".git"))
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}
+
+// gitClone clones a repository to the target directory.
+var gitClone = func(url, targetDir string) error {
+	c := exec.Command("git", "clone", url, targetDir)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	return c.Run()
+}
+
+// gitRemoteURL returns the origin remote URL for a repo, or empty string on error.
+func gitRemoteURL(repoDir string) string {
+	c := exec.Command("git", "-C", repoDir, "remote", "get-url", "origin")
+	out, err := c.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func init() {
+	projectAddCmd.Flags().String("path", "", "Register with an explicit local path instead of cloning")
+	projectCmd.AddCommand(projectAddCmd)
+	projectCmd.AddCommand(projectListCmd)
+	projectCmd.AddCommand(projectRemoveCmd)
+	projectCmd.AddCommand(projectSetDirCmd)
+	rootCmd.AddCommand(projectCmd)
+}

--- a/internal/project/registry.go
+++ b/internal/project/registry.go
@@ -1,0 +1,192 @@
+package project
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Registry holds the project registry: a default projects directory
+// and a map of project name to local path.
+type Registry struct {
+	ProjectsDir string            `json:"projects_dir"`
+	Projects    map[string]string `json:"projects"`
+}
+
+// registryPath returns the path to ~/.klaus/projects.json.
+func registryPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home dir: %w", err)
+	}
+	return filepath.Join(home, ".klaus", "projects.json"), nil
+}
+
+// ExpandHome expands a leading ~ in a path to the user's home directory.
+func ExpandHome(path string) (string, error) {
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolving home dir: %w", err)
+		}
+		return filepath.Join(home, path[1:]), nil
+	}
+	return path, nil
+}
+
+// contractHome replaces the user's home directory prefix with ~ for storage.
+func contractHome(path string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	if path == home {
+		return "~"
+	}
+	if strings.HasPrefix(path, home+string(filepath.Separator)) {
+		return "~" + path[len(home):]
+	}
+	return path
+}
+
+// Load reads the registry from ~/.klaus/projects.json.
+// Returns an empty registry with defaults if the file doesn't exist.
+func Load() (*Registry, error) {
+	p, err := registryPath()
+	if err != nil {
+		return nil, err
+	}
+	return loadFrom(p)
+}
+
+// loadFrom reads a registry from the given path. Exported for testing via LoadFrom.
+func loadFrom(path string) (*Registry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return defaultRegistry()
+		}
+		return nil, fmt.Errorf("reading projects file: %w", err)
+	}
+
+	var reg Registry
+	if err := json.Unmarshal(data, &reg); err != nil {
+		return nil, fmt.Errorf("parsing projects file: %w", err)
+	}
+	if reg.Projects == nil {
+		reg.Projects = make(map[string]string)
+	}
+	return &reg, nil
+}
+
+// defaultRegistry returns a new registry with sensible defaults.
+func defaultRegistry() (*Registry, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolving home dir: %w", err)
+	}
+	return &Registry{
+		ProjectsDir: filepath.Join(home, "src"),
+		Projects:    make(map[string]string),
+	}, nil
+}
+
+// Save writes the registry to ~/.klaus/projects.json.
+func (r *Registry) Save() error {
+	p, err := registryPath()
+	if err != nil {
+		return err
+	}
+	return r.saveTo(p)
+}
+
+// saveTo writes the registry to the given path.
+func (r *Registry) saveTo(path string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating config dir: %w", err)
+	}
+
+	// Store paths with ~ for readability
+	out := Registry{
+		ProjectsDir: contractHome(r.ProjectsDir),
+		Projects:    make(map[string]string, len(r.Projects)),
+	}
+	for name, p := range r.Projects {
+		out.Projects[name] = contractHome(p)
+	}
+
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling projects file: %w", err)
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o644)
+}
+
+// Add registers a project with the given name and local path.
+// The path must be absolute. Returns an error if the name is already registered.
+func (r *Registry) Add(name, localPath string) error {
+	if _, exists := r.Projects[name]; exists {
+		return fmt.Errorf("project %q is already registered", name)
+	}
+	r.Projects[name] = localPath
+	return nil
+}
+
+// Remove unregisters a project by name. Returns an error if the name is not found.
+func (r *Registry) Remove(name string) error {
+	if _, exists := r.Projects[name]; !exists {
+		return fmt.Errorf("project %q is not registered", name)
+	}
+	delete(r.Projects, name)
+	return nil
+}
+
+// Get returns the local path for a project, expanding ~ if present.
+func (r *Registry) Get(name string) (string, bool) {
+	p, ok := r.Projects[name]
+	if !ok {
+		return "", false
+	}
+	expanded, err := ExpandHome(p)
+	if err != nil {
+		return p, true
+	}
+	return expanded, true
+}
+
+// List returns all registered projects as a map of name to expanded local path.
+func (r *Registry) List() map[string]string {
+	result := make(map[string]string, len(r.Projects))
+	for name, p := range r.Projects {
+		expanded, err := ExpandHome(p)
+		if err != nil {
+			expanded = p
+		}
+		result[name] = expanded
+	}
+	return result
+}
+
+// SetProjectsDir sets the default projects directory.
+func (r *Registry) SetProjectsDir(dir string) {
+	r.ProjectsDir = dir
+}
+
+// ExpandedProjectsDir returns the projects directory with ~ expanded.
+func (r *Registry) ExpandedProjectsDir() (string, error) {
+	return ExpandHome(r.ProjectsDir)
+}
+
+// LoadFrom reads a registry from the given path (for testing).
+func LoadFrom(path string) (*Registry, error) {
+	return loadFrom(path)
+}
+
+// SaveTo writes the registry to the given path (for testing).
+func (r *Registry) SaveTo(path string) error {
+	return r.saveTo(path)
+}

--- a/internal/project/registry_test.go
+++ b/internal/project/registry_test.go
@@ -1,0 +1,273 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadFromEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "projects.json")
+
+	reg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom non-existent file: %v", err)
+	}
+	if len(reg.Projects) != 0 {
+		t.Errorf("expected empty projects map, got %d entries", len(reg.Projects))
+	}
+	if reg.ProjectsDir == "" {
+		t.Error("expected default ProjectsDir, got empty string")
+	}
+}
+
+func TestSaveAndLoad(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "projects.json")
+
+	reg := &Registry{
+		ProjectsDir: "/home/test/projects",
+		Projects:    map[string]string{"myrepo": "/home/test/projects/myrepo"},
+	}
+
+	if err := reg.SaveTo(path); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	loaded, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+
+	if loaded.ProjectsDir != reg.ProjectsDir {
+		t.Errorf("ProjectsDir = %q, want %q", loaded.ProjectsDir, reg.ProjectsDir)
+	}
+	if len(loaded.Projects) != 1 {
+		t.Fatalf("expected 1 project, got %d", len(loaded.Projects))
+	}
+	if loaded.Projects["myrepo"] != "/home/test/projects/myrepo" {
+		t.Errorf("myrepo path = %q, want %q", loaded.Projects["myrepo"], "/home/test/projects/myrepo")
+	}
+}
+
+func TestAddAndGet(t *testing.T) {
+	reg := &Registry{
+		ProjectsDir: "/tmp/projects",
+		Projects:    make(map[string]string),
+	}
+
+	if err := reg.Add("foo", "/tmp/projects/foo"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	path, ok := reg.Get("foo")
+	if !ok {
+		t.Fatal("Get returned false for existing project")
+	}
+	if path != "/tmp/projects/foo" {
+		t.Errorf("Get = %q, want %q", path, "/tmp/projects/foo")
+	}
+}
+
+func TestAddDuplicateReturnsError(t *testing.T) {
+	reg := &Registry{
+		ProjectsDir: "/tmp/projects",
+		Projects:    map[string]string{"foo": "/tmp/foo"},
+	}
+
+	err := reg.Add("foo", "/tmp/other/foo")
+	if err == nil {
+		t.Fatal("expected error for duplicate name, got nil")
+	}
+}
+
+func TestRemove(t *testing.T) {
+	reg := &Registry{
+		ProjectsDir: "/tmp/projects",
+		Projects:    map[string]string{"foo": "/tmp/foo"},
+	}
+
+	if err := reg.Remove("foo"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	_, ok := reg.Get("foo")
+	if ok {
+		t.Error("Get returned true after Remove")
+	}
+}
+
+func TestRemoveNonExistent(t *testing.T) {
+	reg := &Registry{
+		ProjectsDir: "/tmp/projects",
+		Projects:    make(map[string]string),
+	}
+
+	err := reg.Remove("nope")
+	if err == nil {
+		t.Fatal("expected error for non-existent project, got nil")
+	}
+}
+
+func TestGetNonExistent(t *testing.T) {
+	reg := &Registry{
+		ProjectsDir: "/tmp/projects",
+		Projects:    make(map[string]string),
+	}
+
+	_, ok := reg.Get("nope")
+	if ok {
+		t.Error("Get returned true for non-existent project")
+	}
+}
+
+func TestList(t *testing.T) {
+	reg := &Registry{
+		ProjectsDir: "/tmp/projects",
+		Projects: map[string]string{
+			"a": "/tmp/a",
+			"b": "/tmp/b",
+		},
+	}
+
+	list := reg.List()
+	if len(list) != 2 {
+		t.Fatalf("List returned %d entries, want 2", len(list))
+	}
+	if list["a"] != "/tmp/a" {
+		t.Errorf("list[a] = %q, want %q", list["a"], "/tmp/a")
+	}
+	if list["b"] != "/tmp/b" {
+		t.Errorf("list[b] = %q, want %q", list["b"], "/tmp/b")
+	}
+}
+
+func TestSetProjectsDir(t *testing.T) {
+	reg := &Registry{
+		ProjectsDir: "/old",
+		Projects:    make(map[string]string),
+	}
+
+	reg.SetProjectsDir("/new/path")
+	if reg.ProjectsDir != "/new/path" {
+		t.Errorf("ProjectsDir = %q, want %q", reg.ProjectsDir, "/new/path")
+	}
+}
+
+func TestExpandHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home dir")
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"tilde only", "~", home},
+		{"tilde slash", "~/foo/bar", filepath.Join(home, "foo/bar")},
+		{"absolute", "/usr/bin", "/usr/bin"},
+		{"relative", "foo/bar", "foo/bar"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExpandHome(tt.input)
+			if err != nil {
+				t.Fatalf("ExpandHome(%q): %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("ExpandHome(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSaveContractsHomePaths(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home dir")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "projects.json")
+
+	reg := &Registry{
+		ProjectsDir: filepath.Join(home, "projects"),
+		Projects:    map[string]string{"foo": filepath.Join(home, "projects/foo")},
+	}
+
+	if err := reg.SaveTo(path); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	// Read raw JSON to verify ~ is stored
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	raw := string(data)
+	if filepath.Join(home, "projects") != "" {
+		// The file should contain ~/projects, not the expanded path
+		if !contains(raw, "~/projects") {
+			t.Errorf("saved file should contain ~/projects, got:\n%s", raw)
+		}
+	}
+}
+
+func TestRoundTripWithTildePaths(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "projects.json")
+
+	// Write a file with tilde paths
+	if err := os.WriteFile(path, []byte(`{
+		"projects_dir": "~/hack",
+		"projects": {"klaus": "~/hack/klaus"}
+	}`), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	reg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home dir")
+	}
+
+	// Get should expand ~
+	p, ok := reg.Get("klaus")
+	if !ok {
+		t.Fatal("Get returned false")
+	}
+	if p != filepath.Join(home, "hack/klaus") {
+		t.Errorf("Get = %q, want %q", p, filepath.Join(home, "hack/klaus"))
+	}
+
+	// ExpandedProjectsDir should expand ~
+	pd, err := reg.ExpandedProjectsDir()
+	if err != nil {
+		t.Fatalf("ExpandedProjectsDir: %v", err)
+	}
+	if pd != filepath.Join(home, "hack") {
+		t.Errorf("ExpandedProjectsDir = %q, want %q", pd, filepath.Join(home, "hack"))
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Adds `internal/project/registry.go` — persistent project registry stored at `~/.klaus/projects.json` with Load/Save/Add/Remove/Get/List/SetProjectsDir operations and `~` expansion
- Adds `internal/cmd/project.go` — `klaus project add/list/remove/set-dir` subcommands for managing registered projects
- Supports `owner/repo` cloning, bare name GitHub repo lookup via `gh repo list`, and explicit `--path` registration
- Updates README commands table and adds `klaus project` documentation section

## Test plan
- [x] Integration tests for Registry: Load, Save, Add, Remove, Get, List, SetProjectsDir
- [x] Tests for `~` expansion in paths
- [x] Tests that Add rejects duplicate names
- [x] Tests that Remove for non-existent name returns error
- [x] Round-trip test with tilde paths (save contracts, load+get expands)
- [x] `go test ./...` passes
- [x] `go build ./...` passes

Run: 20260307-1517-a424
Fixes #71