### PR TITLE
Skip active runs in cleanup --all unless --force is given

### DIFF
--- a/internal/cmd/cleanup.go
+++ b/internal/cmd/cleanup.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/patflynn/klaus/internal/git"
 	"github.com/patflynn/klaus/internal/run"
@@ -15,9 +16,11 @@ var cleanupCmd = &cobra.Command{
 	Long: `Cleans up a run by killing its tmux pane, removing its worktree,
 deleting local branches, and removing state files.
 
-Use --all to clean up all runs.`,
+Use --all to clean up all runs. Runs with active tmux panes are skipped
+by default; pass --force to remove them anyway.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		all, _ := cmd.Flags().GetBool("all")
+		force, _ := cmd.Flags().GetBool("force")
 
 		root, _ := git.RepoRoot() // may be empty outside a repo
 
@@ -27,7 +30,7 @@ Use --all to clean up all runs.`,
 				return err
 			}
 			if store != nil {
-				return cleanupAll(root, store)
+				return cleanupAll(root, store, force)
 			}
 			// No session env — could scan all, but require explicit session
 			return fmt.Errorf("KLAUS_SESSION_ID not set; specify a run ID or run inside a session")
@@ -42,11 +45,11 @@ Use --all to clean up all runs.`,
 			return err
 		}
 		_ = state // cleanupOne will re-load
-		return cleanupOne(root, store, args[0])
+		return cleanupOne(root, store, args[0], force)
 	},
 }
 
-func cleanupAll(root string, store run.StateStore) error {
+func cleanupAll(root string, store run.StateStore, force bool) error {
 	states, err := store.List()
 	if err != nil {
 		return err
@@ -56,17 +59,35 @@ func cleanupAll(root string, store run.StateStore) error {
 		return nil
 	}
 	for _, s := range states {
-		if err := cleanupOne(root, store, s.ID); err != nil {
+		if err := cleanupOne(root, store, s.ID, force); err != nil {
 			fmt.Printf("  warning: failed to clean up %s: %v\n", s.ID, err)
 		}
 	}
 	return nil
 }
 
-func cleanupOne(root string, store run.StateStore, id string) error {
+// isRunActive reports whether the run has a live tmux pane or is the current session.
+var isRunActive = func(state *run.State) bool {
+	if state.TmuxPane != nil && tmux.PaneExists(*state.TmuxPane) {
+		return true
+	}
+	if state.Type == "session" {
+		if sid := os.Getenv(sessionIDEnv); sid != "" && state.ID == sid {
+			return true
+		}
+	}
+	return false
+}
+
+func cleanupOne(root string, store run.StateStore, id string, force bool) error {
 	state, err := store.Load(id)
 	if err != nil {
 		return fmt.Errorf("no run found with id: %s", id)
+	}
+
+	if !force && isRunActive(state) {
+		fmt.Printf("skipping %s (still running) — use --force to remove\n", id)
+		return nil
 	}
 
 	fmt.Printf("Cleaning up %s...\n", id)
@@ -109,5 +130,6 @@ func cleanupOne(root string, store run.StateStore, id string) error {
 
 func init() {
 	cleanupCmd.Flags().Bool("all", false, "Clean up all runs")
+	cleanupCmd.Flags().Bool("force", false, "Remove runs even if they are still running")
 	rootCmd.AddCommand(cleanupCmd)
 }

--- a/internal/cmd/cleanup_test.go
+++ b/internal/cmd/cleanup_test.go
@@ -1,0 +1,199 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/patflynn/klaus/internal/run"
+)
+
+func TestCleanupAllSkipsActiveRuns(t *testing.T) {
+	store := newFakeStore(
+		&run.State{ID: "run-1", Prompt: "a", Branch: "b1", CreatedAt: "2026-01-01T00:00:00Z"},
+		&run.State{ID: "run-2", Prompt: "b", Branch: "b2", CreatedAt: "2026-01-01T00:01:00Z"},
+		&run.State{ID: "run-3", Prompt: "c", Branch: "b3", CreatedAt: "2026-01-01T00:02:00Z"},
+	)
+
+	// Make run-2 active
+	origIsRunActive := isRunActive
+	defer func() { isRunActive = origIsRunActive }()
+	isRunActive = func(s *run.State) bool { return s.ID == "run-2" }
+
+	output := captureStdout(t, func() {
+		if err := cleanupAll("", store, false); err != nil {
+			t.Fatalf("cleanupAll() error: %v", err)
+		}
+	})
+
+	// run-2 should be skipped
+	if !contains(output, "skipping run-2 (still running)") {
+		t.Errorf("expected skip message for run-2, got: %s", output)
+	}
+
+	// run-1 and run-3 should be cleaned up
+	if _, err := store.Load("run-1"); err == nil {
+		t.Error("run-1 should have been deleted")
+	}
+	if _, err := store.Load("run-2"); err != nil {
+		t.Error("run-2 should still exist (was skipped)")
+	}
+	if _, err := store.Load("run-3"); err == nil {
+		t.Error("run-3 should have been deleted")
+	}
+}
+
+func TestCleanupAllForceRemovesActiveRuns(t *testing.T) {
+	store := newFakeStore(
+		&run.State{ID: "run-1", Prompt: "a", Branch: "b1", CreatedAt: "2026-01-01T00:00:00Z"},
+		&run.State{ID: "run-2", Prompt: "b", Branch: "b2", CreatedAt: "2026-01-01T00:01:00Z"},
+	)
+
+	origIsRunActive := isRunActive
+	defer func() { isRunActive = origIsRunActive }()
+	isRunActive = func(s *run.State) bool { return s.ID == "run-2" }
+
+	output := captureStdout(t, func() {
+		if err := cleanupAll("", store, true); err != nil {
+			t.Fatalf("cleanupAll() error: %v", err)
+		}
+	})
+
+	// No skip messages
+	if contains(output, "skipping") {
+		t.Errorf("expected no skip messages with --force, got: %s", output)
+	}
+
+	// Both should be cleaned up
+	if _, err := store.Load("run-1"); err == nil {
+		t.Error("run-1 should have been deleted")
+	}
+	if _, err := store.Load("run-2"); err == nil {
+		t.Error("run-2 should have been deleted")
+	}
+}
+
+func TestCleanupOneSkipsActiveRun(t *testing.T) {
+	store := newFakeStore(
+		&run.State{ID: "run-1", Prompt: "a", Branch: "b1", CreatedAt: "2026-01-01T00:00:00Z"},
+	)
+
+	origIsRunActive := isRunActive
+	defer func() { isRunActive = origIsRunActive }()
+	isRunActive = func(s *run.State) bool { return true }
+
+	output := captureStdout(t, func() {
+		if err := cleanupOne("", store, "run-1", false); err != nil {
+			t.Fatalf("cleanupOne() error: %v", err)
+		}
+	})
+
+	if !contains(output, "skipping run-1 (still running)") {
+		t.Errorf("expected skip message, got: %s", output)
+	}
+	if _, err := store.Load("run-1"); err != nil {
+		t.Error("run-1 should still exist")
+	}
+}
+
+func TestCleanupOneForceRemovesActiveRun(t *testing.T) {
+	store := newFakeStore(
+		&run.State{ID: "run-1", Prompt: "a", Branch: "b1", CreatedAt: "2026-01-01T00:00:00Z"},
+	)
+
+	origIsRunActive := isRunActive
+	defer func() { isRunActive = origIsRunActive }()
+	isRunActive = func(s *run.State) bool { return true }
+
+	captureStdout(t, func() {
+		if err := cleanupOne("", store, "run-1", true); err != nil {
+			t.Fatalf("cleanupOne() error: %v", err)
+		}
+	})
+
+	if _, err := store.Load("run-1"); err == nil {
+		t.Error("run-1 should have been deleted")
+	}
+}
+
+func TestIsRunActiveWithSessionEnv(t *testing.T) {
+	origIsRunActive := isRunActive
+	defer func() { isRunActive = origIsRunActive }()
+	// Reset to the real implementation for this test
+	isRunActive = origIsRunActive
+
+	t.Setenv(sessionIDEnv, "sess-123")
+
+	// Session run matching current session ID should be active
+	s := &run.State{ID: "sess-123", Type: "session"}
+	if !isRunActive(s) {
+		t.Error("expected session run matching KLAUS_SESSION_ID to be active")
+	}
+
+	// Different session ID should not be active (no tmux pane)
+	s2 := &run.State{ID: "sess-456", Type: "session"}
+	if isRunActive(s2) {
+		t.Error("expected different session ID to not be active")
+	}
+
+	// Non-session run without tmux pane should not be active
+	s3 := &run.State{ID: "sess-123", Type: "launch"}
+	if isRunActive(s3) {
+		t.Error("expected non-session run without tmux pane to not be active")
+	}
+}
+
+// fakeStore is an in-memory StateStore for testing.
+type fakeStore struct {
+	states map[string]*run.State
+}
+
+func newFakeStore(states ...*run.State) *fakeStore {
+	s := &fakeStore{states: make(map[string]*run.State)}
+	for _, st := range states {
+		s.states[st.ID] = st
+	}
+	return s
+}
+
+func (f *fakeStore) Save(s *run.State) error     { f.states[s.ID] = s; return nil }
+func (f *fakeStore) Load(id string) (*run.State, error) {
+	s, ok := f.states[id]
+	if !ok {
+		return nil, fmt.Errorf("not found: %s", id)
+	}
+	return s, nil
+}
+func (f *fakeStore) List() ([]*run.State, error) {
+	var out []*run.State
+	for _, s := range f.states {
+		out = append(out, s)
+	}
+	return out, nil
+}
+func (f *fakeStore) Delete(id string) error { delete(f.states, id); return nil }
+func (f *fakeStore) LogDir() string         { return "" }
+func (f *fakeStore) StateDir() string       { return "" }
+func (f *fakeStore) EnsureDirs() error      { return nil }
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	fn()
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && bytes.Contains([]byte(s), []byte(substr))
+}


### PR DESCRIPTION
## Summary
- `cleanup --all` now skips runs that have active tmux panes or are the current session
- Added `--force` flag to override the protection and remove active runs anyway
- Skipped runs print a message: `skipping <id> (still running) — use --force to remove`
- Same check applies to `cleanup <id>` for a specific run

## Test plan
- [x] `TestCleanupAllSkipsActiveRuns` — verifies active runs are skipped
- [x] `TestCleanupAllForceRemovesActiveRuns` — verifies `--force` removes everything
- [x] `TestCleanupOneSkipsActiveRun` — verifies single-run cleanup warns for active run
- [x] `TestCleanupOneForceRemovesActiveRun` — verifies `--force` on a single active run
- [x] `TestIsRunActiveWithSessionEnv` — verifies session ID env var detection
- [x] Full test suite passes (`go test ./...`)

Run: 20260307-1523-5d09
Fixes #64