### PR TITLE
Auto-launch dashboard pane on session start

### DIFF
--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -139,6 +139,15 @@ from inside the session to target specific repositories.`,
 		fmt.Println("  Use 'klaus launch' from inside to spawn workers.")
 		fmt.Println()
 
+		// Launch dashboard in a bottom pane before starting Claude
+		if currentPane != "" {
+			dashCmd := fmt.Sprintf("KLAUS_SESSION_ID=%s klaus dashboard", id)
+			_, err := tmux.SplitWindowSized(currentPane, worktree, dashCmd, "-v", "30%")
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "warning: could not open dashboard pane: %v\n", err)
+			}
+		}
+
 		// Run claude interactively in the worktree, passing session ID to children
 		claude := exec.Command("claude", "--dangerously-skip-permissions", "--append-system-prompt", sessionPrompt)
 		claude.Dir = worktree

--- a/internal/cmd/session_test.go
+++ b/internal/cmd/session_test.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestDashboardPaneCommand(t *testing.T) {
+	// Verify the dashboard command format matches what session.go constructs
+	sessionID := "session-abc123"
+	got := fmt.Sprintf("KLAUS_SESSION_ID=%s klaus dashboard", sessionID)
+	want := "KLAUS_SESSION_ID=session-abc123 klaus dashboard"
+	if got != want {
+		t.Errorf("dashboard command = %q, want %q", got, want)
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -32,6 +32,26 @@ func SplitWindow(targetPane, dir, command string) (string, error) {
 	return out, nil
 }
 
+// SplitWindowSized creates a new tmux pane with a specified size.
+// orientation is "-v" for top/bottom or "-h" for left/right.
+// size is passed to tmux's -l flag (e.g. "30%" or "15").
+func SplitWindowSized(targetPane, dir, command, orientation, size string) (string, error) {
+	args := []string{
+		"split-window",
+		"-t", targetPane,
+		orientation, "-d",
+		"-l", size,
+		"-P", "-F", "#{pane_id}",
+		"-c", dir,
+		command,
+	}
+	out, err := runTmux(args...)
+	if err != nil {
+		return "", fmt.Errorf("split-window: %w", err)
+	}
+	return out, nil
+}
+
 // SetPaneTitle sets the title of a tmux pane.
 func SetPaneTitle(paneID, title string) error {
 	_, err := runTmux("select-pane", "-t", paneID, "-T", title)

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -85,6 +85,34 @@ func TestBuildArgsRenameWindow(t *testing.T) {
 	}
 }
 
+func TestBuildArgsSplitWindowSized(t *testing.T) {
+	args := BuildArgs("split-window", "-t", "%0", "-v", "-d", "-l", "30%", "-P", "-F", "#{pane_id}", "-c", "/tmp/test", "klaus dashboard")
+	want := []string{"split-window", "-t", "%0", "-v", "-d", "-l", "30%", "-P", "-F", "#{pane_id}", "-c", "/tmp/test", "klaus dashboard"}
+
+	if len(args) != len(want) {
+		t.Fatalf("len(args) = %d, want %d", len(args), len(want))
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Errorf("args[%d] = %q, want %q", i, args[i], want[i])
+		}
+	}
+}
+
+func TestBuildArgsSplitWindowSizedHorizontal(t *testing.T) {
+	args := BuildArgs("split-window", "-t", "%0", "-h", "-d", "-l", "50%", "-P", "-F", "#{pane_id}", "-c", "/tmp/test", "echo hello")
+	want := []string{"split-window", "-t", "%0", "-h", "-d", "-l", "50%", "-P", "-F", "#{pane_id}", "-c", "/tmp/test", "echo hello"}
+
+	if len(args) != len(want) {
+		t.Fatalf("len(args) = %d, want %d", len(args), len(want))
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Errorf("args[%d] = %q, want %q", i, args[i], want[i])
+		}
+	}
+}
+
 func TestInSessionOutsideTmux(t *testing.T) {
 	// When running tests outside tmux, TMUX env var is typically not set
 	// This test documents the behavior — it may pass or fail depending on env


### PR DESCRIPTION
## Summary
- Automatically opens `klaus dashboard` in a bottom tmux pane (30% height) when `klaus session` starts
- Adds `SplitWindowSized` to the tmux package for splits with orientation and size control
- Dashboard failure is non-fatal — prints a warning and continues normally

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Run `klaus session` inside tmux and verify the dashboard pane appears at the bottom
- [ ] Verify the main Claude session pane remains interactive and unaffected
- [ ] Close the dashboard pane and verify the session continues normally

Run: 20260307-1523-f5f3
Fixes #63