### PR TITLE
Wire project registry into launch, target, new, and session prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The coordinator session uses these — you generally don't run them directly:
 | `klaus session` | Start an interactive coordinator session |
 | `klaus launch "<prompt>"` | Spawn an autonomous agent |
 | `klaus launch --repo owner/repo "<prompt>"` | Launch an agent against a different GitHub repo |
+| `klaus launch --repo <project-name> "<prompt>"` | Launch an agent using a registered project |
 | `klaus target owner/repo` | Set session-level default target repo |
 | `klaus watch <pr-number>` | Monitor CI for a PR and fix failures autonomously |
 | `klaus status` | Dashboard of all runs (with CI, conflict, and merge-readiness columns) |
@@ -97,19 +98,21 @@ klaus launch --repo owner/repo "Fix the bug in their API"
 
 ### `klaus target`
 
-Set a session-level default target repo. When the coordinator session is not inside a git repo, this avoids needing `--repo` on every `klaus launch`.
+Set a session-level default target repo. When the coordinator session is not inside a git repo, this avoids needing `--repo` on every `klaus launch`. Accepts a registered project name or `owner/repo`.
 
 ```bash
-klaus target owner/repo              # set default
+klaus target owner/repo              # set default by owner/repo
+klaus target my-project              # set default using registered project name
 klaus target                         # show current target
 klaus target --clear                 # remove default
 ```
 
 The targeting priority for `klaus launch` is:
-1. `--repo` flag (explicit, always wins)
-2. Current git repo (if in one)
-3. Session target (`klaus target` setting)
-4. Error with usage hint
+1. `--repo` flag — if it matches a registered project name (no `owner/` prefix), resolves to that project's local path
+2. `--repo` flag — `owner/repo` or full URL (clones/fetches from GitHub)
+3. Current git repo (if in one)
+4. Session target (`klaus target` setting)
+5. Error with usage hint
 
 ### `klaus status` columns
 
@@ -154,7 +157,7 @@ klaus project set-dir ~/hack              # set the default clone directory
 
 ### `klaus new`
 
-Creates a new GitHub repo and launches a Claude agent to scaffold it. Reads principles from `.klaus/principles.md` (or built-in defaults). The agent makes all scaffolding decisions based on those principles — no templates.
+Creates a new GitHub repo and launches a Claude agent to scaffold it. Reads principles from `.klaus/principles.md` (or built-in defaults). The agent makes all scaffolding decisions based on those principles — no templates. The new project is automatically registered in the project registry.
 
 ```bash
 klaus new my-project

--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -10,6 +10,7 @@ import (
 	"github.com/patflynn/klaus/internal/config"
 	"github.com/patflynn/klaus/internal/git"
 	"github.com/patflynn/klaus/internal/nix"
+	"github.com/patflynn/klaus/internal/project"
 	"github.com/patflynn/klaus/internal/run"
 	"github.com/patflynn/klaus/internal/tmux"
 	"github.com/spf13/cobra"
@@ -21,9 +22,9 @@ var launchCmd = &cobra.Command{
 	Long: `Creates a git worktree, launches Claude Code in autonomous mode in a new
 tmux pane, and tracks the run state. Must be run inside a tmux session.
 
-Use --repo to launch an agent against a different GitHub repository. The repo
-will be cloned (or fetched if already cached) and the agent gets its own
-worktree in that clone.`,
+Use --repo to launch an agent against a different repository. If the name
+matches a registered project (no owner/ prefix), the project's local path is
+used directly. Otherwise, the repo is cloned from GitHub.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		prompt := args[0]
@@ -38,6 +39,17 @@ worktree in that clone.`,
 		// Host repo — optional when --repo is specified or session target is set
 		hostRoot, _ := git.RepoRoot()
 
+		// Resolve --repo: if it matches a registered project name (no owner/ prefix),
+		// use that project's local path directly instead of cloning.
+		var projectLocalPath string
+		if repoRef != "" && !strings.Contains(repoRef, "/") {
+			if reg, loadErr := project.Load(); loadErr == nil {
+				if localPath, ok := reg.Get(repoRef); ok {
+					projectLocalPath = localPath
+				}
+			}
+		}
+
 		// If no --repo and not in a git repo, check session target
 		if hostRoot == "" && repoRef == "" {
 			if s, storeErr := sessionStore(); storeErr == nil {
@@ -49,8 +61,8 @@ worktree in that clone.`,
 			}
 		}
 
-		if hostRoot == "" && repoRef == "" {
-			return fmt.Errorf("no target repo — use --repo owner/repo or 'klaus target owner/repo' to set a default")
+		if hostRoot == "" && repoRef == "" && projectLocalPath == "" {
+			return fmt.Errorf("no target repo — use --repo owner/repo, 'klaus target owner/repo', or 'klaus project add' to register a project")
 		}
 
 		hostCfg, err := config.Load(hostRoot)
@@ -77,6 +89,7 @@ worktree in that clone.`,
 
 		// Determine the target repo for git operations.
 		// When --repo is set, we clone the target and use it for worktree/branch ops.
+		// When --repo matches a registered project, use the local path directly.
 		// State is always tracked in the host repo.
 		var (
 			repoRoot      string  // repo dir for git ops (clone or host)
@@ -86,7 +99,23 @@ worktree in that clone.`,
 			cloneDirPtr   *string
 		)
 
-		if repoRef != "" {
+		if projectLocalPath != "" {
+			// Registered project — use local path directly, no cloning
+			repoRoot = projectLocalPath
+			repoName = filepath.Base(projectLocalPath)
+
+			defaultBranch = "main"
+			targetCfg, loadErr := config.Load(projectLocalPath)
+			if loadErr != nil {
+				fmt.Fprintf(os.Stderr, "warning: could not load config from project %s: %v\n", repoRef, loadErr)
+			} else if targetCfg.DefaultBranch != "" {
+				defaultBranch = targetCfg.DefaultBranch
+			}
+
+			// Store as target for state tracking
+			targetRepo = &repoRef
+			cloneDirPtr = &projectLocalPath
+		} else if repoRef != "" {
 			owner, repo, cloneURL, err := git.ParseRepoRef(repoRef)
 			if err != nil {
 				return fmt.Errorf("parsing repo reference: %w", err)
@@ -300,7 +329,7 @@ func stringPtr(s string) *string {
 func init() {
 	launchCmd.Flags().String("issue", "", "GitHub issue number to reference")
 	launchCmd.Flags().String("budget", "", "Max spend in USD (default from config)")
-	launchCmd.Flags().String("repo", "", "Target GitHub repo (e.g., owner/repo or full URL)")
+	launchCmd.Flags().String("repo", "", "Target repo: registered project name, owner/repo, or full URL")
 	launchCmd.Flags().Bool("no-watch", false, "Don't auto-launch a watch agent when a PR is created")
 	rootCmd.AddCommand(launchCmd)
 }

--- a/internal/cmd/launch_test.go
+++ b/internal/cmd/launch_test.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/patflynn/klaus/internal/project"
 )
 
 func TestFormatPaneTitle(t *testing.T) {
@@ -100,6 +103,74 @@ func TestFormatPaneTitle(t *testing.T) {
 					tt.id, tt.issue, tt.prompt, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestLaunchResolvesProjectName(t *testing.T) {
+	// Test that a bare name (no /) is resolved from the project registry.
+	// We test the resolution logic directly since the full launch flow needs tmux.
+	tmpDir := t.TempDir()
+	regPath := filepath.Join(tmpDir, "projects.json")
+
+	reg := &project.Registry{
+		Projects: map[string]string{
+			"my-project": "/home/user/src/my-project",
+		},
+	}
+	if err := reg.SaveTo(regPath); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	loaded, err := project.LoadFrom(regPath)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+
+	// Simulate the launch resolution: if repoRef has no "/" and matches a project, use it
+	repoRef := "my-project"
+	var projectLocalPath string
+	if !strings.Contains(repoRef, "/") {
+		if localPath, ok := loaded.Get(repoRef); ok {
+			projectLocalPath = localPath
+		}
+	}
+
+	if projectLocalPath != "/home/user/src/my-project" {
+		t.Errorf("expected project path /home/user/src/my-project, got %q", projectLocalPath)
+	}
+
+	// An owner/repo format should NOT be resolved as a project name
+	repoRef = "owner/repo"
+	projectLocalPath = ""
+	if !strings.Contains(repoRef, "/") {
+		if localPath, ok := loaded.Get(repoRef); ok {
+			projectLocalPath = localPath
+		}
+	}
+
+	if projectLocalPath != "" {
+		t.Errorf("owner/repo should not resolve as project name, got %q", projectLocalPath)
+	}
+
+	// An unregistered project name should not resolve
+	repoRef = "unknown-project"
+	projectLocalPath = ""
+	if !strings.Contains(repoRef, "/") {
+		if localPath, ok := loaded.Get(repoRef); ok {
+			projectLocalPath = localPath
+		}
+	}
+
+	if projectLocalPath != "" {
+		t.Errorf("unregistered project should not resolve, got %q", projectLocalPath)
+	}
+}
+
+func TestLaunchErrorMessageMentionsProjectAdd(t *testing.T) {
+	// Verify the error message hints at 'klaus project add'
+	errMsg := "no target repo — use --repo owner/repo, 'klaus target owner/repo', or 'klaus project add' to register a project"
+	if !strings.Contains(errMsg, "klaus project add") {
+		t.Error("error message should mention 'klaus project add'")
 	}
 }
 

--- a/internal/cmd/new.go
+++ b/internal/cmd/new.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/patflynn/klaus/internal/config"
+	"github.com/patflynn/klaus/internal/project"
 	"github.com/patflynn/klaus/internal/run"
 	"github.com/patflynn/klaus/internal/tmux"
 	"github.com/spf13/cobra"
@@ -95,6 +96,22 @@ func runNew(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("loading principles: %w", err)
 	}
 
+	// Load project registry to determine clone directory
+	reg, regErr := project.Load()
+
+	// If projects_dir is set, clone there instead of cwd
+	cloneDir := cwd
+	if regErr == nil {
+		if projDir, expandErr := reg.ExpandedProjectsDir(); expandErr == nil && projDir != "" {
+			// Only use projects_dir if it's explicitly configured (not the default ~/src)
+			if reg.ProjectsDir != "" {
+				if mkErr := os.MkdirAll(projDir, 0o755); mkErr == nil {
+					cloneDir = projDir
+				}
+			}
+		}
+	}
+
 	// Create GitHub repo and clone it
 	fmt.Printf("Creating repository %s...\n", name)
 	ghOutput, err := runGHRepoCreate(name)
@@ -103,9 +120,20 @@ func runNew(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Println(ghOutput)
 
-	repoDir, err := resolveNewRepoDir(cwd, name)
+	repoDir, err := resolveNewRepoDir(cloneDir, name)
 	if err != nil {
 		return err
+	}
+
+	// Auto-register the new project
+	if regErr == nil {
+		if addErr := reg.Add(name, repoDir); addErr == nil {
+			if saveErr := reg.Save(); saveErr != nil {
+				fmt.Fprintf(os.Stderr, "warning: could not save project registry: %v\n", saveErr)
+			} else {
+				fmt.Printf("Registered project %s → %s\n", name, repoDir)
+			}
+		}
 	}
 
 	// Generate the scaffolding prompt

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -10,6 +10,7 @@ import (
 	"github.com/patflynn/klaus/internal/config"
 	"github.com/patflynn/klaus/internal/git"
 	"github.com/patflynn/klaus/internal/nix"
+	"github.com/patflynn/klaus/internal/project"
 	"github.com/patflynn/klaus/internal/run"
 	"github.com/patflynn/klaus/internal/tmux"
 	"github.com/spf13/cobra"
@@ -111,11 +112,18 @@ from inside the session to target specific repositories.`,
 			return fmt.Errorf("saving state: %w", err)
 		}
 
+		// Load project list for session prompt
+		var projectList string
+		if reg, loadErr := project.Load(); loadErr == nil {
+			projectList = config.FormatProjectList(reg.List())
+		}
+
 		// Render session system prompt
 		sessionPrompt, err := config.RenderSessionPrompt(root, config.PromptVars{
 			RunID:    id,
 			Branch:   branch,
 			RepoName: repoName,
+			Projects: projectList,
 		})
 		if err != nil {
 			return fmt.Errorf("rendering session prompt: %w", err)

--- a/internal/cmd/target.go
+++ b/internal/cmd/target.go
@@ -2,19 +2,22 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/patflynn/klaus/internal/git"
+	"github.com/patflynn/klaus/internal/project"
 	"github.com/patflynn/klaus/internal/run"
 	"github.com/spf13/cobra"
 )
 
 var targetCmd = &cobra.Command{
-	Use:   "target [owner/repo]",
+	Use:   "target [name | owner/repo]",
 	Short: "Set or show the session-level default target repo",
 	Long: `Sets a session-level default repo so that 'klaus launch' without --repo
 uses this target. Useful when the coordinator session is not inside a git repo.
 
   klaus target owner/repo   Set the default target repo
+  klaus target my-project   Set target using a registered project name
   klaus target              Show the current target repo
   klaus target --clear      Remove the default target repo`,
 	Args: cobra.MaximumNArgs(1),
@@ -54,8 +57,32 @@ uses this target. Useful when the coordinator session is not inside a git repo.
 			return nil
 		}
 
-		// Validate the repo reference
 		repoRef := args[0]
+
+		// If no "/" in the reference, try resolving as a registered project name
+		if !strings.Contains(repoRef, "/") {
+			reg, loadErr := project.Load()
+			if loadErr == nil {
+				if localPath, ok := reg.Get(repoRef); ok {
+					// Resolve owner/repo from the git remote
+					remote := gitRemoteURL(localPath)
+					if remote != "" {
+						owner, repo, _, parseErr := git.ParseRepoRef(remote)
+						if parseErr == nil {
+							normalized := owner + "/" + repo
+							if err := run.SaveTarget(baseDir, normalized); err != nil {
+								return err
+							}
+							fmt.Fprintf(cmd.OutOrStdout(), "Target set to %s (from project %s)\n", normalized, repoRef)
+							return nil
+						}
+					}
+					return fmt.Errorf("project %q is registered at %s but has no parseable git remote", repoRef, localPath)
+				}
+			}
+		}
+
+		// Validate the repo reference as owner/repo
 		owner, repo, _, err := git.ParseRepoRef(repoRef)
 		if err != nil {
 			return fmt.Errorf("invalid repo reference: %w", err)

--- a/internal/cmd/target_test.go
+++ b/internal/cmd/target_test.go
@@ -2,9 +2,12 @@ package cmd
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/patflynn/klaus/internal/project"
 	"github.com/patflynn/klaus/internal/run"
 )
 
@@ -123,5 +126,58 @@ func TestTargetCommandIntegration(t *testing.T) {
 	// File should be removed
 	if _, err := os.Stat(targetPath); !os.IsNotExist(err) {
 		t.Errorf("target.json should be removed after clear")
+	}
+}
+
+func TestTargetResolvesProjectName(t *testing.T) {
+	// Create a temporary git repo to simulate a registered project with a remote
+	tmpDir := t.TempDir()
+	repoDir := filepath.Join(tmpDir, "my-project")
+
+	// Init a git repo with a remote
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmds := [][]string{
+		{"git", "init", repoDir},
+		{"git", "-C", repoDir, "remote", "add", "origin", "https://github.com/testowner/my-project.git"},
+	}
+	for _, args := range cmds {
+		cmd := exec.Command(args[0], args[1:]...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("running %v: %v\n%s", args, err, out)
+		}
+	}
+
+	// Create a registry with this project
+	regPath := filepath.Join(tmpDir, "projects.json")
+	reg := &project.Registry{
+		Projects: map[string]string{
+			"my-project": repoDir,
+		},
+	}
+	if err := reg.SaveTo(regPath); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	// Simulate the target resolution logic
+	repoRef := "my-project"
+	loaded, err := project.LoadFrom(regPath)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+
+	if !strings.Contains(repoRef, "/") {
+		if localPath, ok := loaded.Get(repoRef); ok {
+			remote := gitRemoteURL(localPath)
+			if remote == "" {
+				t.Fatal("expected remote URL from project repo")
+			}
+			if !strings.Contains(remote, "testowner/my-project") {
+				t.Errorf("expected remote to contain testowner/my-project, got %q", remote)
+			}
+		} else {
+			t.Error("project my-project should be found in registry")
+		}
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,6 +70,7 @@ type PromptVars struct {
 	Branch   string
 	RepoName string
 	PR       string
+	Projects string // Formatted list of registered projects for session prompt
 }
 
 // RenderPrompt renders the system prompt template from .klaus/prompt.md.
@@ -193,10 +194,14 @@ klaus launch --repo owner/repo "<prompt>"  # override per launch
 - Check on running agents: ` + "`klaus status`" + `
 - View agent output: ` + "`klaus logs <run-id>`" + `
 - Clean up finished runs: ` + "`klaus cleanup <run-id>`" + `
-- Set default target repo: ` + "`klaus target owner/repo`" + `
+- Set default target repo: ` + "`klaus target owner/repo`" + ` or ` + "`klaus target <project-name>`" + `
 - Show current target: ` + "`klaus target`" + `
+{{if .Projects}}
+## Registered projects
 
-## Testing
+These projects are available by name with ` + "`klaus launch --repo <name>`" + ` or ` + "`klaus target <name>`" + `:
+{{.Projects}}
+{{end}}## Testing
 - Ensure launched agents prefer integration and e2e tests over mocked unit tests.
 - Tests should exercise real behavior — a few tests that run the real binary are worth more than many with injected fakes.
 - Only unit test genuinely tricky logic.
@@ -208,6 +213,45 @@ klaus launch --repo owner/repo "<prompt>"  # override per launch
 // It reads from .klaus/session-prompt.md, falling back to the built-in default.
 func RenderSessionPrompt(repoRoot string, vars PromptVars) (string, error) {
 	return renderPromptFromFile(repoRoot, "session-prompt.md", defaultSessionPromptTemplate, vars)
+}
+
+// FormatProjectList formats a map of project name → local path as a bulleted list
+// for use in the session prompt. Returns empty string if no projects are registered.
+func FormatProjectList(projects map[string]string) string {
+	if len(projects) == 0 {
+		return ""
+	}
+	var lines []string
+	for name, localPath := range projects {
+		lines = append(lines, fmt.Sprintf("- %s (%s)", name, contractHomeForDisplay(localPath)))
+	}
+	// Sort for deterministic output
+	sortStrings(lines)
+	return strings.Join(lines, "\n")
+}
+
+// contractHomeForDisplay replaces the home directory prefix with ~ for display.
+func contractHomeForDisplay(path string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	if path == home {
+		return "~"
+	}
+	if strings.HasPrefix(path, home+string(filepath.Separator)) {
+		return "~" + path[len(home):]
+	}
+	return path
+}
+
+// sortStrings sorts a slice of strings in place.
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j] < s[j-1]; j-- {
+			s[j], s[j-1] = s[j-1], s[j]
+		}
+	}
 }
 
 const defaultWatchPromptTemplate = `You are an autonomous CI monitoring agent for PR #{{.PR}} in this repository.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -442,6 +442,93 @@ func TestRenderSessionPromptWithRepo(t *testing.T) {
 	}
 }
 
+func TestRenderSessionPromptWithProjects(t *testing.T) {
+	dir := t.TempDir()
+
+	vars := PromptVars{
+		RunID:    "session-test",
+		Branch:   "session/session-test",
+		RepoName: "test-repo",
+		Projects: "- klaus (/home/user/src/klaus)\n- other-project (/home/user/src/other-project)",
+	}
+
+	prompt, err := RenderSessionPrompt(dir, vars)
+	if err != nil {
+		t.Fatalf("RenderSessionPrompt() error: %v", err)
+	}
+
+	if !strings.Contains(prompt, "## Registered projects") {
+		t.Error("prompt should contain registered projects section when projects are present")
+	}
+	if !strings.Contains(prompt, "klaus (/home/user/src/klaus)") {
+		t.Error("prompt should contain project listing")
+	}
+	if !strings.Contains(prompt, "klaus launch --repo <name>") {
+		t.Error("prompt should mention 'klaus launch --repo <name>'")
+	}
+}
+
+func TestRenderSessionPromptWithoutProjects(t *testing.T) {
+	dir := t.TempDir()
+
+	vars := PromptVars{
+		RunID:    "session-test",
+		Branch:   "session/session-test",
+		RepoName: "test-repo",
+	}
+
+	prompt, err := RenderSessionPrompt(dir, vars)
+	if err != nil {
+		t.Fatalf("RenderSessionPrompt() error: %v", err)
+	}
+
+	if strings.Contains(prompt, "## Registered projects") {
+		t.Error("prompt should not contain registered projects section when no projects")
+	}
+}
+
+func TestFormatProjectList(t *testing.T) {
+	t.Run("empty projects", func(t *testing.T) {
+		result := FormatProjectList(map[string]string{})
+		if result != "" {
+			t.Errorf("expected empty string for empty projects, got %q", result)
+		}
+	})
+
+	t.Run("nil projects", func(t *testing.T) {
+		result := FormatProjectList(nil)
+		if result != "" {
+			t.Errorf("expected empty string for nil projects, got %q", result)
+		}
+	})
+
+	t.Run("single project", func(t *testing.T) {
+		result := FormatProjectList(map[string]string{
+			"my-proj": "/tmp/my-proj",
+		})
+		if !strings.Contains(result, "- my-proj (/tmp/my-proj)") {
+			t.Errorf("unexpected format: %q", result)
+		}
+	})
+
+	t.Run("multiple projects sorted", func(t *testing.T) {
+		result := FormatProjectList(map[string]string{
+			"zebra": "/tmp/zebra",
+			"alpha": "/tmp/alpha",
+		})
+		lines := strings.Split(result, "\n")
+		if len(lines) != 2 {
+			t.Fatalf("expected 2 lines, got %d: %q", len(lines), result)
+		}
+		if !strings.HasPrefix(lines[0], "- alpha") {
+			t.Errorf("expected first line to be alpha, got %q", lines[0])
+		}
+		if !strings.HasPrefix(lines[1], "- zebra") {
+			t.Errorf("expected second line to be zebra, got %q", lines[1])
+		}
+	})
+}
+
 func TestRenderPromptEmptyRepoRoot(t *testing.T) {
 	// With empty repoRoot, should use default template
 	vars := PromptVars{RunID: "test-123"}


### PR DESCRIPTION
## Summary

- **launch**: `--repo` now accepts registered project names (no `owner/` prefix), resolving to the project's local path instead of cloning from GitHub. Error message updated to mention `klaus project add`.
- **target**: accepts registered project names, resolving `owner/repo` from the project's git remote for storage in `target.json`.
- **new**: auto-registers created projects in the registry; respects `projects_dir` when set.
- **session prompt**: loads registered projects and includes them via `{{.Projects}}` template variable, showing available projects in the coordinator prompt.

## Test plan

- [x] Test that launch resolves project names from the registry (new unit test)
- [x] Test that `owner/repo` format still passes through to clone flow
- [x] Test that target resolves project names via git remote (new integration test)
- [x] Test session prompt includes registered projects section
- [x] Test session prompt omits section when no projects registered
- [x] Test `FormatProjectList` formatting and sorting
- [x] `go test ./...` passes
- [x] `go build ./...` passes

Run: 20260307-1522-12b5
Fixes #71