### PR TITLE
Derive flake.nix version from git and inject via ldflags

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,11 +12,14 @@
         pkgs = nixpkgs.legacyPackages.${system};
       in
       {
-        packages.default = pkgs.buildGoModule {
+        packages.default = let
+          version = if (self ? rev) then "0.3.0-${builtins.substring 0 7 self.rev}" else "0.3.0-dirty";
+        in pkgs.buildGoModule {
           pname = "klaus";
-          version = "0.2.0";
+          inherit version;
           src = ./.;
           vendorHash = "sha256-QEmX66Gurv5iozyzrdA5Re6ZKPl+TXpZF3BFngMNfJY=";
+          ldflags = [ "-X" "github.com/patflynn/klaus/internal/cmd.version=${version}" ];
           nativeBuildInputs = [ pkgs.git ];
         };
 

--- a/scripts/update-vendor-hash.sh
+++ b/scripts/update-vendor-hash.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Computes the correct vendorHash for flake.nix.
+#
+# Usage: ./scripts/update-vendor-hash.sh
+#
+# This triggers a nix build with a fake hash, captures the expected hash
+# from the error output, and prints it. You can then update flake.nix
+# with the printed value.
+set -euo pipefail
+
+echo "Computing vendor hash (this will intentionally fail once)..."
+
+# Temporarily set a fake hash to force nix to report the real one
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+cp flake.nix "$tmpdir/flake.nix.bak"
+
+sed -i 's|vendorHash = "sha256-[^"]*"|vendorHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="|' flake.nix
+
+hash=$(nix build .#default 2>&1 | grep 'got:' | awk '{print $2}' || true)
+
+# Restore original flake.nix
+cp "$tmpdir/flake.nix.bak" flake.nix
+
+if [ -z "$hash" ]; then
+  echo "ERROR: Could not extract hash. The current vendorHash may already be correct."
+  echo "Try running: nix build .#default"
+  exit 1
+fi
+
+echo ""
+echo "Correct vendorHash:"
+echo "  vendorHash = \"$hash\";"


### PR DESCRIPTION
## Summary
- Replace hardcoded version `"0.2.0"` in flake.nix with a git-derived version string (`0.3.0-<short-rev>` for clean checkouts, `0.3.0-dirty` for local/dirty builds)
- Add `ldflags` to inject the version into the Go binary at build time via `-X github.com/patflynn/klaus/internal/cmd.version`
- Add `scripts/update-vendor-hash.sh` helper to recompute `vendorHash` when go.sum changes

## Test plan
- [x] `nix build .#default` succeeds
- [x] `./result/bin/klaus --version` shows `0.3.0-dirty` (dirty worktree) — clean checkouts will show `0.3.0-<commit>`
- [x] `go test ./...` passes
- [x] `go build ./...` passes

Run: 20260307-1542-04aa
Fixes #62