### PR TITLE
Add release GitHub Action for tagged builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Extract version
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Cross-compile binaries
+        run: |
+          VERSION=${{ steps.version.outputs.VERSION }}
+          LDFLAGS="-X github.com/patflynn/klaus/internal/cmd.version=${VERSION}"
+
+          targets=(
+            "linux/amd64"
+            "linux/arm64"
+            "darwin/amd64"
+            "darwin/arm64"
+          )
+
+          for target in "${targets[@]}"; do
+            os="${target%/*}"
+            arch="${target#*/}"
+            output="klaus-${os}-${arch}"
+            echo "Building ${output}..."
+            GOOS="${os}" GOARCH="${arch}" go build -ldflags "${LDFLAGS}" -o "${output}" .
+          done
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --generate-notes \
+            klaus-linux-amd64 \
+            klaus-linux-arm64 \
+            klaus-darwin-amd64 \
+            klaus-darwin-arm64


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` triggered on `v*` tag pushes
- Runs `go test ./...` before building to validate the tagged commit
- Cross-compiles binaries for linux/amd64, linux/arm64, darwin/amd64, darwin/arm64 with version injected via ldflags
- Creates a GitHub Release with auto-generated notes and all binaries attached

## Test plan
- [ ] Push a `v*` tag (e.g. `v0.4.0`) and verify the workflow runs
- [ ] Confirm the release is created with all four binaries
- [ ] Download a binary and verify `klaus --version` shows the correct version

Run: 20260307-1548-c25f
Fixes #62