### PR TITLE
Add vendorHash auto-update CI

### DIFF
--- a/.github/workflows/update-vendor-hash.yml
+++ b/.github/workflows/update-vendor-hash.yml
@@ -1,0 +1,74 @@
+name: Update vendorHash
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'go.sum'
+      - 'go.mod'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-vendor-hash:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Check if vendorHash is still correct
+        id: check
+        run: |
+          if nix build .#default 2>&1; then
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compute correct vendorHash
+        if: steps.check.outputs.stale == 'true'
+        id: compute
+        run: |
+          sed -i 's|vendorHash = "sha256-[^"]*"|vendorHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="|' flake.nix
+          hash=$(nix build .#default 2>&1 | grep 'got:' | awk '{print $2}' || true)
+          if [ -z "$hash" ]; then
+            echo "ERROR: Could not extract hash from nix build output"
+            exit 1
+          fi
+          echo "hash=$hash" >> "$GITHUB_OUTPUT"
+
+      - name: Update flake.nix with correct hash
+        if: steps.check.outputs.stale == 'true'
+        run: |
+          sed -i 's|vendorHash = "sha256-[^"]*"|vendorHash = "${{ steps.compute.outputs.hash }}"|' flake.nix
+
+      - name: Verify build with new hash
+        if: steps.check.outputs.stale == 'true'
+        run: nix build .#default
+
+      - name: Create PR
+        if: steps.check.outputs.stale == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          branch="auto/update-vendor-hash"
+          git checkout -B "$branch"
+          git add flake.nix
+          git commit -m "Update flake.nix vendorHash"
+          git push -f origin "$branch"
+
+          if gh pr list --head "$branch" --state open --json number --jq '.[0].number' | grep -q .; then
+            echo "PR already exists, force-pushed update"
+          else
+            gh pr create \
+              --title "Update flake.nix vendorHash" \
+              --body "Automated update: go.sum changed and the vendorHash in flake.nix was stale." \
+              --base main \
+              --head "$branch"
+          fi


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that triggers on pushes to `main` when `go.sum` or `go.mod` change
- Checks if the `vendorHash` in `flake.nix` is stale by attempting `nix build`
- If stale, computes the correct hash and opens a PR on the `auto/update-vendor-hash` branch
- If a PR already exists on that branch, force-pushes to update it

## How it works
1. `nix build .#default` — if it succeeds, the hash is correct and the workflow exits early
2. If it fails, sets a fake hash (`sha256-AAA...`) and re-runs `nix build` to extract the correct hash from the error
3. Updates `flake.nix` with the correct hash via `sed`
4. Verifies the build succeeds with the new hash
5. Commits and opens/updates a PR

## Test plan
- [ ] Verify workflow syntax is valid (push triggers CI lint)
- [ ] Manually change `go.sum` on main to trigger the workflow
- [ ] Confirm PR is created with the correct vendorHash update

Run: 20260307-1548-b02e
Fixes #62