### PR TITLE
Add merge and dashboard commands to coordinator prompt

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -198,6 +198,8 @@ klaus launch --repo owner/repo "<prompt>"  # override per launch
 - Clean up finished runs: ` + "`klaus cleanup <run-id>`" + `
 - Set default target repo: ` + "`klaus target owner/repo`" + ` or ` + "`klaus target <project-name>`" + `
 - Show current target: ` + "`klaus target`" + `
+- Merge PRs sequentially: ` + "`klaus merge <pr-number> [<pr-number>...]`" + `
+- Open live dashboard: ` + "`klaus dashboard`" + `
 {{if .Projects}}
 ## Registered projects
 


### PR DESCRIPTION
## Summary
- Adds `klaus merge <pr-number> [<pr-number>...]` and `klaus dashboard` to the "Managing agents" section of the coordinator session prompt so the orchestrator knows about all available tools.

## Test plan
- [x] `go test ./...` passes
- [x] Verified the new bullet points render correctly in the prompt template

Run: 20260307-1714-8301