### PR TITLE
Fix dashboard staleness after merging PRs

### DIFF
--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -278,7 +278,9 @@ func (m dashboardModel) renderPRLine(prNum string, s *run.State, ps *prStatus) s
 	prompt := truncate(s.Prompt, 20)
 
 	state := "OPEN"
-	if ps != nil && ps.State != "" {
+	if s.MergedAt != nil {
+		state = "MERGED"
+	} else if ps != nil && ps.State != "" {
 		state = ps.State
 	}
 

--- a/internal/cmd/merge.go
+++ b/internal/cmd/merge.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/patflynn/klaus/internal/git"
+	"github.com/patflynn/klaus/internal/run"
 	"github.com/spf13/cobra"
 )
 
@@ -25,9 +26,10 @@ type mergeRunner struct {
 	rebaseAndPush       func(string) error
 	mergePR             func(string, string, bool) error
 	pollCI              func(string) error
+	markMerged          func(prNumber string)
 }
 
-func newMergeRunner(out io.Writer) *mergeRunner {
+func newMergeRunner(out io.Writer, store run.StateStore) *mergeRunner {
 	return &mergeRunner{
 		out:                 out,
 		getPRTitle:          getPRTitle,
@@ -37,6 +39,29 @@ func newMergeRunner(out io.Writer) *mergeRunner {
 		rebaseAndPush:       rebaseAndPush,
 		mergePR:             mergePRExec,
 		pollCI:              defaultPollCI,
+		markMerged:          markRunsMerged(store),
+	}
+}
+
+// markRunsMerged returns a function that finds run states matching a PR number
+// and updates their MergedAt field. This triggers the dashboard's fsnotify
+// watcher so it can reflect the merge immediately.
+func markRunsMerged(store run.StateStore) func(string) {
+	return func(prNumber string) {
+		if store == nil {
+			return
+		}
+		states, err := store.List()
+		if err != nil {
+			return
+		}
+		now := time.Now().UTC().Format(time.RFC3339)
+		for _, s := range states {
+			if extractPRNumber(s) == prNumber {
+				s.MergedAt = &now
+				store.Save(s)
+			}
+		}
 	}
 }
 
@@ -61,7 +86,12 @@ If a rebase fails or CI times out, stops and reports the stuck PR.`,
 			return err
 		}
 
-		runner := newMergeRunner(os.Stdout)
+		// Best-effort: get the session store so we can update run states
+		// after merge. If not in a session, store will be nil and
+		// markMerged will be a no-op.
+		store, _ := sessionStore()
+
+		runner := newMergeRunner(os.Stdout, store)
 
 		if dryRun {
 			return runner.dryRun(args)
@@ -282,6 +312,9 @@ func (r *mergeRunner) run(prNumbers []string, mergeMethod string, deleteBranch b
 			return r.stopQueue(prNum, fmt.Sprintf("merge failed: %v", err), prNumbers[i+1:])
 		}
 		fmt.Fprintf(r.out, "  Merged PR #%s.\n", prNum)
+		if r.markMerged != nil {
+			r.markMerged(prNum)
+		}
 	}
 
 	fmt.Fprintf(r.out, "\nAll %d PRs merged successfully.\n", len(prNumbers))

--- a/internal/cmd/merge_test.go
+++ b/internal/cmd/merge_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/patflynn/klaus/internal/run"
 )
 
 func TestValidateMergeMethod(t *testing.T) {
@@ -457,4 +459,117 @@ func TestRunMergeFailure(t *testing.T) {
 	if !strings.Contains(err.Error(), "merge failed") {
 		t.Errorf("error should mention merge failed: %v", err)
 	}
+}
+
+func TestRunUpdatesStateAfterMerge(t *testing.T) {
+	// Use a real HomeDirStore backed by a temp directory to verify
+	// state files are written to disk after merge.
+	tmpDir := t.TempDir()
+	store := run.NewHomeDirStoreFromPath(tmpDir)
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+
+	// Create run states: two with PRs that will be merged, one unrelated.
+	prURL42 := "https://github.com/owner/repo/pull/42"
+	prURL99 := "https://github.com/owner/repo/pull/99"
+	prURL7 := "https://github.com/owner/repo/pull/7"
+
+	states := []*run.State{
+		{ID: "20260101-0000-aaaa", Prompt: "fix bug", Branch: "b1", PRURL: &prURL42, CreatedAt: "2026-01-01T00:00:00Z"},
+		{ID: "20260101-0000-bbbb", Prompt: "add feature", Branch: "b2", PRURL: &prURL99, CreatedAt: "2026-01-01T00:01:00Z"},
+		{ID: "20260101-0000-cccc", Prompt: "other work", Branch: "b3", PRURL: &prURL7, CreatedAt: "2026-01-01T00:02:00Z"},
+	}
+	for _, s := range states {
+		if err := store.Save(s); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+	}
+
+	var buf bytes.Buffer
+	runner := &mergeRunner{
+		out:                 &buf,
+		getPRTitle:          func(string) string { return "Test PR" },
+		getPRCI:             func(string) string { return "passing" },
+		getPRConflicts:      func(string) string { return "none" },
+		getPRReviewDecision: func(string) string { return "APPROVED" },
+		rebaseAndPush:       func(string) error { return nil },
+		pollCI:              func(string) error { return nil },
+		mergePR:             func(string, string, bool) error { return nil },
+		markMerged:          markRunsMerged(store),
+	}
+
+	err := runner.run([]string{"42", "99"}, "squash", true)
+	if err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+
+	// Reload states from disk and verify MergedAt was set for PRs 42 and 99.
+	s42, err := store.Load("20260101-0000-aaaa")
+	if err != nil {
+		t.Fatalf("Load aaaa: %v", err)
+	}
+	if s42.MergedAt == nil {
+		t.Error("PR #42 state should have MergedAt set after merge")
+	}
+
+	s99, err := store.Load("20260101-0000-bbbb")
+	if err != nil {
+		t.Fatalf("Load bbbb: %v", err)
+	}
+	if s99.MergedAt == nil {
+		t.Error("PR #99 state should have MergedAt set after merge")
+	}
+
+	// PR #7 was not merged — MergedAt should remain nil.
+	s7, err := store.Load("20260101-0000-cccc")
+	if err != nil {
+		t.Fatalf("Load cccc: %v", err)
+	}
+	if s7.MergedAt != nil {
+		t.Errorf("PR #7 state should NOT have MergedAt set, got %q", *s7.MergedAt)
+	}
+}
+
+func TestRunDoesNotUpdateStateOnMergeFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := run.NewHomeDirStoreFromPath(tmpDir)
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+
+	prURL42 := "https://github.com/owner/repo/pull/42"
+	s := &run.State{ID: "20260101-0000-dddd", Prompt: "fix", Branch: "b1", PRURL: &prURL42, CreatedAt: "2026-01-01T00:00:00Z"}
+	if err := store.Save(s); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	var buf bytes.Buffer
+	runner := &mergeRunner{
+		out:                 &buf,
+		getPRTitle:          func(string) string { return "Test PR" },
+		getPRCI:             func(string) string { return "passing" },
+		getPRConflicts:      func(string) string { return "none" },
+		getPRReviewDecision: func(string) string { return "APPROVED" },
+		rebaseAndPush:       func(string) error { return nil },
+		pollCI:              func(string) error { return nil },
+		mergePR:             func(string, string, bool) error { return fmt.Errorf("merge failed") },
+		markMerged:          markRunsMerged(store),
+	}
+
+	_ = runner.run([]string{"42"}, "squash", true)
+
+	reloaded, err := store.Load("20260101-0000-dddd")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if reloaded.MergedAt != nil {
+		t.Error("MergedAt should not be set when merge fails")
+	}
+}
+
+func TestMarkRunsMergedNilStore(t *testing.T) {
+	// markRunsMerged with nil store should not panic.
+	fn := markRunsMerged(nil)
+	fn("42") // Should be a no-op.
 }

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -81,6 +81,9 @@ func determineStatus(s *run.State) string {
 		return "running"
 	}
 
+	if s.MergedAt != nil {
+		return "merged"
+	}
 	if s.PRURL != nil {
 		return "pr-created"
 	}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -25,6 +25,7 @@ type State struct {
 	Type       string   `json:"type,omitempty"`
 	TargetRepo *string  `json:"target_repo,omitempty"`
 	CloneDir   *string  `json:"clone_dir,omitempty"`
+	MergedAt   *string  `json:"merged_at,omitempty"`
 }
 
 // GenID generates a run ID in the format YYYYMMDD-HHMM-XXXX where XXXX is 4 hex chars.


### PR DESCRIPTION
## Summary
- After a successful `klaus merge`, the dashboard kept showing merged PRs as "open" until the next 30-second GitHub poll because no local state files changed
- Added `MergedAt` field to run state and update it on disk after each successful PR merge, triggering the dashboard's fsnotify watcher for immediate refresh
- Dashboard and status commands now check `MergedAt` to show merged status without waiting for a GitHub API call

## Test plan
- [x] `TestRunUpdatesStateAfterMerge` — verifies matching run states get `MergedAt` set and persisted to disk after merge
- [x] `TestRunDoesNotUpdateStateOnMergeFailure` — verifies `MergedAt` is not set when merge fails
- [x] `TestMarkRunsMergedNilStore` — verifies no panic when store is nil (no session)
- [x] All existing tests pass (`go test ./...`)

Run: 20260313-1732-6350