### PR TITLE
Fix dashboard not showing updated PR states

### DIFF
--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -165,6 +165,19 @@ func (m dashboardModel) View() string {
 	}
 
 	groups := groupByRepo(m.states)
+
+	// Populate each group's PRMap from the fetched GitHub statuses.
+	for i := range groups {
+		for _, s := range groups[i].Runs {
+			prNum := extractPRNumber(s)
+			if prNum != "" {
+				if ps, ok := m.ghStatus[prNum]; ok {
+					groups[i].PRMap[prNum] = ps
+				}
+			}
+		}
+	}
+
 	totalCost := computeTotalCost(m.states)
 	runningCount, totalCount := countAgents(m.states)
 	sessionDur := computeSessionDuration(m.states)


### PR DESCRIPTION
## Summary
- `groupByRepo()` creates `repoGroup` objects with empty `PRMap`s on every render cycle
- The GitHub status data fetched by `fetchGHStatusCmd` and stored in `m.ghStatus` was never merged into these groups
- This caused `renderPRLine` to always receive `nil` for `prStatus`, defaulting every PR to "OPEN" regardless of actual state on GitHub
- Fix: populate each group's `PRMap` from `m.ghStatus` after grouping

## Test plan
- [ ] Run `klaus dashboard` with a session that has merged/closed PRs
- [ ] Verify PRs show correct state (MERGED/CLOSED) instead of always OPEN
- [ ] Verify state updates after the 30-second poll interval
- [ ] Press `r` to force refresh and verify states update