### PR TITLE
fix(auto-watch): resolve main repo root correctly from worktree

### DIFF
--- a/internal/cmd/hidden.go
+++ b/internal/cmd/hidden.go
@@ -204,11 +204,15 @@ var autoWatchCmd = &cobra.Command{
 			return nil
 		}
 
-		// Determine git root for worktree/branch cleanup
-		gitRoot, err := git.RepoRoot()
+		// Determine the main repo root for worktree/branch cleanup.
+		// We must use CommonDir (not RepoRoot) because RepoRoot returns the
+		// worktree path when run from a worktree — and we're about to remove
+		// that worktree, which would leave us in a deleted directory.
+		commonDir, err := git.CommonDir()
 		if err != nil {
 			return fmt.Errorf("auto-watch: not inside a git repository")
 		}
+		gitRoot := filepath.Dir(commonDir)
 		if state.CloneDir != nil {
 			gitRoot = *state.CloneDir
 		}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -64,6 +64,56 @@ func TestWorktreeAddRemove(t *testing.T) {
 	}
 }
 
+func TestCommonDirFromWorktree(t *testing.T) {
+	repo := initTestRepo(t)
+	wtPath := filepath.Join(t.TempDir(), "wt")
+
+	if err := WorktreeAdd(repo, wtPath, "test-branch", "main"); err != nil {
+		t.Fatalf("WorktreeAdd: %v", err)
+	}
+	defer WorktreeRemove(repo, wtPath)
+
+	// Save original dir and chdir to worktree
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(origDir)
+	os.Chdir(wtPath)
+
+	// RepoRoot from a worktree returns the worktree path, NOT the main repo
+	root, err := RepoRoot()
+	if err != nil {
+		t.Fatalf("RepoRoot: %v", err)
+	}
+	if root != wtPath {
+		t.Errorf("RepoRoot() = %q, expected worktree path %q", root, wtPath)
+	}
+
+	// CommonDir from a worktree returns the main repo's .git dir
+	common, err := CommonDir()
+	if err != nil {
+		t.Fatalf("CommonDir: %v", err)
+	}
+	mainRoot := filepath.Dir(common)
+	if mainRoot != repo {
+		t.Errorf("filepath.Dir(CommonDir()) = %q, expected main repo %q", mainRoot, repo)
+	}
+
+	// The main repo root survives worktree removal — this is critical for
+	// auto-watch, which removes the worktree then launches watch from the
+	// main repo root.
+	if err := WorktreeRemove(repo, wtPath); err != nil {
+		t.Fatalf("WorktreeRemove: %v", err)
+	}
+	if _, err := os.Stat(mainRoot); err != nil {
+		t.Errorf("main repo root should still exist after worktree removal: %v", err)
+	}
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Error("worktree should be gone after removal")
+	}
+}
+
 func TestEnsureDataRef(t *testing.T) {
 	repo := initTestRepo(t)
 	ref := "refs/klaus/data"


### PR DESCRIPTION
## Summary

- Fix auto-watch failing silently after agent creates a PR by using `git.CommonDir()` instead of `git.RepoRoot()` to resolve the main repo root
- The regression was introduced in 897550a when state storage moved to `~/.klaus/sessions/` — `RepoRoot()` returns the worktree path (which gets deleted), while `CommonDir()` correctly resolves to the main repo root that survives worktree removal
- Add integration test verifying `CommonDir` resolves correctly from a worktree and that the main repo survives worktree removal

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all tests pass
- [x] New `TestCommonDirFromWorktree` test verifies the fix using a real git repo and worktree

Run: 20260314-1122-9991
Fixes #101