### PR TITLE
fix(launch): respect session target over host repo

### DIFF
--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -45,27 +45,19 @@ PR. The agent will commit and push to the PR branch directly.`,
 		// Host repo — optional when --repo is specified or session target is set
 		hostRoot, _ := git.RepoRoot()
 
-		// Resolve --repo: if it matches a registered project name (no owner/ prefix),
-		// use that project's local path directly instead of cloning.
-		var projectLocalPath string
-		if repoRef != "" && !strings.Contains(repoRef, "/") {
-			if reg, loadErr := project.Load(); loadErr == nil {
-				if localPath, ok := reg.Get(repoRef); ok {
-					projectLocalPath = localPath
+		// Load session target (if any) to feed into resolution
+		var sessionTarget string
+		if s, storeErr := sessionStore(); storeErr == nil {
+			if hds, ok := s.(*run.HomeDirStore); ok {
+				if target, loadErr := run.LoadTarget(hds.BaseDir()); loadErr == nil {
+					sessionTarget = target
 				}
 			}
 		}
 
-		// If no --repo and not in a git repo, check session target
-		if hostRoot == "" && repoRef == "" {
-			if s, storeErr := sessionStore(); storeErr == nil {
-				if hds, ok := s.(*run.HomeDirStore); ok {
-					if target, loadErr := run.LoadTarget(hds.BaseDir()); loadErr == nil && target != "" {
-						repoRef = target
-					}
-				}
-			}
-		}
+		// Resolve which repo to use. Priority: --repo > session target > hostRoot
+		reg, _ := project.Load()
+		repoRef, projectLocalPath := resolveRepoTarget(repoRef, sessionTarget, reg)
 
 		if hostRoot == "" && repoRef == "" && projectLocalPath == "" {
 			return fmt.Errorf("no target repo — use --repo owner/repo, 'klaus target owner/repo', or 'klaus project add' to register a project")
@@ -414,6 +406,31 @@ func normalizeTargetRepo(targetRepo *string, hostRoot string) *string {
 	}
 
 	return targetRepo
+}
+
+// resolveRepoTarget determines which repo to use for the agent worktree.
+// Priority: explicit --repo flag > session target > (caller falls back to hostRoot).
+// If the resolved ref matches a registered project name (no "/" in the ref),
+// projectLocalPath is set to the project's local directory.
+func resolveRepoTarget(repoFlag, sessionTarget string, reg *project.Registry) (repoRef, projectLocalPath string) {
+	repoRef = repoFlag
+
+	// If no --repo flag, use the session target. This takes priority over the
+	// current git repo (hostRoot) because the coordinator session may be
+	// running inside one repo while targeting another.
+	if repoRef == "" && sessionTarget != "" {
+		repoRef = sessionTarget
+	}
+
+	// Resolve against project registry: bare names (no "/") may map to a
+	// local clone, avoiding a fresh GitHub clone.
+	if repoRef != "" && !strings.Contains(repoRef, "/") && reg != nil {
+		if localPath, ok := reg.Get(repoRef); ok {
+			projectLocalPath = localPath
+		}
+	}
+
+	return repoRef, projectLocalPath
 }
 
 // getPRURL returns the HTML URL for a PR using the gh CLI.

--- a/internal/cmd/launch_test.go
+++ b/internal/cmd/launch_test.go
@@ -311,6 +311,109 @@ func TestPRFixPromptNoIssue(t *testing.T) {
 	}
 }
 
+func TestResolveRepoTarget_SessionTargetUsedWhenNoFlag(t *testing.T) {
+	reg := &project.Registry{
+		Projects: map[string]string{
+			"reel-life": "/home/user/hack/reel-life",
+		},
+	}
+
+	repoRef, projectLocalPath := resolveRepoTarget("", "reel-life", reg)
+
+	if repoRef != "reel-life" {
+		t.Errorf("repoRef = %q, want %q", repoRef, "reel-life")
+	}
+	if projectLocalPath != "/home/user/hack/reel-life" {
+		t.Errorf("projectLocalPath = %q, want %q", projectLocalPath, "/home/user/hack/reel-life")
+	}
+}
+
+func TestResolveRepoTarget_RepoFlagOverridesSessionTarget(t *testing.T) {
+	reg := &project.Registry{
+		Projects: map[string]string{
+			"reel-life":     "/home/user/hack/reel-life",
+			"other-project": "/home/user/hack/other-project",
+		},
+	}
+
+	repoRef, projectLocalPath := resolveRepoTarget("other-project", "reel-life", reg)
+
+	if repoRef != "other-project" {
+		t.Errorf("repoRef = %q, want %q", repoRef, "other-project")
+	}
+	if projectLocalPath != "/home/user/hack/other-project" {
+		t.Errorf("projectLocalPath = %q, want %q", projectLocalPath, "/home/user/hack/other-project")
+	}
+}
+
+func TestResolveRepoTarget_SessionTargetWorksEvenWithHostRoot(t *testing.T) {
+	// This tests the bug fix from issue #103.
+	// The old code only checked session target when hostRoot was empty.
+	// With the new resolveRepoTarget() function, session target is always
+	// used when repoFlag is empty, regardless of whether the caller has a
+	// hostRoot. The caller (RunE) only falls back to hostRoot after
+	// resolveRepoTarget returns empty values.
+	reg := &project.Registry{
+		Projects: map[string]string{
+			"reel-life": "/home/user/hack/reel-life",
+		},
+	}
+
+	repoRef, projectLocalPath := resolveRepoTarget("", "reel-life", reg)
+
+	if repoRef != "reel-life" {
+		t.Errorf("repoRef = %q, want %q", repoRef, "reel-life")
+	}
+	if projectLocalPath != "/home/user/hack/reel-life" {
+		t.Errorf("projectLocalPath = %q, want %q", projectLocalPath, "/home/user/hack/reel-life")
+	}
+}
+
+func TestResolveRepoTarget_OwnerRepoParsedCorrectly(t *testing.T) {
+	reg := &project.Registry{
+		Projects: map[string]string{
+			"reel-life": "/home/user/hack/reel-life",
+		},
+	}
+
+	repoRef, projectLocalPath := resolveRepoTarget("", "patflynn/reel-life", reg)
+
+	if repoRef != "patflynn/reel-life" {
+		t.Errorf("repoRef = %q, want %q", repoRef, "patflynn/reel-life")
+	}
+	if projectLocalPath != "" {
+		t.Errorf("projectLocalPath = %q, want empty (owner/repo should not resolve as project name)", projectLocalPath)
+	}
+}
+
+func TestResolveRepoTarget_EmptyTargetFallsThrough(t *testing.T) {
+	reg := &project.Registry{
+		Projects: map[string]string{
+			"reel-life": "/home/user/hack/reel-life",
+		},
+	}
+
+	repoRef, projectLocalPath := resolveRepoTarget("", "", reg)
+
+	if repoRef != "" {
+		t.Errorf("repoRef = %q, want empty", repoRef)
+	}
+	if projectLocalPath != "" {
+		t.Errorf("projectLocalPath = %q, want empty", projectLocalPath)
+	}
+}
+
+func TestResolveRepoTarget_NilRegistry(t *testing.T) {
+	repoRef, projectLocalPath := resolveRepoTarget("", "reel-life", nil)
+
+	if repoRef != "reel-life" {
+		t.Errorf("repoRef = %q, want %q", repoRef, "reel-life")
+	}
+	if projectLocalPath != "" {
+		t.Errorf("projectLocalPath = %q, want empty (nil registry should not resolve)", projectLocalPath)
+	}
+}
+
 func TestLaunchCmdHasPRFlag(t *testing.T) {
 	// Verify the --pr flag is registered on the launch command
 	f := launchCmd.Flags().Lookup("pr")


### PR DESCRIPTION
## Summary
- Fix bug where `klaus launch` ignored the session target (set via `klaus target`) when the coordinator session was running inside a git repo
- The session target was only checked when `hostRoot == ""`, but coordinators typically run inside a repo worktree, so the condition was never true
- Agents now correctly create worktrees from the target project's local clone instead of the session's base repo
- Extract `resolveRepoTarget()` helper with correct priority: `--repo` flag > session target > current git repo

## Test plan
- [x] New tests verify `resolveRepoTarget()` handles all resolution scenarios
- [x] Session target is used when no `--repo` flag is set (even with hostRoot)
- [x] `--repo` flag still overrides session target
- [x] Bare project names resolve to local paths via registry
- [x] `owner/repo` format skips project registry lookup
- [x] All existing tests pass

Fixes #103

Run: 20260314-1223-7fce