### PR TITLE
Fix duplicate dashboard tmux panes on session restart

### DIFF
--- a/internal/cmd/cleanup.go
+++ b/internal/cmd/cleanup.go
@@ -71,6 +71,9 @@ var isRunActive = func(state *run.State) bool {
 	if state.TmuxPane != nil && tmux.PaneExists(*state.TmuxPane) {
 		return true
 	}
+	if state.DashboardPane != nil && tmux.PaneExists(*state.DashboardPane) {
+		return true
+	}
 	if state.Type == "session" {
 		if sid := os.Getenv(sessionIDEnv); sid != "" && state.ID == sid {
 			return true
@@ -96,6 +99,13 @@ func cleanupOne(root string, store run.StateStore, id string, force bool) error 
 	if state.TmuxPane != nil && tmux.PaneExists(*state.TmuxPane) {
 		if err := tmux.KillPane(*state.TmuxPane); err == nil {
 			fmt.Println("  killed tmux pane")
+		}
+	}
+
+	// Kill dashboard pane if alive
+	if state.DashboardPane != nil && tmux.PaneExists(*state.DashboardPane) {
+		if err := tmux.KillPane(*state.DashboardPane); err == nil {
+			fmt.Println("  killed dashboard pane")
 		}
 	}
 

--- a/internal/cmd/cleanup_test.go
+++ b/internal/cmd/cleanup_test.go
@@ -145,6 +145,25 @@ func TestIsRunActiveWithSessionEnv(t *testing.T) {
 	}
 }
 
+func TestIsRunActiveWithDashboardPane(t *testing.T) {
+	origIsRunActive := isRunActive
+	defer func() { isRunActive = origIsRunActive }()
+	isRunActive = origIsRunActive
+
+	// A run with no panes should not be active
+	s := &run.State{ID: "run-1"}
+	if isRunActive(s) {
+		t.Error("expected run without panes to not be active")
+	}
+
+	// A run with a DashboardPane that doesn't exist should not be active
+	fakePaneID := "%999999"
+	s2 := &run.State{ID: "run-2", DashboardPane: &fakePaneID}
+	if isRunActive(s2) {
+		t.Error("expected run with dead dashboard pane to not be active")
+	}
+}
+
 // fakeStore is an in-memory StateStore for testing.
 type fakeStore struct {
 	states map[string]*run.State

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -150,15 +150,24 @@ from inside the session to target specific repositories.`,
 		fmt.Println("  Use 'klaus launch' from inside to spawn workers.")
 		fmt.Println()
 
-		// Launch dashboard in a bottom pane before starting Claude
+		// Launch dashboard in a bottom pane before starting Claude.
+		// If a dashboard pane already exists from a prior run, reuse it.
 		var dashPane string
 		if currentPane != "" {
-			dashCmd := fmt.Sprintf("KLAUS_SESSION_ID=%s klaus dashboard", id)
-			paneID, err := tmux.SplitWindowSized(currentPane, worktree, dashCmd, "-v", "30%")
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "warning: could not open dashboard pane: %v\n", err)
+			if state.DashboardPane != nil && tmux.PaneExists(*state.DashboardPane) {
+				dashPane = *state.DashboardPane
 			} else {
-				dashPane = paneID
+				dashCmd := fmt.Sprintf("KLAUS_SESSION_ID=%s klaus dashboard", id)
+				paneID, err := tmux.SplitWindowSized(currentPane, worktree, dashCmd, "-v", "30%")
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "warning: could not open dashboard pane: %v\n", err)
+				} else {
+					dashPane = paneID
+					state.DashboardPane = &dashPane
+					if err := store.Save(state); err != nil {
+						fmt.Fprintf(os.Stderr, "warning: could not persist dashboard pane: %v\n", err)
+					}
+				}
 			}
 		}
 

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -25,7 +25,8 @@ type State struct {
 	Type       string   `json:"type,omitempty"`
 	TargetRepo *string  `json:"target_repo,omitempty"`
 	CloneDir   *string  `json:"clone_dir,omitempty"`
-	MergedAt   *string  `json:"merged_at,omitempty"`
+	MergedAt       *string  `json:"merged_at,omitempty"`
+	DashboardPane  *string  `json:"dashboard_pane,omitempty"`
 }
 
 // GenID generates a run ID in the format YYYYMMDD-HHMM-XXXX where XXXX is 4 hex chars.


### PR DESCRIPTION
## Summary
- Add `DashboardPane` field to `State` struct so the dashboard pane ID is persisted to disk
- Before creating a new dashboard pane, check if the persisted pane is still live and reuse it
- Include `DashboardPane` in `isRunActive` liveness checks and kill it during cleanup

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` passes (new test for `isRunActive` with `DashboardPane`)
- [ ] Manual: start a session, note one dashboard pane, restart the session — verify no duplicate pane
- [ ] Manual: `klaus cleanup <session-id>` kills the dashboard pane

Run: 20260316-2244-a5c1