### PR TITLE
fix: respect user's configured git protocol for clone URLs

### DIFF
--- a/internal/cmd/project.go
+++ b/internal/cmd/project.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/patflynn/klaus/internal/git"
 	"github.com/patflynn/klaus/internal/project"
 	"github.com/spf13/cobra"
 )
@@ -77,7 +78,7 @@ func runProjectAdd(cmd *cobra.Command, args []string) error {
 		parts := strings.SplitN(ref, "/", 2)
 		owner = parts[0]
 		repoName = parts[1]
-		cloneURL = fmt.Sprintf("https://github.com/%s/%s.git", owner, repoName)
+		cloneURL = git.CloneURL(owner, repoName)
 	} else {
 		// Bare name — search GitHub repos
 		repoName = ref

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 )
 
 // RepoRoot returns the top-level directory of the git repository.
@@ -140,6 +141,39 @@ func SyncToDataRef(repoDir, dataRef, commitMsg string, files map[string]string) 
 	return err
 }
 
+// ghProtocol caches the result of detecting the user's preferred git protocol.
+var (
+	ghProtocolOnce sync.Once
+	ghProtocolSSH  bool
+)
+
+// detectGHProtocol runs "gh config get git_protocol" and returns true if SSH.
+// Exported as a variable so tests can override it.
+var detectGHProtocol = func() bool {
+	out, err := exec.Command("gh", "config", "get", "git_protocol").Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "ssh"
+}
+
+// useSSHProtocol returns true if the user has configured gh to use SSH.
+func useSSHProtocol() bool {
+	ghProtocolOnce.Do(func() {
+		ghProtocolSSH = detectGHProtocol()
+	})
+	return ghProtocolSSH
+}
+
+// CloneURL returns the git clone URL for a GitHub repo, respecting the user's
+// configured git protocol (via gh config).
+func CloneURL(owner, repo string) string {
+	if useSSHProtocol() {
+		return fmt.Sprintf("git@github.com:%s/%s.git", owner, repo)
+	}
+	return fmt.Sprintf("https://github.com/%s/%s.git", owner, repo)
+}
+
 // CleanGitHubRef strips GitHub URL prefixes, .git suffix, and trailing slashes
 // from a repo reference, returning the bare "owner/repo" or short name form.
 func CleanGitHubRef(ref string) string {
@@ -171,7 +205,7 @@ func ParseRepoRef(ref string) (owner, repo, cloneURL string, err error) {
 	if strings.Contains(owner, "..") || strings.Contains(repo, "..") {
 		return "", "", "", fmt.Errorf("invalid repo reference %q: path traversal not allowed", ref)
 	}
-	cloneURL = fmt.Sprintf("https://github.com/%s/%s.git", owner, repo)
+	cloneURL = CloneURL(owner, repo)
 	return owner, repo, cloneURL, nil
 }
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"testing"
 )
 
@@ -206,7 +207,50 @@ func TestSyncToDataRefMultipleFiles(t *testing.T) {
 	}
 }
 
+// resetProtocolCache resets the sync.Once so protocol detection runs again.
+func resetProtocolCache() {
+	ghProtocolOnce = sync.Once{}
+	ghProtocolSSH = false
+}
+
+func TestCloneURL(t *testing.T) {
+	origDetect := detectGHProtocol
+	defer func() {
+		detectGHProtocol = origDetect
+		resetProtocolCache()
+	}()
+
+	t.Run("https", func(t *testing.T) {
+		resetProtocolCache()
+		detectGHProtocol = func() bool { return false }
+		got := CloneURL("owner", "repo")
+		want := "https://github.com/owner/repo.git"
+		if got != want {
+			t.Errorf("CloneURL() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("ssh", func(t *testing.T) {
+		resetProtocolCache()
+		detectGHProtocol = func() bool { return true }
+		got := CloneURL("owner", "repo")
+		want := "git@github.com:owner/repo.git"
+		if got != want {
+			t.Errorf("CloneURL() = %q, want %q", got, want)
+		}
+	})
+}
+
 func TestParseRepoRef(t *testing.T) {
+	// Force HTTPS protocol for deterministic test results.
+	origDetect := detectGHProtocol
+	defer func() {
+		detectGHProtocol = origDetect
+		resetProtocolCache()
+	}()
+	resetProtocolCache()
+	detectGHProtocol = func() bool { return false }
+
 	tests := []struct {
 		input     string
 		wantOwner string
@@ -302,6 +346,28 @@ func TestParseRepoRef(t *testing.T) {
 				t.Errorf("url = %q, want %q", url, tt.wantURL)
 			}
 		})
+	}
+}
+
+func TestParseRepoRefSSH(t *testing.T) {
+	origDetect := detectGHProtocol
+	defer func() {
+		detectGHProtocol = origDetect
+		resetProtocolCache()
+	}()
+	resetProtocolCache()
+	detectGHProtocol = func() bool { return true }
+
+	owner, repo, url, err := ParseRepoRef("patflynn/cosmo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if owner != "patflynn" || repo != "cosmo" {
+		t.Errorf("owner/repo = %s/%s, want patflynn/cosmo", owner, repo)
+	}
+	want := "git@github.com:patflynn/cosmo.git"
+	if url != want {
+		t.Errorf("url = %q, want %q", url, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Clone URLs were hardcoded as HTTPS in `ParseRepoRef` and `project add`, failing on systems without HTTPS git auth (e.g. NixOS with home-manager-managed git config)
- Added `CloneURL()` helper that checks `gh config get git_protocol` and uses SSH URLs when configured, falling back to HTTPS
- Protocol detection is cached via `sync.Once` so we only shell out once per process

## Test plan
- [x] Added `TestCloneURL` covering both SSH and HTTPS protocol paths
- [x] Added `TestParseRepoRefSSH` verifying SSH URL generation end-to-end
- [x] Existing `TestParseRepoRef` updated to pin protocol for deterministic results
- [x] Full test suite passes (`go test ./...`)

Run: 20260325-1015-e432