### PR TITLE
feat: add sandbox/host awareness to dashboard and status

### DIFF
--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -61,6 +62,10 @@ type fsEventMsg struct{}
 
 type tickMsg struct{}
 
+type sandboxStatusMsg struct {
+	statuses map[string]bool // hostname -> reachable
+}
+
 type errMsg struct {
 	err error
 }
@@ -83,13 +88,14 @@ type repoGroup struct {
 
 // dashboardModel is the bubbletea model for the dashboard.
 type dashboardModel struct {
-	store    run.StateStore
-	states   []*run.State
-	ghStatus map[string]*prStatus // keyed by PR number
-	width    int
-	height   int
-	err      error
-	watcher  *fsnotify.Watcher
+	store        run.StateStore
+	states       []*run.State
+	ghStatus     map[string]*prStatus // keyed by PR number
+	sandboxHosts map[string]bool      // hostname -> reachable
+	width        int
+	height       int
+	err          error
+	watcher      *fsnotify.Watcher
 }
 
 func newDashboardModel(store run.StateStore) dashboardModel {
@@ -129,12 +135,15 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case statesLoadedMsg:
 		m.states = msg.states
-		return m, fetchGHStatusCmd(m.states)
+		return m, tea.Batch(fetchGHStatusCmd(m.states), checkSandboxCmd(m.states))
 
 	case ghStatusMsg:
 		for k, v := range msg.statuses {
 			m.ghStatus[k] = v
 		}
+
+	case sandboxStatusMsg:
+		m.sandboxHosts = msg.statuses
 
 	case fsEventMsg:
 		return m, tea.Batch(loadStatesCmd(m.store), watchFSCmd(m.watcher))
@@ -142,6 +151,7 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tickMsg:
 		return m, tea.Batch(
 			fetchGHStatusCmd(m.states),
+			checkSandboxCmd(m.states),
 			tickAfterCmd(),
 		)
 
@@ -190,7 +200,14 @@ func (m dashboardModel) View() string {
 		rightAlignPad(fmt.Sprintf("Session: %s | Cost: $%.2f", formatDuration(sessionDur), totalCost), m.width-18),
 	))
 	b.WriteString(header)
-	b.WriteString("\n\n")
+	b.WriteString("\n")
+
+	// Sandbox status line (only if any runs have a Host set)
+	if sandboxLine := renderSandboxStatus(m.sandboxHosts); sandboxLine != "" {
+		b.WriteString(sandboxLine)
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
 
 	if len(groups) == 0 {
 		b.WriteString(dimStyle.Render("  No runs found."))
@@ -319,7 +336,11 @@ func (m dashboardModel) renderPRLine(prNum string, s *run.State, ps *prStatus) s
 func renderAgentSubline(s *run.State) string {
 	shortID := shortRunID(s.ID)
 	prompt := truncate(s.Prompt, 20)
-	return yellowStyle.Render(fmt.Sprintf("   └─ agent:%s %s...", shortID, prompt))
+	line := yellowStyle.Render(fmt.Sprintf("   └─ agent:%s %s...", shortID, prompt))
+	if s.Host != nil && *s.Host != "" {
+		line += " " + sandboxStyle.Render(fmt.Sprintf("[%s]", *s.Host))
+	}
+	return line
 }
 
 func renderBareAgentLine(s *run.State) string {
@@ -327,11 +348,15 @@ func renderBareAgentLine(s *run.State) string {
 	status := agentStatusLabel(s)
 	cost := formatCost(s)
 	prompt := truncate(s.Prompt, 20)
+	hostTag := ""
+	if s.Host != nil && *s.Host != "" {
+		hostTag = " " + sandboxStyle.Render(fmt.Sprintf("[%s]", *s.Host))
+	}
 
 	if isAgentRunning(s) {
-		return yellowStyle.Render(fmt.Sprintf("  agent:%s  %-20s  RUNNING   %s", shortID, prompt, cost))
+		return yellowStyle.Render(fmt.Sprintf("  agent:%s  %-20s  RUNNING   %s", shortID, prompt, cost)) + hostTag
 	}
-	return dimStyle.Render(fmt.Sprintf("  agent:%s  %-20s  %s   %s", shortID, prompt, status, cost))
+	return dimStyle.Render(fmt.Sprintf("  agent:%s  %-20s  %s   %s", shortID, prompt, status, cost)) + hostTag
 }
 
 // Commands for the bubbletea event loop.
@@ -412,6 +437,59 @@ func watchFSCmd(w *fsnotify.Watcher) tea.Cmd {
 			}
 		}
 	}
+}
+
+// collectUniqueHosts returns the set of unique non-empty Host values from states.
+func collectUniqueHosts(states []*run.State) []string {
+	seen := make(map[string]bool)
+	var hosts []string
+	for _, s := range states {
+		if s.Host != nil && *s.Host != "" && !seen[*s.Host] {
+			seen[*s.Host] = true
+			hosts = append(hosts, *s.Host)
+		}
+	}
+	sort.Strings(hosts)
+	return hosts
+}
+
+// checkSandboxCmd probes each unique sandbox host for reachability via SSH.
+func checkSandboxCmd(states []*run.State) tea.Cmd {
+	hosts := collectUniqueHosts(states)
+	if len(hosts) == 0 {
+		return nil
+	}
+	return func() tea.Msg {
+		statuses := make(map[string]bool, len(hosts))
+		for _, h := range hosts {
+			cmd := exec.Command("ssh", "-o", "ConnectTimeout=2", "-o", "BatchMode=yes", h, "true")
+			statuses[h] = cmd.Run() == nil
+		}
+		return sandboxStatusMsg{statuses: statuses}
+	}
+}
+
+// renderSandboxStatus returns a header line showing sandbox host reachability.
+// Returns "" if there are no sandbox hosts.
+func renderSandboxStatus(hosts map[string]bool) string {
+	if len(hosts) == 0 {
+		return ""
+	}
+	var parts []string
+	// Sort keys for deterministic output
+	keys := make([]string, 0, len(hosts))
+	for k := range hosts {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, h := range keys {
+		if hosts[h] {
+			parts = append(parts, greenStyle.Render(fmt.Sprintf("%s: ✓", h)))
+		} else {
+			parts = append(parts, redStyle.Render(fmt.Sprintf("%s: ✗", h)))
+		}
+	}
+	return dimStyle.Render("  sandbox ") + strings.Join(parts, "  ")
 }
 
 // fetchPRStatus queries GitHub for a single PR's status.
@@ -586,7 +664,8 @@ var (
 	greenStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
 	redStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
 	yellowStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
-	dimStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	dimStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	sandboxStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
 )
 
 func stateLabel(state string) string {

--- a/internal/cmd/dashboard_test.go
+++ b/internal/cmd/dashboard_test.go
@@ -583,6 +583,155 @@ func TestRightAlignPad(t *testing.T) {
 	}
 }
 
+func TestRenderBareAgentLineWithHost(t *testing.T) {
+	host := "klaus-worker-0"
+	s := &run.State{
+		ID:       "20260307-0900-aaaa",
+		Prompt:   "fix tests",
+		Type:     "launch",
+		TmuxPane: strPtr("%1"),
+		Host:     &host,
+	}
+	line := renderBareAgentLine(s)
+	if !strings.Contains(line, "klaus-worker-0") {
+		t.Error("bare agent line should contain host tag when Host is set")
+	}
+	if !strings.Contains(line, "RUNNING") {
+		t.Error("running agent should show RUNNING")
+	}
+}
+
+func TestRenderAgentSublineWithHost(t *testing.T) {
+	host := "klaus-worker-0"
+	s := &run.State{
+		ID:       "20260307-0900-aaaa",
+		Prompt:   "fix tests",
+		Type:     "launch",
+		TmuxPane: strPtr("%1"),
+		Host:     &host,
+	}
+	line := renderAgentSubline(s)
+	if !strings.Contains(line, "klaus-worker-0") {
+		t.Error("agent subline should contain host tag when Host is set")
+	}
+}
+
+func TestCountAgentsWithHost(t *testing.T) {
+	host := "klaus-worker-0"
+	states := []*run.State{
+		{ID: "1", Type: "launch", TmuxPane: strPtr("%1"), Host: &host},
+		{ID: "2", Type: "launch", TmuxPane: strPtr("%2")},
+		{ID: "3", Type: "session"},
+	}
+	running, total := countAgents(states)
+	if total != 2 {
+		t.Errorf("total = %d, want 2", total)
+	}
+	if running != 2 {
+		t.Errorf("running = %d, want 2", running)
+	}
+}
+
+func TestSandboxStatusMsgUpdate(t *testing.T) {
+	m := dashboardModel{
+		states:   []*run.State{},
+		ghStatus: map[string]*prStatus{},
+		width:    80,
+		height:   24,
+	}
+
+	msg := sandboxStatusMsg{statuses: map[string]bool{"worker-0": true, "worker-1": false}}
+	updated, _ := m.Update(msg)
+	dm := updated.(dashboardModel)
+	if dm.sandboxHosts == nil {
+		t.Fatal("sandboxHosts should be set after sandboxStatusMsg")
+	}
+	if !dm.sandboxHosts["worker-0"] {
+		t.Error("worker-0 should be reachable")
+	}
+	if dm.sandboxHosts["worker-1"] {
+		t.Error("worker-1 should be unreachable")
+	}
+}
+
+func TestRenderSandboxStatus(t *testing.T) {
+	// No hosts — empty string
+	if got := renderSandboxStatus(nil); got != "" {
+		t.Errorf("nil hosts should return empty, got %q", got)
+	}
+	if got := renderSandboxStatus(map[string]bool{}); got != "" {
+		t.Errorf("empty hosts should return empty, got %q", got)
+	}
+
+	// With hosts
+	hosts := map[string]bool{"worker-0": true, "worker-1": false}
+	got := renderSandboxStatus(hosts)
+	if !strings.Contains(got, "sandbox") {
+		t.Error("should contain 'sandbox' label")
+	}
+	if !strings.Contains(got, "worker-0") {
+		t.Error("should contain worker-0")
+	}
+	if !strings.Contains(got, "worker-1") {
+		t.Error("should contain worker-1")
+	}
+	if !strings.Contains(got, "✓") {
+		t.Error("should contain check mark for reachable host")
+	}
+	if !strings.Contains(got, "✗") {
+		t.Error("should contain cross mark for unreachable host")
+	}
+}
+
+func TestDashboardViewRenderWithSandbox(t *testing.T) {
+	host := "klaus-worker-0"
+	states := []*run.State{
+		{
+			ID:         "20260307-0900-aaaa",
+			Prompt:     "fix sandbox tests",
+			Type:       "launch",
+			CreatedAt:  time.Now().Format(time.RFC3339),
+			TargetRepo: strPtr("testowner/testrepo"),
+			TmuxPane:   strPtr("%5"),
+			Host:       &host,
+		},
+	}
+
+	m := dashboardModel{
+		states:       states,
+		ghStatus:     map[string]*prStatus{},
+		sandboxHosts: map[string]bool{"klaus-worker-0": true},
+		width:        80,
+		height:       24,
+	}
+
+	view := m.View()
+	if !strings.Contains(view, "sandbox") {
+		t.Error("view should contain sandbox status line")
+	}
+	if !strings.Contains(view, "klaus-worker-0") {
+		t.Error("view should contain the sandbox host name")
+	}
+}
+
+func TestCollectUniqueHosts(t *testing.T) {
+	host1 := "worker-0"
+	host2 := "worker-1"
+	states := []*run.State{
+		{Host: &host1},
+		{Host: &host2},
+		{Host: &host1}, // duplicate
+		{},              // no host
+	}
+	hosts := collectUniqueHosts(states)
+	if len(hosts) != 2 {
+		t.Fatalf("expected 2 unique hosts, got %d", len(hosts))
+	}
+	if hosts[0] != "worker-0" || hosts[1] != "worker-1" {
+		t.Errorf("hosts = %v, want [worker-0 worker-1]", hosts)
+	}
+}
+
 // Helper functions for tests.
 
 func float64Ptr(f float64) *float64 {

--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -38,6 +38,7 @@ PR. The agent will commit and push to the PR branch directly.`,
 		budget, _ := cmd.Flags().GetString("budget")
 		repoRef, _ := cmd.Flags().GetString("repo")
 		prNumber, _ := cmd.Flags().GetString("pr")
+		host, _ := cmd.Flags().GetString("host")
 
 		if !tmux.InSession() {
 			return fmt.Errorf("klaus launch must be run inside a tmux session")
@@ -294,6 +295,9 @@ PR. The agent will commit and push to the PR branch directly.`,
 			TargetRepo: normalizedTarget,
 			CloneDir:   cloneDirPtr,
 		}
+		if host != "" {
+			state.Host = &host
+		}
 		if isPRFix {
 			state.Type = "pr-fix"
 			if prURL != "" {
@@ -475,5 +479,6 @@ func init() {
 	launchCmd.Flags().String("budget", "", "Max spend in USD (default from config)")
 	launchCmd.Flags().String("repo", "", "Target repo: registered project name, owner/repo, or full URL")
 	launchCmd.Flags().Bool("no-watch", false, "Don't auto-launch a watch agent when a PR is created")
+	launchCmd.Flags().String("host", "", "Remote host to run the agent on (e.g. klaus-worker-0)")
 	rootCmd.AddCommand(launchCmd)
 }

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -26,10 +26,10 @@ var statusCmd = &cobra.Command{
 			return nil
 		}
 
-		fmt.Fprintf(os.Stdout, "%-22s  %-10s  %-8s  %-6s  %-20s  %-6s  %-10s  %-10s  %-10s  %s\n",
-			"RUN ID", "STATUS", "COST", "ISSUE", "REPO", "PR", "CI", "CONFLICTS", "MERGE", "PROMPT")
-		fmt.Fprintf(os.Stdout, "%-22s  %-10s  %-8s  %-6s  %-20s  %-6s  %-10s  %-10s  %-10s  %s\n",
-			"------", "------", "----", "-----", "----", "--", "--", "---------", "-----", "------")
+		fmt.Fprintf(os.Stdout, "%-22s  %-10s  %-8s  %-6s  %-20s  %-16s  %-6s  %-10s  %-10s  %-10s  %s\n",
+			"RUN ID", "STATUS", "COST", "ISSUE", "REPO", "HOST", "PR", "CI", "CONFLICTS", "MERGE", "PROMPT")
+		fmt.Fprintf(os.Stdout, "%-22s  %-10s  %-8s  %-6s  %-20s  %-16s  %-6s  %-10s  %-10s  %-10s  %s\n",
+			"------", "------", "----", "-----", "----", "----", "--", "--", "---------", "-----", "------")
 
 		for _, s := range states {
 			status := determineStatus(s)
@@ -41,6 +41,10 @@ var statusCmd = &cobra.Command{
 			repo := "-"
 			if s.TargetRepo != nil {
 				repo = truncate(*s.TargetRepo, 20)
+			}
+			host := "-"
+			if s.Host != nil && *s.Host != "" {
+				host = truncate(*s.Host, 16)
 			}
 			pr := formatPR(s)
 			prompt := truncate(s.Prompt, 40)
@@ -61,8 +65,8 @@ var statusCmd = &cobra.Command{
 				}
 			}
 
-			fmt.Fprintf(os.Stdout, "%-22s  %-10s  %-8s  %-6s  %-20s  %-6s  %-10s  %-10s  %-10s  %s\n",
-				s.ID, status, cost, issue, repo, pr, ci, conflicts, merge, prompt)
+			fmt.Fprintf(os.Stdout, "%-22s  %-10s  %-8s  %-6s  %-20s  %-16s  %-6s  %-10s  %-10s  %-10s  %s\n",
+				s.ID, status, cost, issue, repo, host, pr, ci, conflicts, merge, prompt)
 		}
 
 		return nil

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -29,6 +29,7 @@ type State struct {
 	DashboardPane  *string  `json:"dashboard_pane,omitempty"`
 	Approved       *bool    `json:"approved,omitempty"`
 	ApprovedAt     *string  `json:"approved_at,omitempty"`
+	Host           *string  `json:"host,omitempty"`
 }
 
 // GenID generates a run ID in the format YYYYMMDD-HHMM-XXXX where XXXX is 4 hex chars.


### PR DESCRIPTION
## Summary
- Add `Host` field to `run.State` to track which hostname an agent runs on (nil/empty = local)
- Dashboard shows `[hostname]` tag on sandboxed agent lines (bare and sublines) in cyan
- Dashboard header shows per-host SSH reachability (`✓`/`✗`) when any runs have a Host set
- Status command gains a `HOST` column between REPO and PR
- Launch command accepts `--host` flag to persist the hostname (remote execution is a separate task)

## Test plan
- [x] `TestRenderBareAgentLineWithHost` — verifies sandbox tag appears on bare agent lines
- [x] `TestRenderAgentSublineWithHost` — verifies sandbox tag on sublines
- [x] `TestCountAgentsWithHost` — Host field doesn't affect running/total counts
- [x] `TestSandboxStatusMsgUpdate` — sandboxStatusMsg correctly updates model
- [x] `TestRenderSandboxStatus` — header line rendering with reachable/unreachable hosts
- [x] `TestDashboardViewRenderWithSandbox` — full view includes sandbox status
- [x] `TestCollectUniqueHosts` — deduplication and sorting of hosts
- [x] `go test ./...` passes

Run: 20260328-1909-a24f