### PR TITLE
feat: add sandbox support for remote agent execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,23 @@ Launch an agent against a different GitHub repository. The repo is cloned (or fe
 klaus launch --repo owner/repo "Fix the bug in their API"
 ```
 
+### Sandbox (remote execution)
+
+When `sandbox_host` is set in `~/.klaus/config.json`, agents run remotely via SSH on the sandbox host instead of locally. The worktree is synced to the sandbox before launch, and results are synced back after completion. Log streaming, formatting, and finalization still happen locally.
+
+```json
+{"sandbox_host": "klaus-worker-0"}
+```
+
+If the sandbox is unreachable, execution falls back to local automatically. Use `--local` to force local execution, or `--host <name>` to override the configured sandbox host.
+
+```bash
+klaus launch --local "Run this locally"
+klaus launch --host my-sandbox "Run on a specific host"
+```
+
+The dashboard shows `[sandbox]` tags on remotely-executed agents and displays sandbox reachability status in the header. The `status` command includes a HOST column.
+
 ### `klaus target`
 
 Set a session-level default target repo. When the coordinator session is not inside a git repo, this avoids needing `--repo` on every `klaus launch`. Accepts a registered project name or `owner/repo`.

--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -61,6 +61,10 @@ type fsEventMsg struct{}
 
 type tickMsg struct{}
 
+type sandboxStatusMsg struct {
+	hosts map[string]bool // host -> reachable
+}
+
 type errMsg struct {
 	err error
 }
@@ -83,19 +87,21 @@ type repoGroup struct {
 
 // dashboardModel is the bubbletea model for the dashboard.
 type dashboardModel struct {
-	store    run.StateStore
-	states   []*run.State
-	ghStatus map[string]*prStatus // keyed by PR number
-	width    int
-	height   int
-	err      error
-	watcher  *fsnotify.Watcher
+	store        run.StateStore
+	states       []*run.State
+	ghStatus     map[string]*prStatus // keyed by PR number
+	sandboxHosts map[string]bool      // host -> reachable
+	width        int
+	height       int
+	err          error
+	watcher      *fsnotify.Watcher
 }
 
 func newDashboardModel(store run.StateStore) dashboardModel {
 	return dashboardModel{
-		store:    store,
-		ghStatus: make(map[string]*prStatus),
+		store:        store,
+		ghStatus:     make(map[string]*prStatus),
+		sandboxHosts: make(map[string]bool),
 	}
 }
 
@@ -139,9 +145,15 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case fsEventMsg:
 		return m, tea.Batch(loadStatesCmd(m.store), watchFSCmd(m.watcher))
 
+	case sandboxStatusMsg:
+		for k, v := range msg.hosts {
+			m.sandboxHosts[k] = v
+		}
+
 	case tickMsg:
 		return m, tea.Batch(
 			fetchGHStatusCmd(m.states),
+			checkSandboxCmd(m.states),
 			tickAfterCmd(),
 		)
 
@@ -185,12 +197,19 @@ func (m dashboardModel) View() string {
 	var b strings.Builder
 
 	// Header
+	headerRight := fmt.Sprintf("Session: %s | Cost: $%.2f", formatDuration(sessionDur), totalCost)
 	header := headerStyle.Render(fmt.Sprintf(
 		" klaus dashboard%s",
-		rightAlignPad(fmt.Sprintf("Session: %s | Cost: $%.2f", formatDuration(sessionDur), totalCost), m.width-18),
+		rightAlignPad(headerRight, m.width-18),
 	))
 	b.WriteString(header)
-	b.WriteString("\n\n")
+	b.WriteString("\n")
+
+	// Sandbox status line (only if any runs have a Host set)
+	if sandboxLine := renderSandboxStatus(m.sandboxHosts); sandboxLine != "" {
+		b.WriteString(sandboxLine)
+	}
+	b.WriteString("\n")
 
 	if len(groups) == 0 {
 		b.WriteString(dimStyle.Render("  No runs found."))
@@ -319,7 +338,8 @@ func (m dashboardModel) renderPRLine(prNum string, s *run.State, ps *prStatus) s
 func renderAgentSubline(s *run.State) string {
 	shortID := shortRunID(s.ID)
 	prompt := truncate(s.Prompt, 20)
-	return yellowStyle.Render(fmt.Sprintf("   └─ agent:%s %s...", shortID, prompt))
+	hostTag := sandboxTag(s)
+	return yellowStyle.Render(fmt.Sprintf("   └─ agent:%s %s...%s", shortID, prompt, hostTag))
 }
 
 func renderBareAgentLine(s *run.State) string {
@@ -327,11 +347,20 @@ func renderBareAgentLine(s *run.State) string {
 	status := agentStatusLabel(s)
 	cost := formatCost(s)
 	prompt := truncate(s.Prompt, 20)
+	hostTag := sandboxTag(s)
 
 	if isAgentRunning(s) {
-		return yellowStyle.Render(fmt.Sprintf("  agent:%s  %-20s  RUNNING   %s", shortID, prompt, cost))
+		return yellowStyle.Render(fmt.Sprintf("  agent:%s  %-20s  RUNNING   %s", shortID, prompt, cost)) + hostTag
 	}
-	return dimStyle.Render(fmt.Sprintf("  agent:%s  %-20s  %s   %s", shortID, prompt, status, cost))
+	return dimStyle.Render(fmt.Sprintf("  agent:%s  %-20s  %s   %s", shortID, prompt, status, cost)) + hostTag
+}
+
+// sandboxTag returns a styled "[sandbox]" tag if the agent ran on a sandbox host.
+func sandboxTag(s *run.State) string {
+	if s.Host != nil {
+		return " " + sandboxStyle.Render("[sandbox]")
+	}
+	return ""
 }
 
 // Commands for the bubbletea event loop.
@@ -412,6 +441,39 @@ func watchFSCmd(w *fsnotify.Watcher) tea.Cmd {
 			}
 		}
 	}
+}
+
+func checkSandboxCmd(states []*run.State) tea.Cmd {
+	return func() tea.Msg {
+		hosts := make(map[string]bool)
+		for _, s := range states {
+			if s.Host != nil && *s.Host != "" {
+				if _, ok := hosts[*s.Host]; !ok {
+					hosts[*s.Host] = CheckSandboxReachable(*s.Host)
+				}
+			}
+		}
+		if len(hosts) == 0 {
+			return nil
+		}
+		return sandboxStatusMsg{hosts: hosts}
+	}
+}
+
+func renderSandboxStatus(hosts map[string]bool) string {
+	if len(hosts) == 0 {
+		return ""
+	}
+	var parts []string
+	for host, reachable := range hosts {
+		if reachable {
+			parts = append(parts, greenStyle.Render(fmt.Sprintf("  sandbox %s: ✓", host)))
+		} else {
+			parts = append(parts, redStyle.Render(fmt.Sprintf("  sandbox %s: ✗", host)))
+		}
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "  ") + "\n"
 }
 
 // fetchPRStatus queries GitHub for a single PR's status.
@@ -581,12 +643,13 @@ func formatDuration(d time.Duration) string {
 // Styling.
 
 var (
-	headerStyle = lipgloss.NewStyle().Bold(true)
-	repoStyle   = lipgloss.NewStyle().Bold(true)
-	greenStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
-	redStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
-	yellowStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
-	dimStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	headerStyle  = lipgloss.NewStyle().Bold(true)
+	repoStyle    = lipgloss.NewStyle().Bold(true)
+	greenStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+	redStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
+	yellowStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+	dimStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	sandboxStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
 )
 
 func stateLabel(state string) string {

--- a/internal/cmd/dashboard_test.go
+++ b/internal/cmd/dashboard_test.go
@@ -583,6 +583,170 @@ func TestRightAlignPad(t *testing.T) {
 	}
 }
 
+func TestHostFieldRoundTrip(t *testing.T) {
+	host := "klaus-worker-0"
+	s := run.State{
+		ID:        "20260328-1915-e4b3",
+		Prompt:    "test",
+		Branch:    "agent/test",
+		Worktree:  "/tmp/worktree",
+		CreatedAt: "2026-03-28T19:15:00Z",
+		Host:      &host,
+	}
+
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var loaded run.State
+	if err := json.Unmarshal(data, &loaded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if loaded.Host == nil {
+		t.Fatal("Host should not be nil after round-trip")
+	}
+	if *loaded.Host != "klaus-worker-0" {
+		t.Errorf("Host = %q, want %q", *loaded.Host, "klaus-worker-0")
+	}
+}
+
+func TestHostFieldOmittedWhenNil(t *testing.T) {
+	s := run.State{
+		ID:        "20260328-1915-e4b3",
+		Prompt:    "test",
+		Branch:    "agent/test",
+		Worktree:  "/tmp/worktree",
+		CreatedAt: "2026-03-28T19:15:00Z",
+	}
+
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	if strings.Contains(string(data), `"host"`) {
+		t.Error("host field should be omitted when nil")
+	}
+}
+
+func TestRenderBareAgentLineWithHost(t *testing.T) {
+	host := "klaus-worker-0"
+	s := &run.State{
+		ID:       "20260328-1915-e4b3",
+		Prompt:   "fix tests",
+		TmuxPane: strPtr("%5"),
+		Host:     &host,
+	}
+
+	line := renderBareAgentLine(s)
+	if !strings.Contains(line, "[sandbox]") {
+		t.Error("bare agent with Host set should show [sandbox], got:", line)
+	}
+}
+
+func TestRenderBareAgentLineWithoutHost(t *testing.T) {
+	s := &run.State{
+		ID:       "20260328-1915-e4b3",
+		Prompt:   "fix tests",
+		TmuxPane: strPtr("%5"),
+	}
+
+	line := renderBareAgentLine(s)
+	if strings.Contains(line, "[sandbox]") {
+		t.Error("bare agent without Host should not show [sandbox], got:", line)
+	}
+}
+
+func TestRenderAgentSublineWithHost(t *testing.T) {
+	host := "klaus-worker-0"
+	s := &run.State{
+		ID:       "20260328-1915-e4b3",
+		Prompt:   "fix tests",
+		TmuxPane: strPtr("%5"),
+		Host:     &host,
+	}
+
+	line := renderAgentSubline(s)
+	if !strings.Contains(line, "[sandbox]") {
+		t.Error("agent subline with Host set should show [sandbox], got:", line)
+	}
+}
+
+func TestSandboxTag(t *testing.T) {
+	t.Run("with host", func(t *testing.T) {
+		host := "klaus-worker-0"
+		s := &run.State{Host: &host}
+		tag := sandboxTag(s)
+		if !strings.Contains(tag, "[sandbox]") {
+			t.Errorf("sandboxTag with host should contain [sandbox], got %q", tag)
+		}
+	})
+
+	t.Run("without host", func(t *testing.T) {
+		s := &run.State{}
+		tag := sandboxTag(s)
+		if tag != "" {
+			t.Errorf("sandboxTag without host should be empty, got %q", tag)
+		}
+	})
+}
+
+func TestRenderSandboxStatus(t *testing.T) {
+	t.Run("empty hosts returns empty", func(t *testing.T) {
+		got := renderSandboxStatus(map[string]bool{})
+		if got != "" {
+			t.Errorf("expected empty string, got %q", got)
+		}
+	})
+
+	t.Run("reachable host shows checkmark", func(t *testing.T) {
+		got := renderSandboxStatus(map[string]bool{"myhost": true})
+		if !strings.Contains(got, "sandbox myhost: ✓") {
+			t.Errorf("expected checkmark for reachable host, got %q", got)
+		}
+	})
+
+	t.Run("unreachable host shows X", func(t *testing.T) {
+		got := renderSandboxStatus(map[string]bool{"myhost": false})
+		if !strings.Contains(got, "sandbox myhost: ✗") {
+			t.Errorf("expected X for unreachable host, got %q", got)
+		}
+	})
+}
+
+func TestDashboardViewWithSandboxAgent(t *testing.T) {
+	host := "klaus-worker-0"
+	states := []*run.State{
+		{
+			ID:         "20260328-1915-e4b3",
+			Prompt:     "sandbox test",
+			Type:       "launch",
+			CreatedAt:  time.Now().Format(time.RFC3339),
+			TargetRepo: strPtr("testowner/testrepo"),
+			TmuxPane:   strPtr("%5"),
+			Host:       &host,
+		},
+	}
+
+	m := dashboardModel{
+		states:       states,
+		ghStatus:     map[string]*prStatus{},
+		sandboxHosts: map[string]bool{"klaus-worker-0": true},
+		width:        80,
+		height:       24,
+	}
+
+	view := m.View()
+	if !strings.Contains(view, "[sandbox]") {
+		t.Error("view should show [sandbox] for agent with Host set")
+	}
+	if !strings.Contains(view, "sandbox klaus-worker-0: ✓") {
+		t.Error("view should show sandbox reachability in header")
+	}
+}
+
 // Helper functions for tests.
 
 func float64Ptr(f float64) *float64 {

--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -30,7 +30,12 @@ matches a registered project (no owner/ prefix), the project's local path is
 used directly. Otherwise, the repo is cloned from GitHub.
 
 Use --pr to push fixes to an existing PR's branch instead of creating a new
-PR. The agent will commit and push to the PR branch directly.`,
+PR. The agent will commit and push to the PR branch directly.
+
+When sandbox_host is configured in ~/.klaus/config.json, agents run remotely
+via SSH on the sandbox host. The worktree is synced before launch and results
+are synced back after completion. Use --local to force local execution, or
+--host to override the configured sandbox host.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		prompt := args[0]
@@ -38,6 +43,8 @@ PR. The agent will commit and push to the PR branch directly.`,
 		budget, _ := cmd.Flags().GetString("budget")
 		repoRef, _ := cmd.Flags().GetString("repo")
 		prNumber, _ := cmd.Flags().GetString("pr")
+		forceLocal, _ := cmd.Flags().GetBool("local")
+		hostOverride, _ := cmd.Flags().GetString("host")
 
 		if !tmux.InSession() {
 			return fmt.Errorf("klaus launch must be run inside a tmux session")
@@ -246,8 +253,37 @@ PR. The agent will commit and push to the PR branch directly.`,
 			finalizePrefix = fmt.Sprintf("cd %s && ", shellQuote(hostRoot))
 		}
 		noWatch, _ := cmd.Flags().GetBool("no-watch")
-		// PR-fix runs always skip auto-watch since we're already on the PR branch
-		paneCmd := buildPaneCommand(worktree, claudeCmd, logFile, selfBin, finalizePrefix, id, noWatch || isPRFix)
+
+		// Determine sandbox host: --host flag > config sandbox_host
+		sandboxHost := hostCfg.SandboxHost
+		if hostOverride != "" {
+			sandboxHost = hostOverride
+		}
+
+		// Attempt sandbox execution unless --local is set
+		var useSandbox bool
+		var sandboxHostName string
+		if sandboxHost != "" && !forceLocal {
+			if CheckSandboxReachable(sandboxHost) {
+				useSandbox = true
+				sandboxHostName = sandboxHost
+				// Sync worktree to sandbox before launching
+				if err := syncWorktreeToSandbox(sandboxHost, worktree); err != nil {
+					fmt.Fprintf(os.Stderr, "warning: sandbox sync failed, falling back to local: %v\n", err)
+					useSandbox = false
+				}
+			} else {
+				fmt.Fprintf(os.Stderr, "warning: sandbox %s unreachable, falling back to local execution\n", sandboxHost)
+			}
+		}
+
+		var paneCmd string
+		if useSandbox {
+			paneCmd = buildSandboxPaneCommand(sandboxHostName, worktree, claudeCmd, logFile, selfBin, finalizePrefix, id, noWatch || isPRFix)
+		} else {
+			// PR-fix runs always skip auto-watch since we're already on the PR branch
+			paneCmd = buildPaneCommand(worktree, claudeCmd, logFile, selfBin, finalizePrefix, id, noWatch || isPRFix)
+		}
 
 		// Launch in tmux pane, targeting the pane that ran this command
 		currentPane := os.Getenv("TMUX_PANE")
@@ -280,6 +316,11 @@ PR. The agent will commit and push to the PR branch directly.`,
 		// canonical name in the dashboard.
 		normalizedTarget := normalizeTargetRepo(targetRepo, hostRoot)
 
+		var hostPtr *string
+		if useSandbox {
+			hostPtr = &sandboxHostName
+		}
+
 		state := &run.State{
 			ID:         id,
 			Prompt:     prompt,
@@ -291,6 +332,7 @@ PR. The agent will commit and push to the PR branch directly.`,
 			Budget:     budgetPtr,
 			LogFile:    logFilePtr,
 			CreatedAt:  createdAt,
+			Host:       hostPtr,
 			TargetRepo: normalizedTarget,
 			CloneDir:   cloneDirPtr,
 		}
@@ -321,6 +363,11 @@ PR. The agent will commit and push to the PR branch directly.`,
 		}
 
 		fmt.Printf("  pane:     %s\n", paneID)
+		if useSandbox {
+			fmt.Printf("  host:     %s (sandbox)\n", sandboxHostName)
+		} else {
+			fmt.Printf("  host:     local\n")
+		}
 		fmt.Printf("  budget:   $%s\n", budget)
 		fmt.Printf("  log:      %s\n", logFile)
 		fmt.Println()
@@ -469,11 +516,61 @@ func getPRURL(prNumber string) (string, error) {
 	return strings.TrimSpace(stdout.String()), nil
 }
 
+// CheckSandboxReachable tests whether a sandbox host is reachable via SSH.
+func CheckSandboxReachable(host string) bool {
+	cmd := exec.Command("ssh", "-o", "ConnectTimeout=3", "-o", "BatchMode=yes", host, "true")
+	return cmd.Run() == nil
+}
+
+// syncWorktreeToSandbox syncs a local worktree to a sandbox host via rsync.
+func syncWorktreeToSandbox(host, worktree string) error {
+	// Create remote directory
+	mkdirCmd := exec.Command("ssh", host, fmt.Sprintf("mkdir -p %s", shellQuote(worktree)))
+	if out, err := mkdirCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("creating remote dir: %w: %s", err, string(out))
+	}
+
+	// Sync worktree contents
+	rsyncCmd := exec.Command("rsync", "-az", "--delete", worktree+"/", fmt.Sprintf("%s:%s/", host, worktree))
+	if out, err := rsyncCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("rsync to sandbox: %w: %s", err, string(out))
+	}
+
+	return nil
+}
+
+func buildSandboxPaneCommand(host, worktree, claudeCmd, logFile, selfBin, finalizePrefix, id string, noWatch bool) string {
+	autoWatch := ""
+	if !noWatch {
+		autoWatch = fmt.Sprintf("; %s%s _auto-watch %s", finalizePrefix, selfBin, shellQuote(id))
+	}
+	// Run claude on sandbox via SSH, pipe output locally through tee + formatter,
+	// then finalize locally, rsync results back, and optionally auto-watch.
+	rsyncBack := fmt.Sprintf("rsync -az %s:%s/ %s/",
+		shellQuote(host), shellQuote(worktree), shellQuote(worktree))
+	return fmt.Sprintf(
+		"%sssh %s 'cd %s && %s' | tee %s | %s _format-stream; %s%s _finalize %s; %s%s",
+		tmuxSessionEnvPrefix(),
+		shellQuote(host),
+		shellQuote(worktree),
+		claudeCmd,
+		shellQuote(logFile),
+		selfBin,
+		finalizePrefix,
+		selfBin,
+		shellQuote(id),
+		rsyncBack,
+		autoWatch,
+	)
+}
+
 func init() {
 	launchCmd.Flags().String("issue", "", "GitHub issue number to reference")
 	launchCmd.Flags().String("pr", "", "Push fixes to an existing PR's branch instead of creating a new PR")
 	launchCmd.Flags().String("budget", "", "Max spend in USD (default from config)")
 	launchCmd.Flags().String("repo", "", "Target repo: registered project name, owner/repo, or full URL")
 	launchCmd.Flags().Bool("no-watch", false, "Don't auto-launch a watch agent when a PR is created")
+	launchCmd.Flags().Bool("local", false, "Force local execution even when sandbox is configured")
+	launchCmd.Flags().String("host", "", "Override sandbox host (ignores config sandbox_host)")
 	rootCmd.AddCommand(launchCmd)
 }

--- a/internal/cmd/launch_test.go
+++ b/internal/cmd/launch_test.go
@@ -414,6 +414,86 @@ func TestResolveRepoTarget_NilRegistry(t *testing.T) {
 	}
 }
 
+func TestBuildSandboxPaneCommand(t *testing.T) {
+	host := "klaus-worker-0"
+	worktree := "/tmp/klaus-sessions/repo/abc123"
+	claudeCmd := "claude -p 'do stuff'"
+	logFile := "/tmp/logs/abc123.jsonl"
+	selfBin := "klaus"
+	id := "20260328-1915-e4b3"
+
+	t.Run("wraps claude in SSH", func(t *testing.T) {
+		t.Setenv(sessionIDEnv, "")
+		cmd := buildSandboxPaneCommand(host, worktree, claudeCmd, logFile, selfBin, "", id, false)
+		if !strings.Contains(cmd, "ssh 'klaus-worker-0'") {
+			t.Error("expected ssh to sandbox host, got:", cmd)
+		}
+		if !strings.Contains(cmd, "cd '/tmp/klaus-sessions/repo/abc123'") {
+			t.Error("expected cd to worktree on remote, got:", cmd)
+		}
+	})
+
+	t.Run("tee and format run locally", func(t *testing.T) {
+		t.Setenv(sessionIDEnv, "")
+		cmd := buildSandboxPaneCommand(host, worktree, claudeCmd, logFile, selfBin, "", id, true)
+		if !strings.Contains(cmd, "| tee") {
+			t.Error("expected tee in local pipeline, got:", cmd)
+		}
+		if !strings.Contains(cmd, "_format-stream") {
+			t.Error("expected _format-stream in local pipeline, got:", cmd)
+		}
+		if !strings.Contains(cmd, "_finalize") {
+			t.Error("expected _finalize in local pipeline, got:", cmd)
+		}
+	})
+
+	t.Run("rsyncs results back after finalize", func(t *testing.T) {
+		t.Setenv(sessionIDEnv, "")
+		cmd := buildSandboxPaneCommand(host, worktree, claudeCmd, logFile, selfBin, "", id, true)
+		if !strings.Contains(cmd, "rsync -az") {
+			t.Error("expected rsync back in command, got:", cmd)
+		}
+		// rsync should reference host:worktree/ -> worktree/
+		if !strings.Contains(cmd, "'klaus-worker-0':'/tmp/klaus-sessions/repo/abc123'/") {
+			t.Error("expected rsync from host:worktree, got:", cmd)
+		}
+	})
+
+	t.Run("includes auto-watch by default", func(t *testing.T) {
+		t.Setenv(sessionIDEnv, "")
+		cmd := buildSandboxPaneCommand(host, worktree, claudeCmd, logFile, selfBin, "", id, false)
+		if !strings.Contains(cmd, "_auto-watch") {
+			t.Error("expected _auto-watch in sandbox command, got:", cmd)
+		}
+	})
+
+	t.Run("no-watch excludes auto-watch", func(t *testing.T) {
+		t.Setenv(sessionIDEnv, "")
+		cmd := buildSandboxPaneCommand(host, worktree, claudeCmd, logFile, selfBin, "", id, true)
+		if strings.Contains(cmd, "_auto-watch") {
+			t.Error("expected no _auto-watch with noWatch=true, got:", cmd)
+		}
+	})
+}
+
+func TestLaunchCmdHasSandboxFlags(t *testing.T) {
+	f := launchCmd.Flags().Lookup("local")
+	if f == nil {
+		t.Fatal("expected --local flag to be registered on launch command")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("--local default value should be 'false', got %q", f.DefValue)
+	}
+
+	h := launchCmd.Flags().Lookup("host")
+	if h == nil {
+		t.Fatal("expected --host flag to be registered on launch command")
+	}
+	if h.DefValue != "" {
+		t.Errorf("--host default value should be empty, got %q", h.DefValue)
+	}
+}
+
 func TestLaunchCmdHasPRFlag(t *testing.T) {
 	// Verify the --pr flag is registered on the launch command
 	f := launchCmd.Flags().Lookup("pr")

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -26,10 +26,10 @@ var statusCmd = &cobra.Command{
 			return nil
 		}
 
-		fmt.Fprintf(os.Stdout, "%-22s  %-10s  %-8s  %-6s  %-20s  %-6s  %-10s  %-10s  %-10s  %s\n",
-			"RUN ID", "STATUS", "COST", "ISSUE", "REPO", "PR", "CI", "CONFLICTS", "MERGE", "PROMPT")
-		fmt.Fprintf(os.Stdout, "%-22s  %-10s  %-8s  %-6s  %-20s  %-6s  %-10s  %-10s  %-10s  %s\n",
-			"------", "------", "----", "-----", "----", "--", "--", "---------", "-----", "------")
+		fmt.Fprintf(os.Stdout, "%-22s  %-10s  %-8s  %-6s  %-20s  %-15s  %-6s  %-10s  %-10s  %-10s  %s\n",
+			"RUN ID", "STATUS", "COST", "ISSUE", "REPO", "HOST", "PR", "CI", "CONFLICTS", "MERGE", "PROMPT")
+		fmt.Fprintf(os.Stdout, "%-22s  %-10s  %-8s  %-6s  %-20s  %-15s  %-6s  %-10s  %-10s  %-10s  %s\n",
+			"------", "------", "----", "-----", "----", "----", "--", "--", "---------", "-----", "------")
 
 		for _, s := range states {
 			status := determineStatus(s)
@@ -41,6 +41,10 @@ var statusCmd = &cobra.Command{
 			repo := "-"
 			if s.TargetRepo != nil {
 				repo = truncate(*s.TargetRepo, 20)
+			}
+			host := "-"
+			if s.Host != nil {
+				host = *s.Host
 			}
 			pr := formatPR(s)
 			prompt := truncate(s.Prompt, 40)
@@ -61,8 +65,8 @@ var statusCmd = &cobra.Command{
 				}
 			}
 
-			fmt.Fprintf(os.Stdout, "%-22s  %-10s  %-8s  %-6s  %-20s  %-6s  %-10s  %-10s  %-10s  %s\n",
-				s.ID, status, cost, issue, repo, pr, ci, conflicts, merge, prompt)
+			fmt.Fprintf(os.Stdout, "%-22s  %-10s  %-8s  %-6s  %-20s  %-15s  %-6s  %-10s  %-10s  %-10s  %s\n",
+				s.ID, status, cost, issue, repo, host, pr, ci, conflicts, merge, prompt)
 		}
 
 		return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	RequireApproval     *bool            `json:"require_approval,omitempty"`
 	AutoMergeOnApproval *bool            `json:"auto_merge_on_approval,omitempty"`
 	PreReview           *PreReviewConfig `json:"pre_review,omitempty"`
+	SandboxHost         string           `json:"sandbox_host,omitempty"`
 }
 
 // PreReviewConfig configures the pre-PR review checks.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -776,6 +776,30 @@ func TestAutoMergesOnApprovalExplicit(t *testing.T) {
 	}
 }
 
+func TestLoadSandboxHostConfig(t *testing.T) {
+	dir := t.TempDir()
+	klausDir := filepath.Join(dir, ".klaus")
+	os.MkdirAll(klausDir, 0o755)
+
+	os.WriteFile(filepath.Join(klausDir, "config.json"),
+		[]byte(`{"sandbox_host": "klaus-worker-0"}`), 0o644)
+
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.SandboxHost != "klaus-worker-0" {
+		t.Errorf("SandboxHost = %q, want %q", cfg.SandboxHost, "klaus-worker-0")
+	}
+}
+
+func TestSandboxHostDefaultEmpty(t *testing.T) {
+	cfg := Defaults()
+	if cfg.SandboxHost != "" {
+		t.Errorf("SandboxHost default should be empty, got %q", cfg.SandboxHost)
+	}
+}
+
 func TestLoadApprovalConfig(t *testing.T) {
 	dir := t.TempDir()
 	klausDir := filepath.Join(dir, ".klaus")

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -25,6 +25,7 @@ type State struct {
 	Type       string   `json:"type,omitempty"`
 	TargetRepo *string  `json:"target_repo,omitempty"`
 	CloneDir   *string  `json:"clone_dir,omitempty"`
+	Host           *string  `json:"host,omitempty"`
 	MergedAt       *string  `json:"merged_at,omitempty"`
 	DashboardPane  *string  `json:"dashboard_pane,omitempty"`
 	Approved       *bool    `json:"approved,omitempty"`


### PR DESCRIPTION
## Summary
- Adds `sandbox_host` config field and `Host` run state field for tracking remote execution
- Implements SSH-based remote agent execution with rsync worktree sync (pre-launch and post-completion)
- Auto-falls back to local execution when sandbox is unreachable
- Adds `--local` and `--host` flags to `klaus launch` for execution control
- Dashboard shows `[sandbox]` tags on remote agents and sandbox reachability in header
- Status command includes a HOST column

## Test plan
- [x] Config loading with `sandbox_host` field
- [x] Host field JSON round-trip in run.State
- [x] Dashboard rendering with sandbox agents (Host set)
- [x] renderBareAgentLine with and without Host
- [x] renderAgentSubline with Host
- [x] sandboxTag function
- [x] renderSandboxStatus function
- [x] Sandbox pane command builder produces correct SSH-wrapped commands
- [x] --local and --host flags registered correctly
- [x] All existing tests pass (`go test ./...`)

Run: 20260328-1915-e4b3