### PR TITLE
fix: update vendor hash after sandbox dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
           pname = "klaus";
           inherit version;
           src = ./.;
-          vendorHash = "sha256-QEmX66Gurv5iozyzrdA5Re6ZKPl+TXpZF3BFngMNfJY=";
+          vendorHash = "sha256-cTLSz2wqFC0yJ9madAn3oDR6zhgfnqTTluBWHpJk+F8=";
           ldflags = [ "-X" "github.com/patflynn/klaus/internal/cmd.version=${version}" ];
           nativeBuildInputs = [ pkgs.git ];
         };


### PR DESCRIPTION
## Summary
- Update `vendorHash` in `flake.nix` after PR #123 added `golang.org/x/crypto` for SSH support
- Fixes `nix build` / NixOS rebuild failures due to hash mismatch

## Test plan
- [ ] `nix build` succeeds