### PR TITLE
Install commit-msg hook to strip Claude/Anthropic attribution

### DIFF
--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -214,6 +214,10 @@ are synced back after completion. Use --local to force local execution, or
 			fmt.Fprintf(os.Stderr, "warning: could not write .claude/settings.json: %v\n", err)
 		}
 
+		if err := git.InstallCommitMsgHook(worktree); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not install commit-msg hook: %v\n", err)
+		}
+
 		// Set up Nix dev environment if flake.nix exists
 		nix.SetupDevEnvironment(worktree)
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -231,6 +231,52 @@ func PushDataRef(repoDir, dataRef string) error {
 	return err
 }
 
+// commitMsgHookScript is a git commit-msg hook that strips Co-Authored-By
+// trailers referencing Claude or Anthropic, and removes AI attribution lines
+// from commit messages. Legitimate human co-author lines are preserved.
+const commitMsgHookScript = `#!/bin/sh
+# Installed by klaus — strips Claude/Anthropic attribution from commit messages.
+sed -i.bak \
+  -e '/^Co-[Aa]uthored-[Bb]y:.*[Cc]laude/d' \
+  -e '/^Co-[Aa]uthored-[Bb]y:.*[Aa]nthropic/d' \
+  -e '/^[Gg]enerated.*[Cc]laude/d' \
+  -e '/^[Gg]enerated.*[Aa]nthropic/d' \
+  -e '/🤖.*[Cc]laude/d' \
+  "$1"
+rm -f "$1.bak"
+`
+
+// InstallCommitMsgHook installs a commit-msg hook in the given worktree that
+// strips Claude/Anthropic attribution from commit messages.
+func InstallCommitMsgHook(worktreeDir string) error {
+	// Find the git dir for this worktree
+	gitDir, err := runGit(worktreeDir, "rev-parse", "--git-dir")
+	if err != nil {
+		return fmt.Errorf("finding git dir: %w", err)
+	}
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(worktreeDir, gitDir)
+	}
+
+	hooksDir := filepath.Join(gitDir, "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		return fmt.Errorf("creating hooks dir: %w", err)
+	}
+
+	hookPath := filepath.Join(hooksDir, "commit-msg")
+	if err := os.WriteFile(hookPath, []byte(commitMsgHookScript), 0o755); err != nil {
+		return fmt.Errorf("writing commit-msg hook: %w", err)
+	}
+
+	// Worktrees use the main repo's hooks by default. Point this worktree
+	// at its own hooks directory so our commit-msg hook actually runs.
+	if _, err := runGit(worktreeDir, "config", "core.hooksPath", hooksDir); err != nil {
+		return fmt.Errorf("setting core.hooksPath: %w", err)
+	}
+
+	return nil
+}
+
 // runGit executes a git command and returns trimmed stdout.
 func runGit(dir string, args ...string) (string, error) {
 	cmd := exec.Command("git", args...)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -366,6 +367,163 @@ func TestParseRepoRefSSH(t *testing.T) {
 	want := "git@github.com:patflynn/cosmo.git"
 	if url != want {
 		t.Errorf("url = %q, want %q", url, want)
+	}
+}
+
+func TestInstallCommitMsgHook_StripsClaudeAttribution(t *testing.T) {
+	repo := initTestRepo(t)
+	wtPath := filepath.Join(t.TempDir(), "wt-hook")
+
+	if err := WorktreeAdd(repo, wtPath, "hook-test", "main"); err != nil {
+		t.Fatalf("WorktreeAdd: %v", err)
+	}
+	defer WorktreeRemove(repo, wtPath)
+
+	if err := InstallCommitMsgHook(wtPath); err != nil {
+		t.Fatalf("InstallCommitMsgHook: %v", err)
+	}
+
+	// Create a file and commit with a Co-Authored-By trailer
+	if err := os.WriteFile(filepath.Join(wtPath, "file.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, args := range [][]string{
+		{"git", "-C", wtPath, "add", "file.txt"},
+		{"git", "-C", wtPath, "commit", "-m", "add file\n\nCo-Authored-By: Claude Sonnet 4 <noreply@anthropic.com>"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+
+	// Verify the Co-Authored-By line was stripped
+	msg, err := runGit(wtPath, "log", "-1", "--format=%B")
+	if err != nil {
+		t.Fatalf("git log: %v", err)
+	}
+	if strings.Contains(msg, "Co-Authored-By") {
+		t.Errorf("commit message should not contain Co-Authored-By, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "add file") {
+		t.Errorf("commit message should still contain the original message, got:\n%s", msg)
+	}
+}
+
+func TestInstallCommitMsgHook_PreservesHumanCoAuthor(t *testing.T) {
+	repo := initTestRepo(t)
+	wtPath := filepath.Join(t.TempDir(), "wt-hook-human")
+
+	if err := WorktreeAdd(repo, wtPath, "hook-human-test", "main"); err != nil {
+		t.Fatalf("WorktreeAdd: %v", err)
+	}
+	defer WorktreeRemove(repo, wtPath)
+
+	if err := InstallCommitMsgHook(wtPath); err != nil {
+		t.Fatalf("InstallCommitMsgHook: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(wtPath, "file.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, args := range [][]string{
+		{"git", "-C", wtPath, "add", "file.txt"},
+		{"git", "-C", wtPath, "commit", "-m", "add file\n\nCo-Authored-By: Alice Smith <alice@example.com>"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+
+	msg, err := runGit(wtPath, "log", "-1", "--format=%B")
+	if err != nil {
+		t.Fatalf("git log: %v", err)
+	}
+	if !strings.Contains(msg, "Co-Authored-By: Alice Smith") {
+		t.Errorf("commit message should preserve human Co-Authored-By, got:\n%s", msg)
+	}
+}
+
+func TestInstallCommitMsgHook_NoTrailerUnchanged(t *testing.T) {
+	repo := initTestRepo(t)
+	wtPath := filepath.Join(t.TempDir(), "wt-hook-clean")
+
+	if err := WorktreeAdd(repo, wtPath, "hook-clean-test", "main"); err != nil {
+		t.Fatalf("WorktreeAdd: %v", err)
+	}
+	defer WorktreeRemove(repo, wtPath)
+
+	if err := InstallCommitMsgHook(wtPath); err != nil {
+		t.Fatalf("InstallCommitMsgHook: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(wtPath, "file.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, args := range [][]string{
+		{"git", "-C", wtPath, "add", "file.txt"},
+		{"git", "-C", wtPath, "commit", "-m", "just a normal commit message"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+
+	msg, err := runGit(wtPath, "log", "-1", "--format=%B")
+	if err != nil {
+		t.Fatalf("git log: %v", err)
+	}
+	if !strings.Contains(msg, "just a normal commit message") {
+		t.Errorf("commit message should be unchanged, got:\n%s", msg)
+	}
+}
+
+func TestInstallCommitMsgHook_StripsMultiplePatterns(t *testing.T) {
+	repo := initTestRepo(t)
+	wtPath := filepath.Join(t.TempDir(), "wt-hook-multi")
+
+	if err := WorktreeAdd(repo, wtPath, "hook-multi-test", "main"); err != nil {
+		t.Fatalf("WorktreeAdd: %v", err)
+	}
+	defer WorktreeRemove(repo, wtPath)
+
+	if err := InstallCommitMsgHook(wtPath); err != nil {
+		t.Fatalf("InstallCommitMsgHook: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(wtPath, "file.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	commitMsg := "fix bug\n\nCo-Authored-By: Claude Opus 4 (1M context) <noreply@anthropic.com>\n🤖 Generated with Claude Code"
+
+	for _, args := range [][]string{
+		{"git", "-C", wtPath, "add", "file.txt"},
+		{"git", "-C", wtPath, "commit", "-m", commitMsg},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+
+	msg, err := runGit(wtPath, "log", "-1", "--format=%B")
+	if err != nil {
+		t.Fatalf("git log: %v", err)
+	}
+	if strings.Contains(msg, "Co-Authored-By") {
+		t.Errorf("should strip Co-Authored-By, got:\n%s", msg)
+	}
+	if strings.Contains(msg, "Claude") {
+		t.Errorf("should strip Claude references, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "fix bug") {
+		t.Errorf("should preserve original message, got:\n%s", msg)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Installs a `commit-msg` git hook in every agent worktree that strips `Co-Authored-By` trailers referencing Claude or Anthropic, plus other AI attribution lines (emoji badges, "Generated with" lines)
- Uses `core.hooksPath` to ensure the hook runs in git worktrees (which otherwise inherit hooks from the main repo)
- Human co-author trailers are preserved unchanged

## Changes
- `internal/git/git.go`: Added `InstallCommitMsgHook()` function with sed-based commit-msg hook script
- `internal/cmd/launch.go`: Call `InstallCommitMsgHook()` during worktree setup for all agent types
- `internal/git/git_test.go`: 4 integration tests covering stripping, preservation of human trailers, no-op on clean messages, and multi-pattern stripping

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` — all tests pass
- [x] Integration tests verify hook strips Claude/Anthropic Co-Authored-By trailers
- [x] Integration tests verify human Co-Authored-By lines are preserved
- [x] Integration tests verify commits without trailers are unaffected

Run: 20260401-1521-a098