### PR TITLE
feat: add 'klaus track' and 'klaus untrack' commands

### DIFF
--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -81,6 +81,13 @@ func determineStatus(s *run.State) string {
 		return "ended"
 	}
 
+	if s.Type == "track" {
+		if s.MergedAt != nil {
+			return "merged"
+		}
+		return "tracking"
+	}
+
 	if s.TmuxPane != nil && tmux.PaneExists(*s.TmuxPane) {
 		return "running"
 	}

--- a/internal/cmd/track.go
+++ b/internal/cmd/track.go
@@ -1,0 +1,201 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/patflynn/klaus/internal/project"
+	"github.com/patflynn/klaus/internal/run"
+	"github.com/spf13/cobra"
+)
+
+var trackCmd = &cobra.Command{
+	Use:   "track <pr-ref> [<pr-ref>...]",
+	Short: "Track existing PRs on the dashboard",
+	Long: `Adds existing PRs to the klaus dashboard for monitoring.
+
+Accepts PR numbers, full GitHub PR URLs, or owner/repo#number references.
+Use --repo to specify the repository when using bare PR numbers.
+
+Examples:
+  klaus track 405                              # uses session target repo
+  klaus track 405 --repo cosmo                 # explicit repo
+  klaus track https://github.com/org/repo/pull/405
+  klaus track 405 406 407                      # multiple PRs`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		repoFlag, _ := cmd.Flags().GetString("repo")
+
+		store, err := sessionStore()
+		if err != nil {
+			return err
+		}
+		if err := store.EnsureDirs(); err != nil {
+			return err
+		}
+
+		// Load existing states to check for duplicates
+		existingStates, err := store.List()
+		if err != nil {
+			return err
+		}
+
+		// Resolve repo context for bare PR numbers
+		resolvedRepo := resolveTrackRepo(repoFlag)
+
+		for _, ref := range args {
+			if err := trackPR(ref, resolvedRepo, store, existingStates); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: %s: %v\n", ref, err)
+			}
+		}
+		return nil
+	},
+}
+
+// ownerRepoPRPattern matches owner/repo#number references.
+var ownerRepoPRPattern = regexp.MustCompile(`^([^/]+/[^#]+)#(\d+)$`)
+
+// parsePRRef parses a PR reference into (repo, prNumber) where repo may be empty.
+// Supported formats:
+//   - "405" → ("", "405")
+//   - "https://github.com/org/repo/pull/405" → ("org/repo", "405")
+//   - "owner/repo#405" → ("owner/repo", "405")
+func parsePRRef(ref string) (repo, prNumber string, err error) {
+	// Full GitHub URL
+	if strings.HasPrefix(ref, "https://github.com/") {
+		// https://github.com/owner/repo/pull/123
+		trimmed := strings.TrimPrefix(ref, "https://github.com/")
+		parts := strings.Split(trimmed, "/")
+		if len(parts) >= 4 && parts[2] == "pull" {
+			return parts[0] + "/" + parts[1], parts[3], nil
+		}
+		return "", "", fmt.Errorf("invalid GitHub PR URL: %s", ref)
+	}
+
+	// owner/repo#number
+	if m := ownerRepoPRPattern.FindStringSubmatch(ref); m != nil {
+		return m[1], m[2], nil
+	}
+
+	// Bare number
+	for _, c := range ref {
+		if c < '0' || c > '9' {
+			return "", "", fmt.Errorf("invalid PR reference: %s", ref)
+		}
+	}
+	if ref == "" {
+		return "", "", fmt.Errorf("empty PR reference")
+	}
+	return "", ref, nil
+}
+
+// resolveTrackRepo determines which repo to use for bare PR numbers.
+// Priority: --repo flag > session target.
+func resolveTrackRepo(repoFlag string) string {
+	if repoFlag != "" {
+		return repoFlag
+	}
+	// Try session target
+	if s, storeErr := sessionStore(); storeErr == nil {
+		if hds, ok := s.(*run.HomeDirStore); ok {
+			if target, loadErr := run.LoadTarget(hds.BaseDir()); loadErr == nil && target != "" {
+				return target
+			}
+		}
+	}
+	return ""
+}
+
+// trackPR tracks a single PR reference.
+func trackPR(ref, defaultRepo string, store run.StateStore, existingStates []*run.State) error {
+	repo, prNumber, err := parsePRRef(ref)
+	if err != nil {
+		return err
+	}
+
+	// If no repo from the reference, use the default
+	if repo == "" {
+		repo = defaultRepo
+	}
+	if repo == "" {
+		return fmt.Errorf("no repo specified for PR #%s — use --repo or set a session target", prNumber)
+	}
+
+	// Fetch PR metadata from GitHub
+	prURL, title, headBranch, state, err := fetchPRMetadata(prNumber, repo)
+	if err != nil {
+		return fmt.Errorf("fetching PR #%s metadata: %w", prNumber, err)
+	}
+
+	// Check for duplicates
+	for _, s := range existingStates {
+		if s.PRURL != nil && *s.PRURL == prURL {
+			fmt.Printf("Already tracking PR #%s (%s)\n", prNumber, repo)
+			return nil
+		}
+	}
+
+	// Warn if PR is closed/merged
+	if strings.EqualFold(state, "MERGED") || strings.EqualFold(state, "CLOSED") {
+		fmt.Fprintf(os.Stderr, "warning: PR #%s is %s\n", prNumber, strings.ToLower(state))
+	}
+
+	// Normalize repo name
+	reg, _ := project.Load()
+	normalizedRepo := project.NormalizeRepoName(repo, reg)
+
+	id, err := run.GenID()
+	if err != nil {
+		return err
+	}
+
+	st := &run.State{
+		ID:         id,
+		Prompt:     title,
+		Branch:     headBranch,
+		PRURL:      &prURL,
+		Type:       "track",
+		TargetRepo: &normalizedRepo,
+		CreatedAt:  time.Now().Format(time.RFC3339),
+	}
+
+	if err := store.Save(st); err != nil {
+		return fmt.Errorf("saving state: %w", err)
+	}
+
+	fmt.Printf("Tracking PR #%s (%s) — %s\n", prNumber, normalizedRepo, title)
+	return nil
+}
+
+// fetchPRMetadata fetches PR URL, title, head branch, and state from GitHub via gh CLI.
+func fetchPRMetadata(prNumber, repo string) (prURL, title, headBranch, state string, err error) {
+	args := []string{
+		"pr", "view", prNumber,
+		"--repo", repo,
+		"--json", "url,title,headRefName,state",
+		"-q", `(.url) + "\t" + (.title) + "\t" + (.headRefName) + "\t" + (.state)`,
+	}
+	cmd := exec.Command("gh", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", "", "", "", fmt.Errorf("gh pr view: %s", strings.TrimSpace(stderr.String()))
+	}
+
+	parts := strings.SplitN(strings.TrimSpace(stdout.String()), "\t", 4)
+	if len(parts) < 4 {
+		return "", "", "", "", fmt.Errorf("unexpected gh output: %s", stdout.String())
+	}
+	return parts[0], parts[1], parts[2], parts[3], nil
+}
+
+func init() {
+	trackCmd.Flags().String("repo", "", "Target repo: registered project name, owner/repo, or full URL")
+	rootCmd.AddCommand(trackCmd)
+}

--- a/internal/cmd/track_test.go
+++ b/internal/cmd/track_test.go
@@ -1,0 +1,247 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/patflynn/klaus/internal/run"
+)
+
+func TestParsePRRef(t *testing.T) {
+	tests := []struct {
+		name     string
+		ref      string
+		wantRepo string
+		wantPR   string
+		wantErr  bool
+	}{
+		{"bare number", "405", "", "405", false},
+		{"full URL", "https://github.com/org/repo/pull/405", "org/repo", "405", false},
+		{"owner/repo#number", "owner/repo#123", "owner/repo", "123", false},
+		{"invalid ref", "not-a-pr", "", "", true},
+		{"empty ref", "", "", "", true},
+		{"bad URL", "https://github.com/bad", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, pr, err := parsePRRef(tt.ref)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parsePRRef(%q) error = %v, wantErr %v", tt.ref, err, tt.wantErr)
+				return
+			}
+			if repo != tt.wantRepo {
+				t.Errorf("parsePRRef(%q) repo = %q, want %q", tt.ref, repo, tt.wantRepo)
+			}
+			if pr != tt.wantPR {
+				t.Errorf("parsePRRef(%q) pr = %q, want %q", tt.ref, pr, tt.wantPR)
+			}
+		})
+	}
+}
+
+func TestTrackCreateState(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := run.NewHomeDirStoreFromPath(tmpDir)
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+
+	// Simulate what trackPR does (without calling gh CLI)
+	prURL := "https://github.com/owner/repo/pull/42"
+	title := "Fix the widget"
+	repo := "owner/repo"
+
+	id, err := run.GenID()
+	if err != nil {
+		t.Fatalf("GenID: %v", err)
+	}
+
+	st := &run.State{
+		ID:         id,
+		Prompt:     title,
+		Branch:     "fix-widget",
+		PRURL:      &prURL,
+		Type:       "track",
+		TargetRepo: &repo,
+		CreatedAt:  "2026-04-01T00:00:00Z",
+	}
+	if err := store.Save(st); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Verify the state was saved correctly
+	loaded, err := store.Load(id)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.Type != "track" {
+		t.Errorf("Type = %q, want %q", loaded.Type, "track")
+	}
+	if loaded.PRURL == nil || *loaded.PRURL != prURL {
+		t.Errorf("PRURL = %v, want %q", loaded.PRURL, prURL)
+	}
+	if loaded.Prompt != title {
+		t.Errorf("Prompt = %q, want %q", loaded.Prompt, title)
+	}
+	if loaded.Branch != "fix-widget" {
+		t.Errorf("Branch = %q, want %q", loaded.Branch, "fix-widget")
+	}
+	if loaded.TargetRepo == nil || *loaded.TargetRepo != repo {
+		t.Errorf("TargetRepo = %v, want %q", loaded.TargetRepo, repo)
+	}
+	if loaded.Worktree != "" {
+		t.Errorf("Worktree = %q, want empty", loaded.Worktree)
+	}
+}
+
+func TestTrackDuplicateDetection(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := run.NewHomeDirStoreFromPath(tmpDir)
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+
+	prURL := "https://github.com/owner/repo/pull/42"
+	existing := &run.State{
+		ID:        "20260401-0000-aaaa",
+		Prompt:    "existing PR",
+		Branch:    "fix-it",
+		PRURL:     &prURL,
+		Type:      "track",
+		CreatedAt: "2026-04-01T00:00:00Z",
+	}
+	if err := store.Save(existing); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	states, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	// Check that the duplicate detection logic works
+	isDuplicate := false
+	for _, s := range states {
+		if s.PRURL != nil && *s.PRURL == prURL {
+			isDuplicate = true
+			break
+		}
+	}
+	if !isDuplicate {
+		t.Error("should detect duplicate PRURL")
+	}
+}
+
+func TestUntrackOnlyRemovesTrackedType(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := run.NewHomeDirStoreFromPath(tmpDir)
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+
+	prURL42 := "https://github.com/owner/repo/pull/42"
+	prURL99 := "https://github.com/owner/repo/pull/99"
+
+	// Agent-created state (Type is empty, not "track")
+	agentState := &run.State{
+		ID:        "20260401-0000-aaaa",
+		Prompt:    "agent work",
+		Branch:    "agent/branch",
+		PRURL:     &prURL42,
+		Type:      "agent",
+		CreatedAt: "2026-04-01T00:00:00Z",
+	}
+	// Tracked state
+	trackedState := &run.State{
+		ID:        "20260401-0000-bbbb",
+		Prompt:    "tracked PR",
+		Branch:    "fix-it",
+		PRURL:     &prURL99,
+		Type:      "track",
+		CreatedAt: "2026-04-01T00:01:00Z",
+	}
+	for _, s := range []*run.State{agentState, trackedState} {
+		if err := store.Save(s); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+	}
+
+	states, _ := store.List()
+
+	// Try to untrack PR #42 (agent-created) — should not find it
+	found := false
+	for _, s := range states {
+		if s.Type != "track" {
+			continue
+		}
+		if extractPRNumber(s) == "42" {
+			found = true
+		}
+	}
+	if found {
+		t.Error("should not find agent-created PR #42 as a tracked PR")
+	}
+
+	// Untrack PR #99 (tracked) — should find it
+	found = false
+	for _, s := range states {
+		if s.Type != "track" {
+			continue
+		}
+		if extractPRNumber(s) == "99" {
+			found = true
+			if err := store.Delete(s.ID); err != nil {
+				t.Fatalf("Delete: %v", err)
+			}
+		}
+	}
+	if !found {
+		t.Error("should find tracked PR #99")
+	}
+
+	// Verify agent state still exists
+	remaining, _ := store.List()
+	if len(remaining) != 1 {
+		t.Errorf("expected 1 remaining state, got %d", len(remaining))
+	}
+	if remaining[0].ID != "20260401-0000-aaaa" {
+		t.Errorf("remaining state should be agent state, got %s", remaining[0].ID)
+	}
+}
+
+func TestDetermineStatusTrack(t *testing.T) {
+	tests := []struct {
+		name string
+		s    *run.State
+		want string
+	}{
+		{
+			name: "tracked PR returns tracking",
+			s:    &run.State{Type: "track", PRURL: strPtr("https://github.com/owner/repo/pull/1")},
+			want: "tracking",
+		},
+		{
+			name: "tracked PR with merged returns merged",
+			s: &run.State{
+				Type:     "track",
+				PRURL:    strPtr("https://github.com/owner/repo/pull/1"),
+				MergedAt: strPtr("2026-04-01T00:00:00Z"),
+			},
+			want: "merged",
+		},
+		{
+			name: "tracked PR no PRURL returns tracking",
+			s:    &run.State{Type: "track"},
+			want: "tracking",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := determineStatus(tt.s)
+			if got != tt.want {
+				t.Errorf("determineStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/untrack.go
+++ b/internal/cmd/untrack.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var untrackCmd = &cobra.Command{
+	Use:   "untrack <pr-number> [<pr-number>...]",
+	Short: "Stop tracking PRs on the dashboard",
+	Long: `Removes tracked PRs from the klaus dashboard. Only removes PRs that were
+added via 'klaus track' — agent-created runs are never removed.`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		store, err := sessionStore()
+		if err != nil {
+			return err
+		}
+
+		states, err := store.List()
+		if err != nil {
+			return err
+		}
+
+		for _, prNum := range args {
+			prNum = strings.TrimPrefix(prNum, "#")
+			found := false
+			for _, s := range states {
+				if s.Type != "track" {
+					continue
+				}
+				if extractPRNumber(s) == prNum {
+					if err := store.Delete(s.ID); err != nil {
+						fmt.Fprintf(os.Stderr, "warning: failed to remove PR #%s: %v\n", prNum, err)
+					} else {
+						fmt.Printf("Stopped tracking PR #%s\n", prNum)
+					}
+					found = true
+					break
+				}
+			}
+			if !found {
+				fmt.Fprintf(os.Stderr, "warning: no tracked PR #%s found\n", prNum)
+			}
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(untrackCmd)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -353,6 +353,8 @@ that confirms expired tokens are rejected. See issue #42 for the user report."
 - ` + "`klaus target [owner/repo | project-name]`" + ` — get/set default target repo
 - ` + "`klaus approve <pr-number> [...]`" + ` — approve PRs for merging
 - ` + "`klaus merge <pr-number> [...]`" + ` — merge PRs sequentially
+- ` + "`klaus track <pr-number> [--repo <repo>]`" + ` — track existing PRs on the dashboard
+- ` + "`klaus untrack <pr-number>`" + ` — stop tracking a PR
 - ` + "`klaus dashboard`" + ` — open live dashboard
 {{if .Projects}}
 ## Registered projects


### PR DESCRIPTION
## Summary
- Add `klaus track` command to add existing PRs to the dashboard for monitoring (accepts PR numbers, URLs, or owner/repo#number)
- Add `klaus untrack` command to remove tracked PRs (only removes Type='track' states, never agent-created ones)
- Update `determineStatus()` to show tracked PRs as 'tracking' instead of 'exited'
- Update coordinator session prompt to document the new commands

## Test plan
- [x] `TestParsePRRef` — validates all PR reference formats (bare number, URL, owner/repo#number)
- [x] `TestTrackCreateState` — verifies state file fields (Type='track', PRURL set, empty Worktree)
- [x] `TestTrackDuplicateDetection` — confirms duplicate PRURL detection works
- [x] `TestUntrackOnlyRemovesTrackedType` — ensures agent-created states are never removed
- [x] `TestDetermineStatusTrack` — validates 'tracking' and 'merged' status for tracked PRs
- [x] Full test suite passes (`go test ./...`)
- [x] `go vet ./...` clean

Run: 20260401-1550-adfa