### PR TITLE
feat: dispatch review fix agents for trusted reviewer comments

### DIFF
--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -79,11 +79,12 @@ type errMsg struct {
 
 // prStatus holds the GitHub-fetched status for a single PR.
 type prStatus struct {
-	PRNumber       string
-	State          string // OPEN, MERGED, CLOSED
-	CI             string // passing, failing, pending, unknown
-	Conflicts      string // yes, none, unknown
-	ReviewDecision string // APPROVED, CHANGES_REQUESTED, etc.
+	PRNumber              string
+	State                 string // OPEN, MERGED, CLOSED
+	CI                    string // passing, failing, pending, unknown
+	Conflicts             string // yes, none, unknown
+	ReviewDecision        string // APPROVED, CHANGES_REQUESTED, etc.
+	HasNewTrustedComments bool   // unaddressed comments from trusted reviewers
 }
 
 // repoGroup is a set of runs and PRs belonging to the same repository.
@@ -164,11 +165,12 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		pStatuses := make(map[string]*pipeline.PRStatus, len(msg.statuses))
 		for k, v := range msg.statuses {
 			ps := &pipeline.PRStatus{
-				PRNumber:       v.PRNumber,
-				State:          v.State,
-				CI:             v.CI,
-				Conflicts:      v.Conflicts,
-				ReviewDecision: v.ReviewDecision,
+				PRNumber:              v.PRNumber,
+				State:                 v.State,
+				CI:                    v.CI,
+				Conflicts:             v.Conflicts,
+				ReviewDecision:        v.ReviewDecision,
+				HasNewTrustedComments: v.HasNewTrustedComments,
 			}
 			// Find the PR URL and target repo from run states.
 			for _, s := range m.states {
@@ -547,6 +549,16 @@ func fetchPRStatus(prNumber, prRef string) *prStatus {
 	ps.CI = getPRCI(prRef)
 	ps.Conflicts = getPRConflicts(prRef)
 	ps.ReviewDecision = getPRReviewDecision(prRef)
+
+	// When reviewDecision is not CHANGES_REQUESTED, check for unaddressed
+	// trusted reviewer comments that GitHub doesn't reflect in reviewDecision.
+	if !strings.EqualFold(ps.ReviewDecision, "CHANGES_REQUESTED") &&
+		!strings.EqualFold(ps.ReviewDecision, "APPROVED") {
+		ownerRepo := ownerRepoFromPRURL(prRef)
+		if ownerRepo != "" {
+			ps.HasNewTrustedComments = hasUnaddressedTrustedComments(ownerRepo, prNumber)
+		}
+	}
 	return ps
 }
 

--- a/internal/cmd/review_check.go
+++ b/internal/cmd/review_check.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/patflynn/klaus/internal/config"
+)
+
+// ownerRepoFromPRURL extracts "owner/repo" from a full GitHub PR URL.
+func ownerRepoFromPRURL(prURL string) string {
+	prURL = strings.TrimPrefix(prURL, "https://github.com/")
+	prURL = strings.TrimPrefix(prURL, "http://github.com/")
+	parts := strings.Split(prURL, "/")
+	if len(parts) >= 2 {
+		return parts[0] + "/" + parts[1]
+	}
+	return ""
+}
+
+// ghReview represents a single review from the GitHub API.
+type ghReview struct {
+	User        ghUser `json:"user"`
+	State       string `json:"state"`
+	SubmittedAt string `json:"submitted_at"`
+}
+
+type ghUser struct {
+	Login string `json:"login"`
+}
+
+// ghCommit represents a commit from the GitHub pulls commits API.
+type ghCommit struct {
+	Commit ghCommitDetail `json:"commit"`
+}
+
+type ghCommitDetail struct {
+	Author ghCommitAuthor `json:"author"`
+}
+
+type ghCommitAuthor struct {
+	Date string `json:"date"`
+}
+
+// hasUnaddressedTrustedComments checks whether a PR has review comments from
+// trusted reviewers that haven't been addressed by a subsequent push.
+func hasUnaddressedTrustedComments(ownerRepo, prNumber string) bool {
+	cfg, err := config.Load("")
+	if err != nil || len(cfg.TrustedReviewers) == 0 {
+		return false
+	}
+
+	trustedSet := make(map[string]bool, len(cfg.TrustedReviewers))
+	for _, r := range cfg.TrustedReviewers {
+		trustedSet[r] = true
+	}
+
+	// Fetch reviews.
+	reviews := fetchPRReviews(ownerRepo, prNumber)
+	if len(reviews) == 0 {
+		return false
+	}
+
+	// Find the most recent trusted reviewer review with state COMMENTED or CHANGES_REQUESTED.
+	var latestTrustedReviewTime time.Time
+	for _, r := range reviews {
+		if !trustedSet[r.User.Login] {
+			continue
+		}
+		state := strings.ToUpper(r.State)
+		if state != "COMMENTED" && state != "CHANGES_REQUESTED" {
+			continue
+		}
+		t, err := time.Parse(time.RFC3339, r.SubmittedAt)
+		if err != nil {
+			continue
+		}
+		if t.After(latestTrustedReviewTime) {
+			latestTrustedReviewTime = t
+		}
+	}
+
+	if latestTrustedReviewTime.IsZero() {
+		return false
+	}
+
+	// Fetch the latest commit timestamp.
+	latestCommitTime := fetchLatestCommitTime(ownerRepo, prNumber)
+	if latestCommitTime.IsZero() {
+		// Can't determine commit time; assume comments are unaddressed.
+		return true
+	}
+
+	// Comments are unaddressed if the latest trusted review is after the latest commit.
+	return latestTrustedReviewTime.After(latestCommitTime)
+}
+
+// fetchPRReviews calls gh api to get reviews for a PR.
+func fetchPRReviews(ownerRepo, prNumber string) []ghReview {
+	endpoint := "repos/" + ownerRepo + "/pulls/" + prNumber + "/reviews"
+	cmd := exec.Command("gh", "api", endpoint)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+	var reviews []ghReview
+	if err := json.Unmarshal(out, &reviews); err != nil {
+		return nil
+	}
+	return reviews
+}
+
+// fetchLatestCommitTime calls gh api to get the latest commit time on a PR.
+func fetchLatestCommitTime(ownerRepo, prNumber string) time.Time {
+	endpoint := "repos/" + ownerRepo + "/pulls/" + prNumber + "/commits"
+	cmd := exec.Command("gh", "api", endpoint)
+	out, err := cmd.Output()
+	if err != nil {
+		return time.Time{}
+	}
+	var commits []ghCommit
+	if err := json.Unmarshal(out, &commits); err != nil {
+		return time.Time{}
+	}
+	var latest time.Time
+	for _, c := range commits {
+		t, err := time.Parse(time.RFC3339, c.Commit.Author.Date)
+		if err != nil {
+			continue
+		}
+		if t.After(latest) {
+			latest = t
+		}
+	}
+	return latest
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -30,13 +30,14 @@ const (
 
 // PRStatus holds the GitHub-fetched status for a single PR, passed from the dashboard.
 type PRStatus struct {
-	PRNumber       string
-	PRURL          string
-	State          string // OPEN, MERGED, CLOSED
-	CI             string // passing, failing, pending, unknown
-	Conflicts      string // yes, none, unknown
-	ReviewDecision string // APPROVED, CHANGES_REQUESTED, etc.
-	TargetRepo     string // owner/repo for dispatch context
+	PRNumber               string
+	PRURL                  string
+	State                  string // OPEN, MERGED, CLOSED
+	CI                     string // passing, failing, pending, unknown
+	Conflicts              string // yes, none, unknown
+	ReviewDecision         string // APPROVED, CHANGES_REQUESTED, etc.
+	TargetRepo             string // owner/repo for dispatch context
+	HasNewTrustedComments  bool   // unaddressed comments from trusted reviewers
 }
 
 // PRPipelineState tracks per-PR pipeline state.
@@ -275,8 +276,25 @@ func (c *Controller) evaluate(ctx context.Context, ps *PRPipelineState, status *
 				actions = append(actions, Action{Type: "launch", Detail: fmt.Sprintf("Review fix agent for PR #%s", ps.PRNumber)})
 			}
 		} else {
-			// CI passed, waiting for review.
-			if ps.Stage != StageApproved && ps.Stage != StageMerging {
+			// CI passed, no explicit CHANGES_REQUESTED or APPROVED.
+			if status.HasNewTrustedComments && !ps.AgentRunning {
+				// Trusted reviewer left unaddressed comments — dispatch fix agent.
+				prompt := fmt.Sprintf(
+					"PR #%s in %s has review comments from a trusted reviewer that need to be addressed. Check the review comments with: gh api repos/%s/pulls/%s/comments",
+					ps.PRNumber, status.TargetRepo, status.TargetRepo, ps.PRNumber,
+				)
+				agentID, err := c.launchAgent(ctx, ps.PRNumber, status.TargetRepo, prompt)
+				if err != nil {
+					c.logger.Error("failed to dispatch trusted review fix agent", "pr", ps.PRNumber, "err", err)
+					ps.Stage = StageStalled
+					return actions
+				}
+				ps.LastAgentID = agentID
+				ps.AgentRunning = true
+				ps.Stage = StageReviewPending
+				actions = append(actions, Action{Type: "launch", Detail: fmt.Sprintf("Review fix agent for PR #%s (trusted reviewer)", ps.PRNumber)})
+			} else if ps.Stage != StageApproved && ps.Stage != StageMerging && !ps.AgentRunning {
+				// Waiting for review.
 				ps.Stage = StageCIPassed
 				c.emitEvent(ps.PRNumber, event.PRAwaitingApproval, map[string]interface{}{
 					"pr_number": ps.PRNumber,

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -427,6 +427,109 @@ func TestReviewFixLaunchRetry(t *testing.T) {
 	}
 }
 
+func TestTrustedCommentDispatch(t *testing.T) {
+	c, _ := newTestController(t)
+
+	var launchedPrompt string
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+		launchedPrompt = prompt
+		return "agent-trusted", nil
+	})
+
+	statuses := map[string]*PRStatus{
+		"42": {
+			PRNumber:              "42",
+			State:                 "OPEN",
+			CI:                    "passing",
+			ReviewDecision:        "", // empty — not CHANGES_REQUESTED
+			HasNewTrustedComments: true,
+			TargetRepo:            "owner/repo",
+		},
+	}
+
+	actions := c.HandleGHStatus(context.Background(), statuses, nil)
+
+	if launchedPrompt == "" {
+		t.Error("expected agent dispatch for trusted reviewer comments")
+	}
+	if len(actions) != 1 || actions[0].Type != "launch" {
+		t.Errorf("expected 1 launch action, got %v", actions)
+	}
+
+	states := c.PipelineStates()
+	if states["42"].Stage != StageReviewPending {
+		t.Errorf("expected stage review_pending, got %s", states["42"].Stage)
+	}
+}
+
+func TestNoDispatchWithoutTrustedComments(t *testing.T) {
+	c, _ := newTestController(t)
+
+	launchCount := 0
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+		launchCount++
+		return "agent-001", nil
+	})
+
+	statuses := map[string]*PRStatus{
+		"42": {
+			PRNumber:              "42",
+			State:                 "OPEN",
+			CI:                    "passing",
+			ReviewDecision:        "",
+			HasNewTrustedComments: false,
+			TargetRepo:            "owner/repo",
+		},
+	}
+
+	c.HandleGHStatus(context.Background(), statuses, nil)
+
+	if launchCount != 0 {
+		t.Errorf("expected no agent dispatch without trusted comments, got %d launches", launchCount)
+	}
+
+	states := c.PipelineStates()
+	if states["42"].Stage != StageCIPassed {
+		t.Errorf("expected stage ci_passed, got %s", states["42"].Stage)
+	}
+}
+
+func TestNoDoubleDispatchOnTrustedComments(t *testing.T) {
+	c, _ := newTestController(t)
+
+	launchCount := 0
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+		launchCount++
+		return "agent-trusted", nil
+	})
+
+	statuses := map[string]*PRStatus{
+		"42": {
+			PRNumber:              "42",
+			State:                 "OPEN",
+			CI:                    "passing",
+			ReviewDecision:        "",
+			HasNewTrustedComments: true,
+			TargetRepo:            "owner/repo",
+		},
+	}
+
+	// First call dispatches.
+	c.HandleGHStatus(context.Background(), statuses, nil)
+	if launchCount != 1 {
+		t.Fatalf("expected 1 launch, got %d", launchCount)
+	}
+
+	// Simulate agent still running.
+	runStates := []*run.State{
+		{ID: "agent-trusted", TmuxPane: strPtr("%1")},
+	}
+	c.HandleGHStatus(context.Background(), statuses, runStates)
+	if launchCount != 1 {
+		t.Errorf("expected no duplicate launch while agent running, got %d total", launchCount)
+	}
+}
+
 func strPtr(s string) *string {
 	return &s
 }


### PR DESCRIPTION
## Summary
- The pipeline controller only dispatched review fix agents when GitHub's `reviewDecision` was `CHANGES_REQUESTED`, but trusted reviewers like `gemini-code-assist[bot]` submit reviews with state `COMMENTED` which left their feedback silently ignored
- Added detection of unaddressed trusted reviewer comments by fetching PR reviews via `gh api` and comparing review timestamps against the latest commit timestamp
- When unaddressed trusted reviewer comments are found and CI is passing, a review fix agent is now dispatched (same flow as `CHANGES_REQUESTED`)

## Changes
- **`internal/pipeline/pipeline.go`**: Added `HasNewTrustedComments` to `PRStatus`; updated `evaluate()` else branch to dispatch fix agent when trusted comments exist
- **`internal/cmd/dashboard.go`**: Added `HasNewTrustedComments` to `prStatus`; extended `fetchPRStatus()` to check for trusted reviewer comments; passed field through to pipeline
- **`internal/cmd/review_check.go`** (new): Helper functions to fetch PR reviews and commits via `gh api`, determine if trusted reviewer comments are unaddressed by comparing timestamps
- **`internal/pipeline/pipeline_test.go`**: Three new tests — dispatch on trusted comments, no dispatch without them, no double dispatch when agent already running

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (including 3 new pipeline tests)
- [x] `go vet ./...` clean
- [x] `klaus _pre-review` passes
- [ ] Manual verification: PR with gemini-code-assist[bot] COMMENTED review triggers fix agent
- [ ] Manual verification: existing CHANGES_REQUESTED flow still works unchanged

Run: 20260401-1557-254c