### PR TITLE
feat: fetch all refs before creating agent worktree

### DIFF
--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -155,9 +155,13 @@ are synced back after completion. Use --local to force local execution, or
 
 		worktree := filepath.Join(hostCfg.WorktreeBase, repoName, id)
 
-		// Fetch all refs from origin so the worktree starts from latest state
-		if err := git.FetchAll(repoRoot); err != nil {
-			return fmt.Errorf("fetching origin: %w", err)
+		// Fetch all refs so the worktree starts from the latest state.
+		// Skip when EnsureClone was already called — it fetches with the
+		// same flags (--prune --tags), so a second fetch is redundant.
+		if repoRef == "" || projectLocalPath != "" {
+			if err := git.FetchAll(repoRoot); err != nil {
+				return fmt.Errorf("fetching origin: %w", err)
+			}
 		}
 
 		// When --pr is set, track the PR's branch instead of creating a new one

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -30,9 +30,9 @@ func CommonDir() (string, error) {
 	return abs, nil
 }
 
-// FetchAll fetches all refs from origin, pruning deleted remote branches.
+// FetchAll fetches all branches and tags from origin, pruning deleted remote branches.
 func FetchAll(repoDir string) error {
-	_, err := runGit(repoDir, "fetch", "origin", "--prune", "--quiet")
+	_, err := runGit(repoDir, "fetch", "origin", "--prune", "--tags", "--quiet")
 	return err
 }
 
@@ -219,7 +219,7 @@ func ParseRepoRef(ref string) (owner, repo, cloneURL string, err error) {
 // If it already exists, fetches the latest from origin.
 func EnsureClone(cloneURL, destDir string) error {
 	if _, err := os.Stat(filepath.Join(destDir, ".git")); err == nil {
-		_, fetchErr := runGit(destDir, "fetch", "origin", "--quiet")
+		_, fetchErr := runGit(destDir, "fetch", "origin", "--prune", "--tags", "--quiet")
 		return fetchErr
 	}
 


### PR DESCRIPTION
## Summary
- Add `FetchAll` function to `internal/git/git.go` that runs `git fetch origin --prune --quiet`
- Replace per-branch `FetchBranch` calls in `launch.go` with a single `FetchAll` call before the PR/new-branch branching logic
- Ensures agents always start from the latest upstream state with all tags and branches

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `klaus _pre-review` passes with no issues

Run: 20260401-1630-6305