### PR TITLE
feat: show klaus approval status in dashboard PR lines

### DIFF
--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -344,7 +344,7 @@ func (m dashboardModel) renderGroup(g repoGroup) string {
 		if len(agents) == 0 {
 			continue
 		}
-		b.WriteString(m.renderPRLine(prNum, agents[0], g.PRMap[prNum]))
+		b.WriteString(m.renderPRLine(prNum, agents, g.PRMap[prNum]))
 		b.WriteString("\n")
 		for _, s := range agents {
 			if isAgentRunning(s) {
@@ -363,7 +363,8 @@ func (m dashboardModel) renderGroup(g repoGroup) string {
 	return b.String()
 }
 
-func (m dashboardModel) renderPRLine(prNum string, s *run.State, ps *prStatus) string {
+func (m dashboardModel) renderPRLine(prNum string, agents []*run.State, ps *prStatus) string {
+	s := agents[0]
 	prLabel := fmt.Sprintf("  #%-5s", prNum)
 	prompt := truncate(s.Prompt, 20)
 
@@ -390,12 +391,28 @@ func (m dashboardModel) renderPRLine(prNum string, s *run.State, ps *prStatus) s
 		}
 	}
 
+	// Show klaus-internal approval if any run for this PR is approved.
+	if state == "OPEN" && isAnyRunApproved(agents) {
+		parts = append(parts, cyanStyle.Render("✓ approved"))
+	}
+
 	// Append pipeline stage if available.
 	if pps, ok := m.pipelineStates[prNum]; ok {
 		parts = append(parts, dimStyle.Render(pipeline.StageLabel(pps.Stage)))
 	}
 
 	return fmt.Sprintf("%s  %-20s  %s", prLabel, prompt, strings.Join(parts, "  "))
+}
+
+// isAnyRunApproved returns true if any of the given run states has been
+// approved via `klaus approve`.
+func isAnyRunApproved(states []*run.State) bool {
+	for _, s := range states {
+		if s.Approved != nil && *s.Approved {
+			return true
+		}
+	}
+	return false
 }
 
 func renderAgentSubline(s *run.State) string {
@@ -723,6 +740,7 @@ var (
 	redStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
 	yellowStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
 	dimStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	cyanStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
 	sandboxStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
 )
 

--- a/internal/cmd/dashboard_test.go
+++ b/internal/cmd/dashboard_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/patflynn/klaus/internal/pipeline"
 	"github.com/patflynn/klaus/internal/project"
 	"github.com/patflynn/klaus/internal/run"
 )
@@ -512,7 +513,7 @@ func TestRenderPRLine(t *testing.T) {
 	}
 
 	// Without GitHub status
-	line := m.renderPRLine("42", s, nil)
+	line := m.renderPRLine("42", []*run.State{s},nil)
 	if !strings.Contains(line, "#42") {
 		t.Error("should contain PR number")
 	}
@@ -530,7 +531,7 @@ func TestRenderPRLine(t *testing.T) {
 		CI:        "passing",
 		Conflicts: "yes",
 	}
-	line = m.renderPRLine("42", s, ps)
+	line = m.renderPRLine("42", []*run.State{s},ps)
 	if !strings.Contains(line, "CI ✓") {
 		t.Error("should show passing CI")
 	}
@@ -540,9 +541,55 @@ func TestRenderPRLine(t *testing.T) {
 
 	// Merged PR
 	ps.State = "MERGED"
-	line = m.renderPRLine("42", s, ps)
+	line = m.renderPRLine("42", []*run.State{s}, ps)
 	if !strings.Contains(line, "MERGED") {
 		t.Error("should show MERGED")
+	}
+}
+
+func TestRenderPRLineApproval(t *testing.T) {
+	m := dashboardModel{
+		width:          80,
+		pipelineStates: map[string]*pipeline.PRPipelineState{},
+	}
+
+	approved := true
+	notApproved := false
+
+	base := &run.State{
+		ID:     "run-1",
+		Prompt: "fix bug",
+		Branch: "fix-bug",
+		Type:   "launch",
+		PRURL:  strPtr("https://github.com/o/r/pull/10"),
+	}
+
+	// No approval — should not show indicator
+	line := m.renderPRLine("10", []*run.State{base}, &prStatus{State: "OPEN"})
+	if strings.Contains(line, "approved") {
+		t.Error("should not show approved when not approved")
+	}
+
+	// Single run approved
+	approvedRun := *base
+	approvedRun.Approved = &approved
+	line = m.renderPRLine("10", []*run.State{&approvedRun}, &prStatus{State: "OPEN"})
+	if !strings.Contains(line, "approved") {
+		t.Error("should show approved indicator")
+	}
+
+	// Multiple runs, only second is approved
+	notApprovedRun := *base
+	notApprovedRun.Approved = &notApproved
+	line = m.renderPRLine("10", []*run.State{&notApprovedRun, &approvedRun}, &prStatus{State: "OPEN"})
+	if !strings.Contains(line, "approved") {
+		t.Error("should show approved when any run is approved")
+	}
+
+	// Approved but MERGED — should not show indicator
+	line = m.renderPRLine("10", []*run.State{&approvedRun}, &prStatus{State: "MERGED"})
+	if strings.Contains(line, "approved") {
+		t.Error("should not show approved for merged PRs")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Dashboard `renderPRLine()` now displays a cyan "✓ approved" indicator when any run for a PR has been approved via `klaus approve`
- Changed `renderPRLine` to accept all run states for a PR, so approval is detected even when multiple runs (e.g. fix agents) reference the same PR
- Indicator is visually distinct from GitHub's review status ("ready") and only shown for OPEN PRs

## Test plan
- [x] Added `TestRenderPRLineApproval` covering: no approval, single approved run, multiple runs with mixed approval, merged PR suppression
- [x] `go test ./...` passes
- [x] `go build ./...` passes

Run: 20260401-1645-ba47