### PR TITLE
fix: improve subagent cleanup logic and unify agent status detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Binaries
+klaus
+
+# Nix / Direnv
+.direnv/
+result
+
+# Logs
+*.log
+*.jsonl
+
+# State
+.session/
+.runs/
+
+# macOS
+.DS_Store

--- a/internal/cmd/cleanup.go
+++ b/internal/cmd/cleanup.go
@@ -66,18 +66,20 @@ func cleanupAll(root string, store run.StateStore, force bool) error {
 	return nil
 }
 
-// isRunActive reports whether the run has a live tmux pane or is the current session.
+// isRunActive reports whether the run has a live, non-idle tmux pane or is the current session.
 var isRunActive = func(state *run.State) bool {
-	if state.TmuxPane != nil && tmux.PaneExists(*state.TmuxPane) {
-		return true
-	}
-	if state.DashboardPane != nil && tmux.PaneExists(*state.DashboardPane) {
-		return true
-	}
 	if state.Type == "session" {
 		if sid := os.Getenv(sessionIDEnv); sid != "" && state.ID == sid {
 			return true
 		}
+	}
+
+	if state.IsAgentRunning() {
+		return true
+	}
+
+	if state.DashboardPane != nil && tmux.PaneExists(*state.DashboardPane) {
+		return true
 	}
 	return false
 }

--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -746,16 +746,7 @@ func computeSessionDuration(states []*run.State) time.Duration {
 
 // isAgentRunning checks if a run's agent is currently active in tmux.
 func isAgentRunning(s *run.State) bool {
-	if s.TmuxPane == nil {
-		return false
-	}
-	// Check if the pane still exists by stat'ing the worktree as a proxy.
-	// In production, we use tmux.PaneExists, but for testability we check
-	// whether cost/duration have been set (finalized agents have these set).
-	if s.CostUSD != nil || s.DurationMS != nil {
-		return false
-	}
-	return true
+	return s.IsAgentRunning()
 }
 
 // agentStatusLabel returns a display label for a non-running agent.

--- a/internal/cmd/dashboard_test.go
+++ b/internal/cmd/dashboard_test.go
@@ -13,6 +13,19 @@ import (
 	"github.com/patflynn/klaus/internal/run"
 )
 
+func init() {
+	// Mock tmux functions in run package for tests.
+	run.PaneExists = func(paneID string) bool {
+		return strings.HasPrefix(paneID, "%")
+	}
+	run.PaneIsIdle = func(paneID string) bool {
+		return true
+	}
+	run.PaneIsDead = func(paneID string) bool {
+		return false
+	}
+}
+
 func TestGroupByRepo(t *testing.T) {
 	states := []*run.State{
 		{ID: "1", TargetRepo: strPtr("owner/repoA"), Type: "launch"},

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -233,15 +233,12 @@ func waitForAgents(store run.StateStore) {
 
 		var stillActive []*run.State
 		for _, s := range active {
-			if !tmux.PaneExists(*s.TmuxPane) {
-				fmt.Printf("  agent %s finished\n", s.ID)
-				continue
+			// Reload state to check for finalized cost/duration
+			if updated, err := store.Load(s.ID); err == nil {
+				s = updated
 			}
 
-			// Check if the pane's command has completed. An idle pane
-			// means the agent's pipeline has finished and the pane is
-			// either dead or left at a shell prompt.
-			if tmux.PaneIsIdle(*s.TmuxPane) {
+			if !s.IsAgentRunning() {
 				fmt.Printf("  agent %s finished, closing pane\n", s.ID)
 				tmux.KillPane(*s.TmuxPane)
 				continue

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -387,27 +387,12 @@ func (c *Controller) cleanupStaleWorktrees(prNumber string, runStates []*run.Sta
 // defaultCleanIdlePanes kills tmux panes for agent runs whose processes have finished.
 func (c *Controller) defaultCleanIdlePanes(runStates []*run.State) {
 	for _, s := range runStates {
-		if s.TmuxPane == nil {
+		if s.TmuxPane == nil || !tmux.PaneExists(*s.TmuxPane) {
 			continue
 		}
-		// Only check runs that still appear active (no finalized cost/duration).
-		if s.CostUSD != nil || s.DurationMS != nil {
-			continue
-		}
-		// Grace period: skip runs created less than 2 minutes ago. Newly
-		// launched panes briefly show a shell as the foreground process
-		// while the command pipeline starts up, which PaneIsIdle would
-		// misidentify as idle.
-		if created, err := time.Parse(time.RFC3339, s.CreatedAt); err == nil {
-			if time.Since(created) < 2*time.Minute {
-				continue
-			}
-		}
-		if !tmux.PaneExists(*s.TmuxPane) {
-			continue
-		}
-		if tmux.PaneIsIdle(*s.TmuxPane) {
-			c.logger.Info("closing idle agent pane", "run", s.ID, "pane", *s.TmuxPane)
+
+		if !s.IsAgentRunning() {
+			c.logger.Info("closing completed agent pane", "run", s.ID, "pane", *s.TmuxPane)
 			tmux.KillPane(*s.TmuxPane)
 		}
 	}

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -610,21 +610,22 @@ func TestIdlePaneCleanupDuringPoll(t *testing.T) {
 	}
 }
 
-func TestIdlePaneCleanupSkipsFinalized(t *testing.T) {
+func TestIdlePaneCleanupHandlesFinalized(t *testing.T) {
 	c, _ := newTestController(t)
 
 	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
 		return "agent-001", nil
 	})
 
-	var cleanupCalled bool
+	var cleanedUpDone bool
 	c.SetCleanIdlePanes(func(runStates []*run.State) {
 		for _, s := range runStates {
-			if s.TmuxPane == nil || s.CostUSD != nil || s.DurationMS != nil {
+			if s.TmuxPane == nil {
 				continue
 			}
-			// No non-finalized runs should reach here.
-			cleanupCalled = true
+			if s.ID == "agent-done" && (s.CostUSD != nil || s.DurationMS != nil) {
+				cleanedUpDone = true
+			}
 		}
 	})
 
@@ -639,12 +640,12 @@ func TestIdlePaneCleanupSkipsFinalized(t *testing.T) {
 
 	c.HandleGHStatus(context.Background(), statuses, runStates)
 
-	if cleanupCalled {
-		t.Error("cleanup should skip finalized runs")
+	if !cleanedUpDone {
+		t.Error("cleanup should now handle finalized runs")
 	}
 }
 
-func TestIdlePaneCleanupSkipsRecentRuns(t *testing.T) {
+func TestIdlePaneCleanupDoesNotSkipRecentRuns(t *testing.T) {
 	c, _ := newTestController(t)
 
 	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
@@ -655,14 +656,8 @@ func TestIdlePaneCleanupSkipsRecentRuns(t *testing.T) {
 	var checkedRuns []string
 	c.SetCleanIdlePanes(func(runStates []*run.State) {
 		for _, s := range runStates {
-			if s.TmuxPane == nil || s.CostUSD != nil || s.DurationMS != nil {
+			if s.TmuxPane == nil {
 				continue
-			}
-			// Grace period: skip runs created less than 2 minutes ago.
-			if created, err := time.Parse(time.RFC3339, s.CreatedAt); err == nil {
-				if time.Since(created) < 2*time.Minute {
-					continue
-				}
 			}
 			checkedRuns = append(checkedRuns, s.ID)
 		}
@@ -673,16 +668,14 @@ func TestIdlePaneCleanupSkipsRecentRuns(t *testing.T) {
 	}
 
 	recentTime := time.Now().Add(-30 * time.Second).Format(time.RFC3339)
-	oldTime := time.Now().Add(-5 * time.Minute).Format(time.RFC3339)
 	runStates := []*run.State{
-		{ID: "agent-new", TmuxPane: strPtr("%new"), CreatedAt: recentTime},  // recent, should be skipped
-		{ID: "agent-old", TmuxPane: strPtr("%old"), CreatedAt: oldTime},     // old, should be checked
+		{ID: "agent-new", TmuxPane: strPtr("%new"), CreatedAt: recentTime},
 	}
 
 	c.HandleGHStatus(context.Background(), statuses, runStates)
 
-	if len(checkedRuns) != 1 || checkedRuns[0] != "agent-old" {
-		t.Errorf("expected only agent-old to be checked, got %v", checkedRuns)
+	if len(checkedRuns) != 1 || checkedRuns[0] != "agent-new" {
+		t.Errorf("expected agent-new to be checked, got %v", checkedRuns)
 	}
 }
 

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -5,6 +5,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"time"
+
+	"github.com/patflynn/klaus/internal/tmux"
 )
 
 // State represents the persistent state of a single agent run.
@@ -30,6 +32,30 @@ type State struct {
 	DashboardPane  *string  `json:"dashboard_pane,omitempty"`
 	Approved       *bool    `json:"approved,omitempty"`
 	ApprovedAt     *string  `json:"approved_at,omitempty"`
+}
+
+// Tmux dependency injection for testing.
+var (
+	PaneExists = tmux.PaneExists
+	PaneIsIdle = tmux.PaneIsIdle
+	PaneIsDead = tmux.PaneIsDead
+)
+
+// IsAgentRunning checks if the agent's tmux pane is still active and
+// executing its command pipeline.
+func (s *State) IsAgentRunning() bool {
+	if s.TmuxPane == nil || !PaneExists(*s.TmuxPane) {
+		return false
+	}
+
+	// Finalized runs (cost/duration set) are running only if their pane
+	// is not idle (e.g. still showing output before the user closes it).
+	if s.CostUSD != nil || s.DurationMS != nil {
+		return !PaneIsIdle(*s.TmuxPane)
+	}
+
+	// Active (unfinalized) runs are running unless the pane is explicitly dead.
+	return !PaneIsDead(*s.TmuxPane)
 }
 
 // GenID generates a run ID in the format YYYYMMDD-HHMM-XXXX where XXXX is 4 hex chars.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -134,21 +134,27 @@ func RenameWindow(target, name string) error {
 	return err
 }
 
+// PaneIsDead checks if a tmux pane's command has exited.
+// Only returns true when remain-on-exit is set and the process is gone.
+func PaneIsDead(paneID string) bool {
+	out, err := runTmux("display-message", "-t", paneID, "-p", "#{pane_dead}")
+	return err == nil && strings.TrimSpace(out) == "1"
+}
+
 // PaneIsIdle checks if a tmux pane's command has finished running.
 // Returns true when the pane is dead (command exited) or the only
 // running foreground process is a shell — which indicates the
-// command pipeline has completed.
+// command pipeline has likely completed. Note that this may return
+// true for active agents that are currently executing shell scripts.
 func PaneIsIdle(paneID string) bool {
-	// Check if the pane is marked dead (command exited, remain-on-exit set)
-	out, err := runTmux("display-message", "-t", paneID, "-p", "#{pane_dead}")
-	if err == nil && strings.TrimSpace(out) == "1" {
+	if PaneIsDead(paneID) {
 		return true
 	}
 
 	// Check the current foreground command in the pane. While the agent's
 	// command pipeline is active, pane_current_command will be "claude",
 	// "tee", "klaus", etc. Once finished, only the shell remains.
-	out, err = runTmux("display-message", "-t", paneID, "-p", "#{pane_current_command}")
+	out, err := runTmux("display-message", "-t", paneID, "-p", "#{pane_current_command}")
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
This PR fixes the issue where completed subagents were not being properly cleaned up, and active agents were sometimes prematurely killed.

Key changes:
- Unified agent status detection in .
- Added  to check for explicitly exited processes.
- Updated  to clean up finalized runs when idle and only kill active runs if dead.
- Removed the 2-minute grace period hack.
- Refactored dashboard and cleanup commands to use the new unified status logic.
- Added test mocks for tmux functions in the  package.