### PR TITLE
feat: conflict detection and auto-rebase in pipeline

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -24,6 +24,7 @@ const (
 	StageCIPassed      Stage = "ci_passed"
 	StageReviewPending Stage = "review_pending"
 	StageApproved      Stage = "approved"
+	StageNeedsRebase   Stage = "needs_rebase"
 	StageMerging       Stage = "merging"
 	StageMerged        Stage = "merged"
 	StageStalled       Stage = "stalled"
@@ -234,7 +235,7 @@ func (c *Controller) evaluate(ctx context.Context, ps *PRPipelineState, status *
 		}
 
 	case status.CI == "passing":
-		if ps.Stage == StageCIFailed || ps.Stage == StageCIPending || ps.Stage == StageReviewPending {
+		if ps.Stage == StageCIFailed || ps.Stage == StageCIPending || ps.Stage == StageReviewPending || ps.Stage == StageNeedsRebase {
 			c.emitEvent(ps.PRNumber, event.AgentCIPassed, map[string]interface{}{
 				"pr_number": ps.PRNumber,
 				"pr_url":    status.PRURL,
@@ -242,7 +243,7 @@ func (c *Controller) evaluate(ctx context.Context, ps *PRPipelineState, status *
 		}
 
 		if strings.EqualFold(status.ReviewDecision, "APPROVED") {
-			if ps.Stage != StageApproved && ps.Stage != StageMerging {
+			if ps.Stage != StageApproved && ps.Stage != StageMerging && ps.Stage != StageNeedsRebase {
 				ps.Stage = StageApproved
 				c.emitEvent(ps.PRNumber, event.PRApproved, map[string]interface{}{
 					"pr_number": ps.PRNumber,
@@ -250,21 +251,46 @@ func (c *Controller) evaluate(ctx context.Context, ps *PRPipelineState, status *
 				})
 			}
 
-			// Auto-merge: CI passing + approved + no conflicts.
-			if status.Conflicts != "yes" && ps.Stage == StageApproved {
-				ps.Stage = StageMerging
-				err := c.mergePRs(ctx, status.TargetRepo, []string{ps.PRNumber})
-				if err != nil {
-					c.logger.Error("auto-merge failed", "pr", ps.PRNumber, "err", err)
-					ps.Stage = StageStalled
-					actions = append(actions, Action{Type: "error", Detail: fmt.Sprintf("PR #%s: auto-merge failed", ps.PRNumber), Error: truncateError(err.Error(), 120)})
+			if ps.Stage == StageApproved || ps.Stage == StageNeedsRebase {
+				if status.Conflicts == "yes" {
+					// Conflicts detected — dispatch rebase agent.
+					if !ps.AgentRunning {
+						c.cleanupStaleWorktrees(ps.PRNumber, runStates)
+						prompt := fmt.Sprintf(
+							"PR #%s has merge conflicts with the base branch. Rebase onto main, resolve all conflicts, and push. Run tests after resolving.",
+							ps.PRNumber,
+						)
+						agentID, err := c.launchAgent(ctx, ps.PRNumber, status.TargetRepo, prompt)
+						if err != nil {
+							c.logger.Error("failed to dispatch rebase agent", "pr", ps.PRNumber, "err", err)
+							if !c.handleLaunchRetry(ps) {
+								ps.Stage = StageStalled
+								return []Action{{Type: "error", Detail: fmt.Sprintf("PR #%s: rebase dispatch failed", ps.PRNumber), Error: truncateError(err.Error(), 120)}}
+							}
+							return actions
+						}
+						ps.RetryCount = 0
+						ps.Stage = StageNeedsRebase
+						ps.LastAgentID = agentID
+						ps.AgentRunning = true
+						actions = append(actions, Action{Type: "launch", Detail: fmt.Sprintf("Rebase agent for PR #%s", ps.PRNumber)})
+					}
 				} else {
-					ps.Stage = StageMerged
-					c.emitEvent(ps.PRNumber, event.PRMerged, map[string]interface{}{
-						"pr_number": ps.PRNumber,
-						"pr_url":    status.PRURL,
-					})
-					actions = append(actions, Action{Type: "merge", Detail: fmt.Sprintf("Merged PR #%s", ps.PRNumber)})
+					// No conflicts — proceed with merge.
+					ps.Stage = StageMerging
+					err := c.mergePRs(ctx, status.TargetRepo, []string{ps.PRNumber})
+					if err != nil {
+						c.logger.Error("auto-merge failed", "pr", ps.PRNumber, "err", err)
+						ps.Stage = StageStalled
+						actions = append(actions, Action{Type: "error", Detail: fmt.Sprintf("PR #%s: auto-merge failed", ps.PRNumber), Error: truncateError(err.Error(), 120)})
+					} else {
+						ps.Stage = StageMerged
+						c.emitEvent(ps.PRNumber, event.PRMerged, map[string]interface{}{
+							"pr_number": ps.PRNumber,
+							"pr_url":    status.PRURL,
+						})
+						actions = append(actions, Action{Type: "merge", Detail: fmt.Sprintf("Merged PR #%s", ps.PRNumber)})
+					}
 				}
 			}
 		} else if strings.EqualFold(status.ReviewDecision, "CHANGES_REQUESTED") {
@@ -497,6 +523,8 @@ func StageLabel(stage Stage) string {
 		return "review fix running"
 	case StageApproved:
 		return "approved, ready"
+	case StageNeedsRebase:
+		return "rebasing"
 	case StageMerging:
 		return "merging"
 	case StageMerged:

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -251,8 +251,11 @@ func TestAutoMergeBlockedByConflicts(t *testing.T) {
 		mergeCount++
 		return nil
 	})
+
+	var launchedPrompt string
 	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
-		return "agent-001", nil
+		launchedPrompt = prompt
+		return "agent-rebase", nil
 	})
 
 	statuses := map[string]*PRStatus{
@@ -262,15 +265,32 @@ func TestAutoMergeBlockedByConflicts(t *testing.T) {
 		},
 	}
 
-	c.HandleGHStatus(context.Background(), statuses, nil)
+	actions := c.HandleGHStatus(context.Background(), statuses, nil)
 
 	if mergeCount != 0 {
 		t.Error("should not merge when conflicts exist")
 	}
 
+	if launchedPrompt == "" {
+		t.Error("expected rebase agent dispatch when conflicts detected")
+	}
+	if !strings.Contains(launchedPrompt, "merge conflicts") {
+		t.Errorf("expected rebase prompt, got %q", launchedPrompt)
+	}
+
+	hasLaunch := false
+	for _, a := range actions {
+		if a.Type == "launch" && strings.Contains(a.Detail, "Rebase") {
+			hasLaunch = true
+		}
+	}
+	if !hasLaunch {
+		t.Errorf("expected rebase launch action, got %v", actions)
+	}
+
 	states := c.PipelineStates()
-	if states["42"].Stage != StageApproved {
-		t.Errorf("expected stage approved (blocked by conflicts), got %s", states["42"].Stage)
+	if states["42"].Stage != StageNeedsRebase {
+		t.Errorf("expected stage needs_rebase, got %s", states["42"].Stage)
 	}
 }
 
@@ -284,6 +304,7 @@ func TestStageLabelCoverage(t *testing.T) {
 		{StageCIPassed, "CI passed, reviewing"},
 		{StageReviewPending, "review fix running"},
 		{StageApproved, "approved, ready"},
+		{StageNeedsRebase, "rebasing"},
 		{StageMerging, "merging"},
 		{StageMerged, "merged"},
 		{StageStalled, "stalled"},
@@ -676,6 +697,233 @@ func TestIdlePaneCleanupDoesNotSkipRecentRuns(t *testing.T) {
 
 	if len(checkedRuns) != 1 || checkedRuns[0] != "agent-new" {
 		t.Errorf("expected agent-new to be checked, got %v", checkedRuns)
+	}
+}
+
+func TestNeedsRebaseTransitionsToMergeAfterConflictsResolved(t *testing.T) {
+	c, _ := newTestController(t)
+
+	launchCount := 0
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+		launchCount++
+		return fmt.Sprintf("agent-%03d", launchCount), nil
+	})
+	mergeCount := 0
+	c.SetMergePRs(func(ctx context.Context, repo string, prNumbers []string) error {
+		mergeCount++
+		return nil
+	})
+
+	// Step 1: Approved with conflicts → dispatches rebase agent.
+	statuses := map[string]*PRStatus{
+		"42": {
+			PRNumber: "42", State: "OPEN", CI: "passing",
+			ReviewDecision: "APPROVED", Conflicts: "yes", TargetRepo: "owner/repo",
+		},
+	}
+	c.HandleGHStatus(context.Background(), statuses, nil)
+
+	if c.PipelineStates()["42"].Stage != StageNeedsRebase {
+		t.Fatalf("expected needs_rebase, got %s", c.PipelineStates()["42"].Stage)
+	}
+	if launchCount != 1 {
+		t.Fatalf("expected 1 launch, got %d", launchCount)
+	}
+
+	// Step 2: Rebase agent completes, CI passes, conflicts resolved → should merge.
+	cost := 1.0
+	runStates := []*run.State{
+		{ID: "agent-001", TmuxPane: strPtr("%1"), CostUSD: &cost}, // completed
+	}
+	statuses["42"] = &PRStatus{
+		PRNumber: "42", State: "OPEN", CI: "passing",
+		ReviewDecision: "APPROVED", Conflicts: "none", TargetRepo: "owner/repo",
+	}
+	actions := c.HandleGHStatus(context.Background(), statuses, runStates)
+
+	hasMerge := false
+	for _, a := range actions {
+		if a.Type == "merge" {
+			hasMerge = true
+		}
+	}
+	if !hasMerge {
+		t.Error("expected merge after rebase resolved conflicts")
+	}
+	if mergeCount != 1 {
+		t.Errorf("expected 1 merge call, got %d", mergeCount)
+	}
+}
+
+func TestNeedsRebaseTransitionsToCIFailedIfCIFails(t *testing.T) {
+	c, _ := newTestController(t)
+
+	launchCount := 0
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+		launchCount++
+		return fmt.Sprintf("agent-%03d", launchCount), nil
+	})
+
+	// Step 1: Approved with conflicts → rebase agent dispatched.
+	statuses := map[string]*PRStatus{
+		"42": {
+			PRNumber: "42", State: "OPEN", CI: "passing",
+			ReviewDecision: "APPROVED", Conflicts: "yes", TargetRepo: "owner/repo",
+		},
+	}
+	c.HandleGHStatus(context.Background(), statuses, nil)
+
+	if c.PipelineStates()["42"].Stage != StageNeedsRebase {
+		t.Fatalf("expected needs_rebase, got %s", c.PipelineStates()["42"].Stage)
+	}
+
+	// Step 2: Rebase agent completes but CI fails.
+	cost := 1.0
+	runStates := []*run.State{
+		{ID: "agent-001", TmuxPane: strPtr("%1"), CostUSD: &cost},
+	}
+	statuses["42"] = &PRStatus{
+		PRNumber: "42", State: "OPEN", CI: "failing", TargetRepo: "owner/repo",
+	}
+	c.HandleGHStatus(context.Background(), statuses, runStates)
+
+	state := c.PipelineStates()["42"]
+	if state.Stage != StageCIFailed {
+		t.Errorf("expected ci_failed after rebase + CI failure, got %s", state.Stage)
+	}
+	// Should have dispatched a CI fix agent (launch 2).
+	if launchCount != 2 {
+		t.Errorf("expected 2 launches (rebase + CI fix), got %d", launchCount)
+	}
+}
+
+func TestNeedsRebaseNoDoubleDispatch(t *testing.T) {
+	c, _ := newTestController(t)
+
+	launchCount := 0
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+		launchCount++
+		return "agent-rebase", nil
+	})
+
+	statuses := map[string]*PRStatus{
+		"42": {
+			PRNumber: "42", State: "OPEN", CI: "passing",
+			ReviewDecision: "APPROVED", Conflicts: "yes", TargetRepo: "owner/repo",
+		},
+	}
+
+	// First call dispatches rebase agent.
+	c.HandleGHStatus(context.Background(), statuses, nil)
+	if launchCount != 1 {
+		t.Fatalf("expected 1 launch, got %d", launchCount)
+	}
+
+	// Agent still running — should not re-dispatch.
+	runStates := []*run.State{
+		{ID: "agent-rebase", TmuxPane: strPtr("%1")},
+	}
+	c.HandleGHStatus(context.Background(), statuses, runStates)
+	if launchCount != 1 {
+		t.Errorf("expected no duplicate rebase dispatch, got %d total", launchCount)
+	}
+}
+
+func TestRebaseDispatchRetryOnFailure(t *testing.T) {
+	c, _ := newTestController(t)
+
+	launchCount := 0
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+		launchCount++
+		return "", fmt.Errorf("worktree already exists")
+	})
+
+	statuses := map[string]*PRStatus{
+		"42": {
+			PRNumber: "42", State: "OPEN", CI: "passing",
+			ReviewDecision: "APPROVED", Conflicts: "yes", TargetRepo: "owner/repo",
+		},
+	}
+
+	// First failure: should retry, not stall.
+	c.HandleGHStatus(context.Background(), statuses, nil)
+	state := c.PipelineStates()["42"]
+	if state.Stage == StageStalled {
+		t.Error("expected retry on first rebase dispatch failure, not stall")
+	}
+
+	// Simulate backoff elapsed.
+	c.mu.Lock()
+	c.prStates["42"].LastFailedAt = time.Now().Add(-2 * time.Minute)
+	c.mu.Unlock()
+
+	// Second failure.
+	c.HandleGHStatus(context.Background(), statuses, nil)
+	state = c.PipelineStates()["42"]
+	if state.Stage == StageStalled {
+		t.Error("expected retry on second failure")
+	}
+
+	// Simulate backoff elapsed.
+	c.mu.Lock()
+	c.prStates["42"].LastFailedAt = time.Now().Add(-2 * time.Minute)
+	c.mu.Unlock()
+
+	// Third failure: should stall.
+	actions := c.HandleGHStatus(context.Background(), statuses, nil)
+	state = c.PipelineStates()["42"]
+	if state.Stage != StageStalled {
+		t.Errorf("expected stalled after retries exhausted, got %s", state.Stage)
+	}
+	hasError := false
+	for _, a := range actions {
+		if a.Type == "error" {
+			hasError = true
+		}
+	}
+	if !hasError {
+		t.Error("expected error action when rebase retries exhausted")
+	}
+}
+
+func TestApprovedNoConflictsMerges(t *testing.T) {
+	c, _ := newTestController(t)
+
+	launchCount := 0
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+		launchCount++
+		return "agent-001", nil
+	})
+	mergeCount := 0
+	c.SetMergePRs(func(ctx context.Context, repo string, prNumbers []string) error {
+		mergeCount++
+		return nil
+	})
+
+	statuses := map[string]*PRStatus{
+		"42": {
+			PRNumber: "42", State: "OPEN", CI: "passing",
+			ReviewDecision: "APPROVED", Conflicts: "none", TargetRepo: "owner/repo",
+		},
+	}
+
+	actions := c.HandleGHStatus(context.Background(), statuses, nil)
+
+	if launchCount != 0 {
+		t.Errorf("expected no agent launch for conflict-free merge, got %d", launchCount)
+	}
+	if mergeCount != 1 {
+		t.Errorf("expected 1 merge, got %d", mergeCount)
+	}
+
+	hasMerge := false
+	for _, a := range actions {
+		if a.Type == "merge" {
+			hasMerge = true
+		}
+	}
+	if !hasMerge {
+		t.Error("expected merge action")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `StageNeedsRebase` pipeline stage for PRs that are approved but have merge conflicts
- When conflicts are detected on an approved PR, dispatches a rebase agent (via `klaus launch`) to rebase onto main, resolve conflicts, and push
- After rebase completes, the pipeline naturally re-evaluates: CI passes → merge, CI fails → CI fix agent
- Includes retry logic with backoff for rebase agent dispatch failures, consistent with other dispatch points

## Test plan
- [x] `TestAutoMergeBlockedByConflicts` — updated: approved PR with conflicts dispatches rebase agent and transitions to `StageNeedsRebase`
- [x] `TestNeedsRebaseTransitionsToMergeAfterConflictsResolved` — rebase completes, conflicts gone → merges
- [x] `TestNeedsRebaseTransitionsToCIFailedIfCIFails` — rebase completes but CI fails → dispatches CI fix agent
- [x] `TestNeedsRebaseNoDoubleDispatch` — no duplicate rebase agent while one is running
- [x] `TestRebaseDispatchRetryOnFailure` — retry limits respected before stalling
- [x] `TestApprovedNoConflictsMerges` — existing conflict-free merge flow unchanged
- [x] `TestStageLabelCoverage` — updated with `StageNeedsRebase` → "rebasing"
- [x] Full test suite: `go test ./...` passes

Run: 20260401-2055-f350
Fixes #130