### PR TITLE
Auto-cleanup agent worktrees on finalize

### DIFF
--- a/internal/cmd/hidden.go
+++ b/internal/cmd/hidden.go
@@ -91,8 +91,37 @@ var finalizeCmd = &cobra.Command{
 		}
 
 		syncRunToDataRef(syncRoot, store, cfg.DataRef, state)
+
+		cleanupWorktree(store, state)
+
 		return nil
 	},
+}
+
+// cleanupWorktree removes the agent's worktree and local branch after
+// completion. The state file and logs are preserved. It is idempotent —
+// if the worktree is already gone, the state is still cleared.
+func cleanupWorktree(store run.StateStore, state *run.State) {
+	if state.Worktree == "" {
+		return
+	}
+	gitRoot := ""
+	if state.CloneDir != nil {
+		gitRoot = *state.CloneDir
+	} else {
+		gitRoot, _ = git.RepoRoot()
+	}
+	if gitRoot == "" {
+		return
+	}
+	if err := git.WorktreeRemove(gitRoot, state.Worktree); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: worktree cleanup: %v\n", err)
+	}
+	if state.Branch != "" {
+		_ = git.BranchDelete(gitRoot, state.Branch)
+	}
+	state.Worktree = ""
+	_ = store.Save(state)
 }
 
 func finalizeFromLog(store run.StateStore, state *run.State) error {

--- a/internal/cmd/hidden_test.go
+++ b/internal/cmd/hidden_test.go
@@ -2,11 +2,114 @@ package cmd
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
 	"github.com/patflynn/klaus/internal/run"
 )
+
+func TestFinalizeWorktreeCleanup(t *testing.T) {
+	t.Run("clears worktree from state after cleanup", func(t *testing.T) {
+		dir := t.TempDir()
+		stateDir := filepath.Join(dir, "runs")
+		if err := os.MkdirAll(stateDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create a real git repo with a worktree so we can verify removal.
+		repoDir := filepath.Join(dir, "repo")
+		initGitRepo(t, repoDir)
+
+		wtPath := filepath.Join(dir, "wt")
+		runGitCmd(t, repoDir, "worktree", "add", wtPath, "-b", "agent/test-branch")
+
+		// Verify worktree exists before cleanup.
+		if _, err := os.Stat(wtPath); err != nil {
+			t.Fatalf("worktree should exist before cleanup: %v", err)
+		}
+
+		state := &run.State{
+			ID:       "test-run",
+			Branch:   "agent/test-branch",
+			Worktree: wtPath,
+			CloneDir: &repoDir,
+		}
+		store := &testStateStore{dir: stateDir, state: state}
+
+		// Simulate the cleanup logic from _finalize.
+		cleanupWorktree(store, state)
+
+		if state.Worktree != "" {
+			t.Errorf("expected Worktree to be cleared, got %q", state.Worktree)
+		}
+		if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+			t.Error("expected worktree directory to be removed")
+		}
+	})
+
+	t.Run("idempotent when worktree already removed", func(t *testing.T) {
+		dir := t.TempDir()
+		stateDir := filepath.Join(dir, "runs")
+		if err := os.MkdirAll(stateDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		repoDir := filepath.Join(dir, "repo")
+		initGitRepo(t, repoDir)
+
+		state := &run.State{
+			ID:       "test-run",
+			Branch:   "agent/gone-branch",
+			Worktree: filepath.Join(dir, "already-gone"),
+			CloneDir: &repoDir,
+		}
+		store := &testStateStore{dir: stateDir, state: state}
+
+		// Should not panic or fail — just clears state.
+		cleanupWorktree(store, state)
+
+		if state.Worktree != "" {
+			t.Errorf("expected Worktree to be cleared, got %q", state.Worktree)
+		}
+	})
+
+	t.Run("no-op when worktree field is empty", func(t *testing.T) {
+		state := &run.State{ID: "test-run", Worktree: ""}
+		store := &testStateStore{state: state}
+
+		cleanupWorktree(store, state)
+
+		if state.Worktree != "" {
+			t.Errorf("expected empty worktree, got %q", state.Worktree)
+		}
+	})
+}
+
+// initGitRepo creates a bare-minimum git repo with one commit.
+func initGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	runGitCmd(t, dir, "init")
+	runGitCmd(t, dir, "commit", "--allow-empty", "-m", "init")
+}
+
+// runGitCmd runs a git command in the given directory.
+func runGitCmd(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}
 
 func TestExtractPRNumberFromURL(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary
- Add worktree and local branch cleanup to the `_finalize` command so agents don't leave stale worktrees after completion
- State files and logs are preserved — only the worktree directory and local branch are removed
- Cleanup is idempotent: already-removed worktrees are handled gracefully with a warning

## Test plan
- [x] Integration test: creates real git repo + worktree, runs cleanup, verifies directory removed and state cleared
- [x] Idempotency test: verifies no failure when worktree is already gone
- [x] No-op test: verifies empty worktree field is handled correctly
- [x] All existing tests pass (`go test ./...`)

Run: 20260401-2056-d422
Fixes #150