### PR TITLE
fix: add dispatch cooldown to prevent duplicate fix agents

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -54,6 +54,7 @@ type PRPipelineState struct {
 	PendingResolveThreadIDs []string  // GraphQL thread IDs to resolve after agent completes
 	RetryCount              int       // number of launch retries after failure
 	LastFailedAt            time.Time // when the last launch failure occurred
+	LastDispatchAt          time.Time // when the last agent was dispatched (cooldown guard)
 }
 
 // Action describes a side-effect the controller wants the dashboard to perform.
@@ -224,6 +225,9 @@ const maxLaunchRetries = 2
 // retryBackoff is the minimum time between launch retries.
 const retryBackoff = 60 * time.Second
 
+// dispatchCooldown is the minimum time between agent dispatches for the same PR.
+const dispatchCooldown = 60 * time.Second
+
 // evaluate checks the current GH status and determines transitions + dispatches.
 func (c *Controller) evaluate(ctx context.Context, ps *PRPipelineState, status *PRStatus, runStates []*run.State) []Action {
 	var actions []Action
@@ -231,7 +235,7 @@ func (c *Controller) evaluate(ctx context.Context, ps *PRPipelineState, status *
 	switch {
 	case status.CI == "failing":
 		if ps.Stage != StageCIFailed || !ps.AgentRunning {
-			if !ps.AgentRunning {
+			if !ps.AgentRunning && time.Since(ps.LastDispatchAt) > dispatchCooldown {
 				// Clean up stale worktrees for this PR before dispatching.
 				c.cleanupStaleWorktrees(ps.PRNumber, runStates)
 
@@ -252,6 +256,7 @@ func (c *Controller) evaluate(ctx context.Context, ps *PRPipelineState, status *
 				ps.RetryCount = 0
 				ps.LastAgentID = agentID
 				ps.AgentRunning = true
+				ps.LastDispatchAt = time.Now()
 				actions = append(actions, Action{Type: "launch", Detail: fmt.Sprintf("CI fix agent for PR #%s", ps.PRNumber)})
 			}
 			ps.Stage = StageCIFailed
@@ -285,7 +290,7 @@ func (c *Controller) evaluate(ctx context.Context, ps *PRPipelineState, status *
 			if ps.Stage == StageApproved || ps.Stage == StageNeedsRebase {
 				if status.Conflicts == "yes" {
 					// Conflicts detected — dispatch rebase agent.
-					if !ps.AgentRunning {
+					if !ps.AgentRunning && time.Since(ps.LastDispatchAt) > dispatchCooldown {
 						c.cleanupStaleWorktrees(ps.PRNumber, runStates)
 						prompt := fmt.Sprintf(
 							"PR #%s has merge conflicts with the base branch. Rebase onto main, resolve all conflicts, and push. Run tests after resolving.",
@@ -304,6 +309,7 @@ func (c *Controller) evaluate(ctx context.Context, ps *PRPipelineState, status *
 						ps.Stage = StageNeedsRebase
 						ps.LastAgentID = agentID
 						ps.AgentRunning = true
+						ps.LastDispatchAt = time.Now()
 						actions = append(actions, Action{Type: "launch", Detail: fmt.Sprintf("Rebase agent for PR #%s", ps.PRNumber)})
 					}
 				} else {
@@ -326,7 +332,7 @@ func (c *Controller) evaluate(ctx context.Context, ps *PRPipelineState, status *
 			}
 		} else if strings.EqualFold(status.ReviewDecision, "CHANGES_REQUESTED") {
 			// Review comments need addressing.
-			if !ps.AgentRunning {
+			if !ps.AgentRunning && time.Since(ps.LastDispatchAt) > dispatchCooldown {
 				// Clean up stale worktrees for this PR before dispatching.
 				c.cleanupStaleWorktrees(ps.PRNumber, runStates)
 
@@ -349,12 +355,13 @@ func (c *Controller) evaluate(ctx context.Context, ps *PRPipelineState, status *
 				ps.RetryCount = 0
 				ps.LastAgentID = agentID
 				ps.AgentRunning = true
+				ps.LastDispatchAt = time.Now()
 				ps.Stage = StageReviewPending
 				actions = append(actions, Action{Type: "launch", Detail: fmt.Sprintf("Review fix agent for PR #%s", ps.PRNumber)})
 			}
 		} else {
 			// CI passed, no explicit CHANGES_REQUESTED or APPROVED.
-			if status.HasNewTrustedComments && !ps.AgentRunning {
+			if status.HasNewTrustedComments && !ps.AgentRunning && time.Since(ps.LastDispatchAt) > dispatchCooldown {
 				// Snapshot unresolved threads before dispatching fix agent.
 				c.snapshotUnresolvedThreads(ps, status.TargetRepo)
 
@@ -371,6 +378,7 @@ func (c *Controller) evaluate(ctx context.Context, ps *PRPipelineState, status *
 				}
 				ps.LastAgentID = agentID
 				ps.AgentRunning = true
+				ps.LastDispatchAt = time.Now()
 				ps.Stage = StageReviewPending
 				actions = append(actions, Action{Type: "launch", Detail: fmt.Sprintf("Review fix agent for PR #%s (trusted reviewer)", ps.PRNumber)})
 			} else if ps.Stage != StageApproved && ps.Stage != StageMerging && !ps.AgentRunning {

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -162,6 +162,11 @@ func TestAgentReDispatchAfterCompletion(t *testing.T) {
 		{ID: "agent-002", TmuxPane: strPtr("%1"), CostUSD: &cost},
 	}
 
+	// Expire the dispatch cooldown so re-dispatch is allowed.
+	c.mu.Lock()
+	c.prStates["42"].LastDispatchAt = time.Now().Add(-61 * time.Second)
+	c.mu.Unlock()
+
 	// CI still failing -> should re-dispatch.
 	c.HandleGHStatus(context.Background(), statuses, runStates)
 	if launchCount != 2 {
@@ -777,6 +782,11 @@ func TestNeedsRebaseTransitionsToCIFailedIfCIFails(t *testing.T) {
 		t.Fatalf("expected needs_rebase, got %s", c.PipelineStates()["42"].Stage)
 	}
 
+	// Expire the dispatch cooldown so the CI fix agent can be dispatched.
+	c.mu.Lock()
+	c.prStates["42"].LastDispatchAt = time.Now().Add(-61 * time.Second)
+	c.mu.Unlock()
+
 	// Step 2: Rebase agent completes but CI fails.
 	cost := 1.0
 	runStates := []*run.State{
@@ -1115,6 +1125,147 @@ func TestNoThreadResolutionWhileAgentRunning(t *testing.T) {
 	if resolveCount != 0 {
 		t.Errorf("expected no thread resolution while agent running, got %d", resolveCount)
 	}
+}
+
+func TestDispatchCooldownPreventsRapidRedispatch(t *testing.T) {
+	t.Run("CI failing", func(t *testing.T) {
+		c, _ := newTestController(t)
+
+		launchCount := 0
+		c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+			launchCount++
+			return fmt.Sprintf("agent-%03d", launchCount), nil
+		})
+
+		statuses := map[string]*PRStatus{
+			"42": {PRNumber: "42", State: "OPEN", CI: "failing", TargetRepo: "owner/repo"},
+		}
+
+		// First poll dispatches agent.
+		c.HandleGHStatus(context.Background(), statuses, nil)
+		if launchCount != 1 {
+			t.Fatalf("expected 1 launch, got %d", launchCount)
+		}
+
+		// Agent completes immediately.
+		cost := 1.0
+		runStates := []*run.State{
+			{ID: "agent-001", TmuxPane: strPtr("%1"), CostUSD: &cost},
+		}
+
+		// Second poll within cooldown — should NOT re-dispatch.
+		c.HandleGHStatus(context.Background(), statuses, runStates)
+		if launchCount != 1 {
+			t.Errorf("expected cooldown to prevent re-dispatch, got %d launches", launchCount)
+		}
+
+		// Simulate cooldown expiry.
+		c.mu.Lock()
+		c.prStates["42"].LastDispatchAt = time.Now().Add(-61 * time.Second)
+		c.mu.Unlock()
+
+		// Third poll after cooldown — should dispatch.
+		c.HandleGHStatus(context.Background(), statuses, runStates)
+		if launchCount != 2 {
+			t.Errorf("expected dispatch after cooldown, got %d launches", launchCount)
+		}
+	})
+
+	t.Run("CHANGES_REQUESTED", func(t *testing.T) {
+		c, _ := newTestController(t)
+
+		launchCount := 0
+		c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+			launchCount++
+			return fmt.Sprintf("agent-%03d", launchCount), nil
+		})
+
+		statuses := map[string]*PRStatus{
+			"42": {
+				PRNumber: "42", State: "OPEN", CI: "passing",
+				ReviewDecision: "CHANGES_REQUESTED", TargetRepo: "owner/repo",
+			},
+		}
+
+		// First poll dispatches.
+		c.HandleGHStatus(context.Background(), statuses, nil)
+		if launchCount != 1 {
+			t.Fatalf("expected 1 launch, got %d", launchCount)
+		}
+
+		// Agent completes.
+		cost := 1.0
+		runStates := []*run.State{
+			{ID: "agent-001", TmuxPane: strPtr("%1"), CostUSD: &cost},
+		}
+
+		// Second poll within cooldown — blocked.
+		c.HandleGHStatus(context.Background(), statuses, runStates)
+		if launchCount != 1 {
+			t.Errorf("expected cooldown to prevent re-dispatch, got %d launches", launchCount)
+		}
+
+		// Expire cooldown.
+		c.mu.Lock()
+		c.prStates["42"].LastDispatchAt = time.Now().Add(-61 * time.Second)
+		c.mu.Unlock()
+
+		// Third poll — allowed.
+		c.HandleGHStatus(context.Background(), statuses, runStates)
+		if launchCount != 2 {
+			t.Errorf("expected dispatch after cooldown, got %d launches", launchCount)
+		}
+	})
+
+	t.Run("trusted comments", func(t *testing.T) {
+		c, _ := newTestController(t)
+
+		launchCount := 0
+		c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+			launchCount++
+			return fmt.Sprintf("agent-%03d", launchCount), nil
+		})
+
+		statuses := map[string]*PRStatus{
+			"42": {
+				PRNumber:              "42",
+				State:                 "OPEN",
+				CI:                    "passing",
+				ReviewDecision:        "",
+				HasNewTrustedComments: true,
+				TargetRepo:            "owner/repo",
+			},
+		}
+
+		// First poll dispatches.
+		c.HandleGHStatus(context.Background(), statuses, nil)
+		if launchCount != 1 {
+			t.Fatalf("expected 1 launch, got %d", launchCount)
+		}
+
+		// Agent completes.
+		cost := 1.0
+		runStates := []*run.State{
+			{ID: "agent-001", TmuxPane: strPtr("%1"), CostUSD: &cost},
+		}
+
+		// Second poll within cooldown — blocked.
+		c.HandleGHStatus(context.Background(), statuses, runStates)
+		if launchCount != 1 {
+			t.Errorf("expected cooldown to prevent re-dispatch, got %d launches", launchCount)
+		}
+
+		// Expire cooldown.
+		c.mu.Lock()
+		c.prStates["42"].LastDispatchAt = time.Now().Add(-61 * time.Second)
+		c.mu.Unlock()
+
+		// Third poll — allowed.
+		c.HandleGHStatus(context.Background(), statuses, runStates)
+		if launchCount != 2 {
+			t.Errorf("expected dispatch after cooldown, got %d launches", launchCount)
+		}
+	})
 }
 
 func strPtr(s string) *string {


### PR DESCRIPTION
## Summary
- Adds a `LastDispatchAt` field to `PRPipelineState` and a 60-second cooldown between agent dispatches for the same PR
- Guards all four dispatch paths (CI failure, CHANGES_REQUESTED, trusted reviewer comments, rebase conflicts)
- Prevents the pipeline from spawning 40+ agents when polling picks up the same status repeatedly

## Test plan
- [x] New `TestDispatchCooldownPreventsRapidRedispatch` covers all three comment-driven dispatch paths (CI, CHANGES_REQUESTED, trusted comments)
- [x] Each subtest verifies: first dispatch works, immediate re-dispatch is blocked, dispatch after 60s cooldown succeeds
- [x] Updated existing tests (`TestAgentReDispatchAfterCompletion`, `TestNeedsRebaseTransitionsToCIFailedIfCIFails`) to expire cooldown before expecting re-dispatch
- [x] `go build ./...`, `go test ./...`, `go vet ./...` all pass

Run: 20260403-1715-30b0
Fixes #159