### PR TITLE
feat: fix agent session resumption

### DIFF
--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -45,6 +45,7 @@ are synced back after completion. Use --local to force local execution, or
 		prNumber, _ := cmd.Flags().GetString("pr")
 		forceLocal, _ := cmd.Flags().GetBool("local")
 		hostOverride, _ := cmd.Flags().GetString("host")
+		resumeFrom, _ := cmd.Flags().GetString("resume-from")
 
 		if !tmux.InSession() {
 			return fmt.Errorf("klaus launch must be run inside a tmux session")
@@ -248,8 +249,20 @@ are synced back after completion. Use --local to force local execution, or
 
 		logFile := filepath.Join(store.LogDir(), id+".jsonl")
 
+		// Validate resume session exists before using it.
+		var resolvedResume string
+		if resumeFrom != "" {
+			if s, loadErr := store.Load(resumeFrom); loadErr == nil && s.SessionName != nil {
+				resolvedResume = *s.SessionName
+			} else {
+				// Fall back to using the run ID directly as session name.
+				// If the session doesn't exist on disk, claude will start fresh.
+				resolvedResume = resumeFrom
+			}
+		}
+
 		// Build the claude command
-		claudeCmd := buildClaudeCommand(sysPrompt, budget, prompt)
+		claudeCmd := buildClaudeCommand(sysPrompt, budget, prompt, id, resolvedResume)
 
 		// Build the pane command: run claude, pipe through tee and formatter, then finalize.
 		// For cross-repo launches with a host repo, finalize must run from the
@@ -332,19 +345,23 @@ are synced back after completion. Use --local to force local execution, or
 		}
 
 		state := &run.State{
-			ID:         id,
-			Prompt:     prompt,
-			Issue:      issuePtr,
-			PR:         stringPtr(prNumber),
-			Branch:     branch,
-			Worktree:   worktree,
-			TmuxPane:   &paneID,
-			Budget:     budgetPtr,
-			LogFile:    logFilePtr,
-			CreatedAt:  createdAt,
-			Host:       hostPtr,
-			TargetRepo: normalizedTarget,
-			CloneDir:   cloneDirPtr,
+			ID:          id,
+			Prompt:      prompt,
+			Issue:       issuePtr,
+			PR:          stringPtr(prNumber),
+			Branch:      branch,
+			Worktree:    worktree,
+			TmuxPane:    &paneID,
+			Budget:      budgetPtr,
+			LogFile:     logFilePtr,
+			CreatedAt:   createdAt,
+			Host:        hostPtr,
+			TargetRepo:  normalizedTarget,
+			CloneDir:    cloneDirPtr,
+			SessionName: &id,
+		}
+		if resumeFrom != "" {
+			state.OriginalRunID = &resumeFrom
 		}
 		if isPRFix {
 			state.Type = "pr-fix"
@@ -400,16 +417,22 @@ func buildPaneCommand(worktree, claudeCmd, logFile, selfBin, finalizePrefix, id 
 	)
 }
 
-func buildClaudeCommand(sysPrompt, budget, prompt string) string {
+func buildClaudeCommand(sysPrompt, budget, prompt, runID, resumeSessionName string) string {
 	parts := []string{
 		"claude", "-p",
+		"-n", shellQuote(runID),
+	}
+	if resumeSessionName != "" {
+		parts = append(parts, "--resume", shellQuote(resumeSessionName), "--fork-session")
+	}
+	parts = append(parts,
 		"--dangerously-skip-permissions",
 		"--verbose",
 		"--output-format", "stream-json",
 		"--max-budget-usd", shellQuote(budget),
 		"--append-system-prompt", shellQuote(sysPrompt),
 		shellQuote(prompt),
-	}
+	)
 	return strings.Join(parts, " ")
 }
 
@@ -621,5 +644,6 @@ func init() {
 	launchCmd.Flags().String("repo", "", "Target repo: registered project name, owner/repo, or full URL")
 	launchCmd.Flags().Bool("local", false, "Force local execution even when sandbox is configured")
 	launchCmd.Flags().String("host", "", "Override sandbox host (ignores config sandbox_host)")
+	launchCmd.Flags().String("resume-from", "", "Resume from a previous agent's session (run ID)")
 	rootCmd.AddCommand(launchCmd)
 }

--- a/internal/cmd/launch_test.go
+++ b/internal/cmd/launch_test.go
@@ -446,6 +446,42 @@ func TestLaunchCmdHasSandboxFlags(t *testing.T) {
 	}
 }
 
+func TestBuildClaudeCommand_SessionNaming(t *testing.T) {
+	cmd := buildClaudeCommand("sys prompt", "5", "do stuff", "20260405-1200-abcd", "")
+	if !strings.Contains(cmd, "-n '20260405-1200-abcd'") {
+		t.Errorf("expected -n flag with run ID, got: %s", cmd)
+	}
+	if strings.Contains(cmd, "--resume") {
+		t.Error("expected no --resume flag when resumeSessionName is empty")
+	}
+	if strings.Contains(cmd, "--fork-session") {
+		t.Error("expected no --fork-session flag when resumeSessionName is empty")
+	}
+}
+
+func TestBuildClaudeCommand_WithResume(t *testing.T) {
+	cmd := buildClaudeCommand("sys prompt", "5", "fix CI", "20260405-1200-efgh", "20260405-1100-abcd")
+	if !strings.Contains(cmd, "-n '20260405-1200-efgh'") {
+		t.Errorf("expected -n flag with new run ID, got: %s", cmd)
+	}
+	if !strings.Contains(cmd, "--resume '20260405-1100-abcd'") {
+		t.Errorf("expected --resume flag with original session name, got: %s", cmd)
+	}
+	if !strings.Contains(cmd, "--fork-session") {
+		t.Errorf("expected --fork-session flag, got: %s", cmd)
+	}
+}
+
+func TestLaunchCmdHasResumeFromFlag(t *testing.T) {
+	f := launchCmd.Flags().Lookup("resume-from")
+	if f == nil {
+		t.Fatal("expected --resume-from flag to be registered on launch command")
+	}
+	if f.DefValue != "" {
+		t.Errorf("--resume-from default value should be empty, got %q", f.DefValue)
+	}
+}
+
 func TestLaunchCmdHasPRFlag(t *testing.T) {
 	// Verify the --pr flag is registered on the launch command
 	f := launchCmd.Flags().Lookup("pr")

--- a/internal/cmd/new.go
+++ b/internal/cmd/new.go
@@ -156,7 +156,7 @@ func runNew(cmd *cobra.Command, args []string) error {
 
 	// Build claude command
 	sysPrompt := "You are scaffolding a new project. Follow all instructions carefully. Push directly to main when done."
-	claudeCmd := buildClaudeCommand(sysPrompt, budget, prompt)
+	claudeCmd := buildClaudeCommand(sysPrompt, budget, prompt, id, "")
 
 	// Build pane command — no finalize prefix (new repo, no state ref setup)
 	selfBin := "klaus"

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -75,7 +75,7 @@ type Controller struct {
 	autoMergeOnApproval bool // whether to auto-merge approved PRs
 
 	// Injectable runners for testing.
-	launchAgent     func(ctx context.Context, prNumber, repo, prompt string) (string, error)
+	launchAgent     func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error)
 	mergePRs        func(ctx context.Context, repo string, prNumbers []string) error
 	cleanIdlePanes  func(runStates []*run.State)
 	snapshotThreads func(repo, prNumber string) ([]string, error)
@@ -106,7 +106,7 @@ func (c *Controller) SetAutoMergeOnApproval(enabled bool) {
 }
 
 // SetLaunchAgent overrides the agent launcher (for testing).
-func (c *Controller) SetLaunchAgent(fn func(ctx context.Context, prNumber, repo, prompt string) (string, error)) {
+func (c *Controller) SetLaunchAgent(fn func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error)) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.launchAgent = fn
@@ -253,7 +253,7 @@ func (c *Controller) evaluate(ctx context.Context, ps *PRPipelineState, status *
 					"CI is failing on PR #%s. Diagnose the failures and push fixes. Check `gh pr checks %s` for details and `gh run view <run-id> --log-failed` for error output.",
 					ps.PRNumber, ps.PRNumber,
 				)
-				agentID, err := c.launchAgent(ctx, ps.PRNumber, status.TargetRepo, prompt)
+				agentID, err := c.launchAgent(ctx, ps.PRNumber, status.TargetRepo, prompt, ps.LastAgentID)
 				if err != nil {
 					c.logger.Error("failed to dispatch CI fix agent", "pr", ps.PRNumber, "err", err)
 					if !c.handleLaunchRetry(ps) {
@@ -305,7 +305,7 @@ func (c *Controller) evaluate(ctx context.Context, ps *PRPipelineState, status *
 							"PR #%s has merge conflicts with the base branch. Rebase onto main, resolve all conflicts, and push. Run tests after resolving.",
 							ps.PRNumber,
 						)
-						agentID, err := c.launchAgent(ctx, ps.PRNumber, status.TargetRepo, prompt)
+						agentID, err := c.launchAgent(ctx, ps.PRNumber, status.TargetRepo, prompt, ps.LastAgentID)
 						if err != nil {
 							c.logger.Error("failed to dispatch rebase agent", "pr", ps.PRNumber, "err", err)
 							if !c.handleLaunchRetry(ps) {
@@ -352,7 +352,7 @@ func (c *Controller) evaluate(ctx context.Context, ps *PRPipelineState, status *
 					"PR #%s has changes requested by reviewers. Address the review comments and push fixes. Check `gh api repos/{owner}/{repo}/pulls/%s/comments` for comment details.",
 					ps.PRNumber, ps.PRNumber,
 				)
-				agentID, err := c.launchAgent(ctx, ps.PRNumber, status.TargetRepo, prompt)
+				agentID, err := c.launchAgent(ctx, ps.PRNumber, status.TargetRepo, prompt, ps.LastAgentID)
 				if err != nil {
 					c.logger.Error("failed to dispatch review fix agent", "pr", ps.PRNumber, "err", err)
 					if !c.handleLaunchRetry(ps) {
@@ -379,7 +379,7 @@ func (c *Controller) evaluate(ctx context.Context, ps *PRPipelineState, status *
 					"PR #%s in %s has review comments from a trusted reviewer that need to be addressed. Check the review comments with: gh api repos/%s/pulls/%s/comments",
 					ps.PRNumber, status.TargetRepo, status.TargetRepo, ps.PRNumber,
 				)
-				agentID, err := c.launchAgent(ctx, ps.PRNumber, status.TargetRepo, prompt)
+				agentID, err := c.launchAgent(ctx, ps.PRNumber, status.TargetRepo, prompt, ps.LastAgentID)
 				if err != nil {
 					c.logger.Error("failed to dispatch trusted review fix agent", "pr", ps.PRNumber, "err", err)
 					ps.Stage = StageStalled
@@ -514,10 +514,13 @@ func (c *Controller) emitEvent(prNumber, eventType string, data map[string]inter
 	}
 }
 
-func (c *Controller) defaultLaunchAgent(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+func (c *Controller) defaultLaunchAgent(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 	args := []string{"launch", "--pr", prNumber}
 	if repo != "" {
 		args = append(args, "--repo", repo)
+	}
+	if resumeFrom != "" {
+		args = append(args, "--resume-from", resumeFrom)
 	}
 	args = append(args, prompt)
 	cmd := exec.CommandContext(ctx, "klaus", args...)

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -35,7 +35,7 @@ func TestStateTransition_CIPendingToFailed(t *testing.T) {
 	c, _ := newTestController(t)
 
 	var launchedPR string
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		launchedPR = prNumber
 		return "agent-001", nil
 	})
@@ -64,7 +64,7 @@ func TestStateTransition_CIFailedToPassedToApproved(t *testing.T) {
 	c.SetAutoMergeOnApproval(true)
 
 	launchCount := 0
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		launchCount++
 		return "agent-001", nil
 	})
@@ -113,7 +113,7 @@ func TestNoDuplicateAgentDispatch(t *testing.T) {
 	c, _ := newTestController(t)
 
 	launchCount := 0
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		launchCount++
 		return "agent-001", nil
 	})
@@ -142,7 +142,7 @@ func TestAgentReDispatchAfterCompletion(t *testing.T) {
 	c, _ := newTestController(t)
 
 	launchCount := 0
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		launchCount++
 		return "agent-002", nil
 	})
@@ -179,7 +179,7 @@ func TestReviewCommentsDispatchAgent(t *testing.T) {
 	c, _ := newTestController(t)
 
 	var launchedPrompt string
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		launchedPrompt = prompt
 		return "agent-review", nil
 	})
@@ -208,7 +208,7 @@ func TestReviewCommentsDispatchAgent(t *testing.T) {
 
 func TestMergedPRCleanedUp(t *testing.T) {
 	c, _ := newTestController(t)
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		return "agent-001", nil
 	})
 
@@ -259,7 +259,7 @@ func TestAutoMergeBlockedByConflicts(t *testing.T) {
 	})
 
 	var launchedPrompt string
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		launchedPrompt = prompt
 		return "agent-rebase", nil
 	})
@@ -367,7 +367,7 @@ func TestLaunchFailureRetriesBeforeStalling(t *testing.T) {
 	c, _ := newTestController(t)
 
 	launchCount := 0
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		launchCount++
 		return "", fmt.Errorf("worktree already exists")
 	})
@@ -437,7 +437,7 @@ func TestWorktreeCleanupBeforeDispatch(t *testing.T) {
 
 	var cleanedUpID string
 	// Override launchAgent to track that cleanup happened before launch.
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		// By the time launch is called, the stale worktree should have
 		// had cleanup attempted. We can't easily verify the cleanup command
 		// ran (it would fail since the run ID doesn't exist in store), but
@@ -474,7 +474,7 @@ func TestReviewFixLaunchRetry(t *testing.T) {
 	c, _ := newTestController(t)
 
 	launchCount := 0
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		launchCount++
 		return "", fmt.Errorf("worktree already exists")
 	})
@@ -498,7 +498,7 @@ func TestTrustedCommentDispatch(t *testing.T) {
 	c, _ := newTestController(t)
 
 	var launchedPrompt string
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		launchedPrompt = prompt
 		return "agent-trusted", nil
 	})
@@ -533,7 +533,7 @@ func TestNoDispatchWithoutTrustedComments(t *testing.T) {
 	c, _ := newTestController(t)
 
 	launchCount := 0
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		launchCount++
 		return "agent-001", nil
 	})
@@ -565,7 +565,7 @@ func TestNoDoubleDispatchOnTrustedComments(t *testing.T) {
 	c, _ := newTestController(t)
 
 	launchCount := 0
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		launchCount++
 		return "agent-trusted", nil
 	})
@@ -600,7 +600,7 @@ func TestNoDoubleDispatchOnTrustedComments(t *testing.T) {
 func TestIdlePaneCleanupDuringPoll(t *testing.T) {
 	c, _ := newTestController(t)
 
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		return "agent-001", nil
 	})
 
@@ -640,7 +640,7 @@ func TestIdlePaneCleanupDuringPoll(t *testing.T) {
 func TestIdlePaneCleanupHandlesFinalized(t *testing.T) {
 	c, _ := newTestController(t)
 
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		return "agent-001", nil
 	})
 
@@ -675,7 +675,7 @@ func TestIdlePaneCleanupHandlesFinalized(t *testing.T) {
 func TestIdlePaneCleanupDoesNotSkipRecentRuns(t *testing.T) {
 	c, _ := newTestController(t)
 
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		return "agent-001", nil
 	})
 
@@ -711,7 +711,7 @@ func TestNeedsRebaseTransitionsToMergeAfterConflictsResolved(t *testing.T) {
 	c.SetAutoMergeOnApproval(true)
 
 	launchCount := 0
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		launchCount++
 		return fmt.Sprintf("agent-%03d", launchCount), nil
 	})
@@ -766,7 +766,7 @@ func TestNeedsRebaseTransitionsToCIFailedIfCIFails(t *testing.T) {
 	c, _ := newTestController(t)
 
 	launchCount := 0
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		launchCount++
 		return fmt.Sprintf("agent-%03d", launchCount), nil
 	})
@@ -813,7 +813,7 @@ func TestNeedsRebaseNoDoubleDispatch(t *testing.T) {
 	c, _ := newTestController(t)
 
 	launchCount := 0
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		launchCount++
 		return "agent-rebase", nil
 	})
@@ -845,7 +845,7 @@ func TestRebaseDispatchRetryOnFailure(t *testing.T) {
 	c, _ := newTestController(t)
 
 	launchCount := 0
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		launchCount++
 		return "", fmt.Errorf("worktree already exists")
 	})
@@ -903,7 +903,7 @@ func TestApprovedNoConflictsMerges(t *testing.T) {
 	c.SetAutoMergeOnApproval(true)
 
 	launchCount := 0
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		launchCount++
 		return "agent-001", nil
 	})
@@ -981,7 +981,7 @@ func TestReviewThreadsResolvedAfterAgentCompletion(t *testing.T) {
 		resolvedThreads = append(resolvedThreads, threadID)
 		return nil
 	})
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		return "agent-fix", nil
 	})
 
@@ -1043,7 +1043,7 @@ func TestReviewThreadResolutionFailureDoesNotBlock(t *testing.T) {
 		}
 		return nil
 	})
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		return "agent-fix", nil
 	})
 	c.SetMergePRs(func(ctx context.Context, repo string, prNumbers []string) error {
@@ -1098,7 +1098,7 @@ func TestTrustedCommentSnapshotsThreads(t *testing.T) {
 	c.SetResolveThread(func(threadID string) error {
 		return nil
 	})
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		return "agent-trusted", nil
 	})
 
@@ -1136,7 +1136,7 @@ func TestNoThreadResolutionWhileAgentRunning(t *testing.T) {
 		resolveCount++
 		return nil
 	})
-	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 		return "agent-fix", nil
 	})
 
@@ -1165,7 +1165,7 @@ func TestDispatchCooldownPreventsRapidRedispatch(t *testing.T) {
 		c, _ := newTestController(t)
 
 		launchCount := 0
-		c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+		c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 			launchCount++
 			return fmt.Sprintf("agent-%03d", launchCount), nil
 		})
@@ -1208,7 +1208,7 @@ func TestDispatchCooldownPreventsRapidRedispatch(t *testing.T) {
 		c, _ := newTestController(t)
 
 		launchCount := 0
-		c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+		c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 			launchCount++
 			return fmt.Sprintf("agent-%03d", launchCount), nil
 		})
@@ -1254,7 +1254,7 @@ func TestDispatchCooldownPreventsRapidRedispatch(t *testing.T) {
 		c, _ := newTestController(t)
 
 		launchCount := 0
-		c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt string) (string, error) {
+		c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
 			launchCount++
 			return fmt.Sprintf("agent-%03d", launchCount), nil
 		})
@@ -1299,6 +1299,86 @@ func TestDispatchCooldownPreventsRapidRedispatch(t *testing.T) {
 			t.Errorf("expected dispatch after cooldown, got %d launches", launchCount)
 		}
 	})
+}
+
+func TestCIFixAgentResumesFromLastAgent(t *testing.T) {
+	c, _ := newTestController(t)
+
+	var capturedResume string
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
+		capturedResume = resumeFrom
+		return "agent-fix", nil
+	})
+
+	// Seed pipeline state with a previous agent ID.
+	c.mu.Lock()
+	c.prStates["42"] = &PRPipelineState{
+		PRNumber:    "42",
+		Stage:       StageCIFailed,
+		LastAgentID: "agent-original",
+	}
+	c.mu.Unlock()
+
+	statuses := map[string]*PRStatus{
+		"42": {PRNumber: "42", State: "OPEN", CI: "failing", TargetRepo: "owner/repo"},
+	}
+
+	c.HandleGHStatus(context.Background(), statuses, nil)
+
+	if capturedResume != "agent-original" {
+		t.Errorf("expected resumeFrom=%q, got %q", "agent-original", capturedResume)
+	}
+}
+
+func TestReviewFixAgentResumesFromLastAgent(t *testing.T) {
+	c, _ := newTestController(t)
+
+	var capturedResume string
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
+		capturedResume = resumeFrom
+		return "agent-review-fix", nil
+	})
+
+	c.mu.Lock()
+	c.prStates["10"] = &PRPipelineState{
+		PRNumber:    "10",
+		Stage:       StageCIPassed,
+		LastAgentID: "agent-prev",
+	}
+	c.mu.Unlock()
+
+	statuses := map[string]*PRStatus{
+		"10": {
+			PRNumber: "10", State: "OPEN", CI: "passing",
+			ReviewDecision: "CHANGES_REQUESTED", TargetRepo: "owner/repo",
+		},
+	}
+
+	c.HandleGHStatus(context.Background(), statuses, nil)
+
+	if capturedResume != "agent-prev" {
+		t.Errorf("expected resumeFrom=%q, got %q", "agent-prev", capturedResume)
+	}
+}
+
+func TestFirstAgentDispatchHasEmptyResume(t *testing.T) {
+	c, _ := newTestController(t)
+
+	var capturedResume string
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
+		capturedResume = resumeFrom
+		return "agent-first", nil
+	})
+
+	statuses := map[string]*PRStatus{
+		"7": {PRNumber: "7", State: "OPEN", CI: "failing", TargetRepo: "owner/repo"},
+	}
+
+	c.HandleGHStatus(context.Background(), statuses, nil)
+
+	if capturedResume != "" {
+		t.Errorf("expected empty resumeFrom for first dispatch, got %q", capturedResume)
+	}
 }
 
 func strPtr(s string) *string {

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -32,6 +32,8 @@ type State struct {
 	DashboardPane  *string  `json:"dashboard_pane,omitempty"`
 	Approved       *bool    `json:"approved,omitempty"`
 	ApprovedAt     *string  `json:"approved_at,omitempty"`
+	SessionName    *string  `json:"session_name,omitempty"`   // claude -n name, same as run ID
+	OriginalRunID  *string  `json:"original_run_id,omitempty"` // run ID this was forked from
 }
 
 // Tmux dependency injection for testing.


### PR DESCRIPTION
## Summary
- Agent sessions are now named with `-n <run-id>` so they're discoverable and resumable by subsequent agents
- When the pipeline dispatches a fix agent (CI failure, review comments, rebase), it passes the previous agent's run ID via `--resume-from`, which translates to `--resume <id> --fork-session` on the Claude CLI
- `run.State` tracks `session_name` and `original_run_id` for traceability
- Falls back gracefully to a fresh session if the resume target doesn't exist

## Changes
- **internal/run/run.go**: Added `SessionName` and `OriginalRunID` fields to `State`
- **internal/cmd/launch.go**: `buildClaudeCommand` now accepts `runID` and `resumeSessionName`; added `--resume-from` flag; sets `SessionName` on state
- **internal/cmd/new.go**: Updated `buildClaudeCommand` call for new signature
- **internal/pipeline/pipeline.go**: `launchAgent` signature includes `resumeFrom`; all 4 dispatch sites pass `ps.LastAgentID`; `defaultLaunchAgent` passes `--resume-from` to `klaus launch`
- **Tests**: `buildClaudeCommand` flag construction tests, pipeline resume propagation tests (CI fix, review fix, first dispatch empty)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/cmd/... ./internal/pipeline/... ./internal/run/...` passes
- [x] New tests verify `-n` flag always present, `--resume`/`--fork-session` only when resuming
- [x] New tests verify pipeline passes `LastAgentID` as `resumeFrom` on re-dispatch
- [x] New test verifies first dispatch has empty `resumeFrom`

Run: 20260405-1659-a3c4
Fixes #161