### PR TITLE
refactor: introduce github.Client interface

### DIFF
--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -65,7 +65,8 @@ Keyboard shortcuts:
 			fmt.Fprintf(os.Stderr, "warning: loading config: %v\n", err)
 		}
 
-		model := newDashboardModel(store, cfg)
+		ghClient := gh.NewGHCLIClient("")
+		model := newDashboardModel(store, cfg, ghClient)
 		if cfg.Webhook != nil {
 			ch := make(chan webhook.Event, 64)
 			port := cfg.Webhook.Port
@@ -157,6 +158,7 @@ type repoGroup struct {
 // dashboardModel is the bubbletea model for the dashboard.
 type dashboardModel struct {
 	store          run.StateStore
+	ghClient       gh.Client
 	states         []*run.State
 	ghStatus       map[string]*prStatus // keyed by PR number
 	sandboxHosts   map[string]bool      // host -> reachable
@@ -174,7 +176,7 @@ type dashboardModel struct {
 	pollEnabled    bool                // true when polling is active (default or poll_fallback)
 }
 
-func newDashboardModel(store run.StateStore, cfg config.Config) dashboardModel {
+func newDashboardModel(store run.StateStore, cfg config.Config, ghClient gh.Client) dashboardModel {
 	var eventLog *event.Log
 	var logWriter io.Writer = io.Discard
 	var logFile *os.File
@@ -192,6 +194,7 @@ func newDashboardModel(store run.StateStore, cfg config.Config) dashboardModel {
 
 	return dashboardModel{
 		store:          store,
+		ghClient:       ghClient,
 		ghStatus:       make(map[string]*prStatus),
 		sandboxHosts:   make(map[string]bool),
 		pipelineCtrl:   ctrl,
@@ -227,7 +230,7 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "r":
 			return m, tea.Batch(
 				loadStatesCmd(m.store),
-				fetchGHStatusCmd(m.states),
+				fetchGHStatusCmd(m.ghClient, m.states),
 			)
 		}
 
@@ -237,7 +240,7 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case statesLoadedMsg:
 		m.states = msg.states
-		return m, fetchGHStatusCmd(m.states)
+		return m, fetchGHStatusCmd(m.ghClient, m.states)
 
 	case ghStatusMsg:
 		for k, v := range msg.statuses {
@@ -320,7 +323,7 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				if len(matchedStates) > 0 {
 					return m, tea.Batch(
-						fetchGHStatusCmd(matchedStates),
+						fetchGHStatusCmd(m.ghClient, matchedStates),
 						waitForWebhookCmd(m.webhookCh),
 					)
 				}
@@ -435,7 +438,7 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			tickAfterCmd(),
 		}
 		if m.pollEnabled {
-			cmds = append(cmds, fetchGHStatusCmd(m.states))
+			cmds = append(cmds, fetchGHStatusCmd(m.ghClient, m.states))
 		}
 		return m, tea.Batch(cmds...)
 
@@ -707,7 +710,7 @@ func loadStatesCmd(store run.StateStore) tea.Cmd {
 	}
 }
 
-func fetchGHStatusCmd(states []*run.State) tea.Cmd {
+func fetchGHStatusCmd(client gh.Client, states []*run.State) tea.Cmd {
 	return func() tea.Msg {
 		statuses := make(map[string]*prStatus)
 		seen := make(map[string]bool)
@@ -718,7 +721,7 @@ func fetchGHStatusCmd(states []*run.State) tea.Cmd {
 				continue
 			}
 			seen[prNum] = true
-			statuses[prNum] = fetchPRStatus(prNum, prRef)
+			statuses[prNum] = fetchPRStatus(client, prNum, prRef)
 		}
 		return ghStatusMsg{statuses: statuses}
 	}
@@ -823,16 +826,16 @@ func renderSandboxStatus(hosts map[string]bool) string {
 
 // fetchPRStatus queries GitHub for a single PR's status.
 // prRef should be a full PR URL so gh can resolve it from any directory.
-func fetchPRStatus(prNumber, prRef string) *prStatus {
-	client := gh.NewPRClient("") // full URL in prRef handles repo resolution
+func fetchPRStatus(client gh.Client, prNumber, prRef string) *prStatus {
+	ctx := context.TODO()
 	ps := &prStatus{PRNumber: prNumber}
-	ps.State = client.GetState(prRef)
+	ps.State = client.GetState(ctx, prRef)
 	if ps.State == "MERGED" || ps.State == "CLOSED" {
 		return ps
 	}
-	ps.CI = client.GetCI(prRef)
-	ps.Conflicts = client.GetConflicts(prRef)
-	ps.ReviewDecision = client.GetReviewDecision(prRef)
+	ps.CI = client.GetCI(ctx, prRef)
+	ps.Conflicts = client.GetConflicts(ctx, prRef)
+	ps.ReviewDecision = client.GetReviewDecision(ctx, prRef)
 
 	// When reviewDecision is not CHANGES_REQUESTED, check for unaddressed
 	// trusted reviewer comments that GitHub doesn't reflect in reviewDecision.

--- a/internal/cmd/dashboard_test.go
+++ b/internal/cmd/dashboard_test.go
@@ -10,6 +10,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/patflynn/klaus/internal/config"
+	gh "github.com/patflynn/klaus/internal/github"
 	"github.com/patflynn/klaus/internal/pipeline"
 	"github.com/patflynn/klaus/internal/project"
 	"github.com/patflynn/klaus/internal/run"
@@ -830,7 +831,7 @@ func TestWebhookMsgSetsHasNewTrustedComments(t *testing.T) {
 		},
 	}
 
-	m := newDashboardModel(run.NewGitDirStore(t.TempDir()), config.Config{})
+	m := newDashboardModel(run.NewGitDirStore(t.TempDir()), config.Config{}, gh.NewGHCLIClient(""))
 	m.states = states
 
 	// Send a webhook event with a review decision that is neither
@@ -895,7 +896,7 @@ func TestWebhookMsgClearsTrustedCommentsOnApproval(t *testing.T) {
 	}
 	t.Cleanup(func() { hasUnaddressedTrustedComments = orig })
 
-	m := newDashboardModel(run.NewGitDirStore(t.TempDir()), config.Config{})
+	m := newDashboardModel(run.NewGitDirStore(t.TempDir()), config.Config{}, gh.NewGHCLIClient(""))
 	// Pre-populate with a status that has trusted comments.
 	m.ghStatus["42"] = &prStatus{
 		PRNumber:              "42",
@@ -941,7 +942,7 @@ func TestWebhookMsgTrustedCommentsFallbackToPRURL(t *testing.T) {
 		},
 	}
 
-	m := newDashboardModel(run.NewGitDirStore(t.TempDir()), config.Config{})
+	m := newDashboardModel(run.NewGitDirStore(t.TempDir()), config.Config{}, gh.NewGHCLIClient(""))
 	m.states = states
 
 	msg := webhookMsg{

--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -172,8 +173,9 @@ are synced back after completion. Use --local to force local execution, or
 
 		if prNumber != "" {
 			ghRepo := resolveGHRepo(repoRef, repoRoot)
-			prClient := gh.NewPRClient(ghRepo)
-			prBranch, err := prClient.GetBranch(prNumber)
+			ghClient := gh.NewGHCLIClient(ghRepo)
+			ctx := context.TODO()
+			prBranch, err := ghClient.GetBranch(ctx, prNumber)
 			if err != nil {
 				return fmt.Errorf("getting PR branch: %w", err)
 			}
@@ -181,7 +183,7 @@ are synced back after completion. Use --local to force local execution, or
 			isPRFix = true
 
 			// Look up the PR URL for state tracking
-			prURL, err = prClient.GetURL(prNumber)
+			prURL, err = ghClient.GetURL(ctx, prNumber)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "warning: could not get PR URL for #%s: %v\n", prNumber, err)
 			}

--- a/internal/cmd/merge.go
+++ b/internal/cmd/merge.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -38,24 +39,25 @@ type mergeRunner struct {
 }
 
 func newMergeRunner(out io.Writer, in io.Reader, store run.StateStore, repoFlag string) *mergeRunner {
+	ctx := context.TODO()
 	r := &mergeRunner{
 		out: out,
 		in:  in,
 		getPRTitle: func(pr, repo string) string {
-			return gh.NewPRClient(repo).GetTitle(pr)
+			return gh.NewGHCLIClient(repo).GetTitle(ctx, pr)
 		},
 		getPRCI: func(pr, repo string) string {
-			return gh.NewPRClient(repo).GetCI(pr)
+			return gh.NewGHCLIClient(repo).GetCI(ctx, pr)
 		},
 		getPRConflicts: func(pr, repo string) string {
-			return gh.NewPRClient(repo).GetConflicts(pr)
+			return gh.NewGHCLIClient(repo).GetConflicts(ctx, pr)
 		},
 		getPRReviewDecision: func(pr, repo string) string {
-			return gh.NewPRClient(repo).GetReviewDecision(pr)
+			return gh.NewGHCLIClient(repo).GetReviewDecision(ctx, pr)
 		},
 		rebaseAndPush: rebaseAndPush,
 		mergePR: func(prNumber, mergeMethod string, deleteBranch bool, repo string) error {
-			return gh.NewPRClient(repo).Merge(prNumber, mergeMethod, deleteBranch)
+			return gh.NewGHCLIClient(repo).Merge(ctx, prNumber, mergeMethod, deleteBranch)
 		},
 		pollCI:        defaultPollCI,
 		markMerged:    markRunsMerged(store),
@@ -140,7 +142,7 @@ func buildApprovalChecker(store run.StateStore) func(string) bool {
 		}
 
 		// Fall back to checking GitHub review decision.
-		decision := gh.NewPRClient(repo).GetReviewDecision(prNumber)
+		decision := gh.NewGHCLIClient(repo).GetReviewDecision(context.TODO(), prNumber)
 		if strings.EqualFold(decision, "APPROVED") {
 			// Persist the approval into run state so future checks are fast.
 			for _, s := range states {
@@ -245,7 +247,7 @@ func validateMergeMethod(method string) error {
 // rebaseAndPush rebases a PR branch onto origin/main, verifies compilation,
 // and force-pushes using a temporary worktree.
 func rebaseAndPush(prNumber string, repo string) error {
-	branch, err := gh.NewPRClient(repo).GetBranch(prNumber)
+	branch, err := gh.NewGHCLIClient(repo).GetBranch(context.TODO(), prNumber)
 	if err != nil {
 		return fmt.Errorf("getting branch: %w", err)
 	}
@@ -315,10 +317,11 @@ func defaultPollCI(prNumber string, repo string) error {
 	timeout := 10 * time.Minute
 	interval := 30 * time.Second
 	deadline := time.Now().Add(timeout)
-	client := gh.NewPRClient(repo)
+	client := gh.NewGHCLIClient(repo)
+	ctx := context.TODO()
 
 	for {
-		ci := client.GetCI(prNumber)
+		ci := client.GetCI(ctx, prNumber)
 		switch ci {
 		case "passing":
 			return nil

--- a/internal/cmd/review_check.go
+++ b/internal/cmd/review_check.go
@@ -1,12 +1,13 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
-	"os/exec"
 	"strings"
 	"time"
 
 	"github.com/patflynn/klaus/internal/config"
+	"github.com/patflynn/klaus/internal/github"
 )
 
 // ownerRepoFromPRURL extracts "owner/repo" from a full GitHub PR URL.
@@ -102,9 +103,9 @@ func hasUnaddressedTrustedCommentsImpl(ownerRepo, prNumber string) bool {
 
 // fetchPRReviews calls gh api to get reviews for a PR.
 func fetchPRReviews(ownerRepo, prNumber string) []ghReview {
+	client := github.NewGHCLIClient("")
 	endpoint := "repos/" + ownerRepo + "/pulls/" + prNumber + "/reviews"
-	cmd := exec.Command("gh", "api", endpoint)
-	out, err := cmd.Output()
+	out, err := client.APIGet(context.TODO(), endpoint)
 	if err != nil {
 		return nil
 	}
@@ -117,9 +118,9 @@ func fetchPRReviews(ownerRepo, prNumber string) []ghReview {
 
 // fetchLatestCommitTime calls gh api to get the latest commit time on a PR.
 func fetchLatestCommitTime(ownerRepo, prNumber string) time.Time {
+	client := github.NewGHCLIClient("")
 	endpoint := "repos/" + ownerRepo + "/pulls/" + prNumber + "/commits"
-	cmd := exec.Command("gh", "api", endpoint)
-	out, err := cmd.Output()
+	out, err := client.APIGet(context.TODO(), endpoint)
 	if err != nil {
 		return time.Time{}
 	}

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -25,11 +26,14 @@ var statusCmd = &cobra.Command{
 			return nil
 		}
 
+		ghClient := gh.NewGHCLIClient("")
+
 		fmt.Fprintf(os.Stdout, "%-22s  %-10s  %-8s  %-6s  %-20s  %-15s  %-6s  %-10s  %-10s  %-10s  %s\n",
 			"RUN ID", "STATUS", "COST", "ISSUE", "REPO", "HOST", "PR", "CI", "CONFLICTS", "MERGE", "PROMPT")
 		fmt.Fprintf(os.Stdout, "%-22s  %-10s  %-8s  %-6s  %-20s  %-15s  %-6s  %-10s  %-10s  %-10s  %s\n",
 			"------", "------", "----", "-----", "----", "----", "--", "--", "---------", "-----", "------")
 
+		ctx := context.TODO()
 		for _, s := range states {
 			status := determineStatus(s)
 			cost := formatCost(s)
@@ -50,8 +54,7 @@ var statusCmd = &cobra.Command{
 
 			ci, conflicts, merge := "-", "-", "-"
 			if prRef := extractPRRef(s); prRef != "" {
-				client := gh.NewPRClient("") // full URL in prRef handles repo resolution
-				prState := client.GetState(prRef)
+				prState := ghClient.GetState(ctx, prRef)
 				switch prState {
 				case "MERGED":
 					status = "merged"
@@ -59,9 +62,9 @@ var statusCmd = &cobra.Command{
 				case "CLOSED":
 					status = "closed"
 				default:
-					ci = client.GetCI(prRef)
-					conflicts = client.GetConflicts(prRef)
-					merge = computeMergeStatus(ci, conflicts, client.GetReviewDecision(prRef))
+					ci = ghClient.GetCI(ctx, prRef)
+					conflicts = ghClient.GetConflicts(ctx, prRef)
+					merge = computeMergeStatus(ci, conflicts, ghClient.GetReviewDecision(ctx, prRef))
 				}
 			}
 

--- a/internal/cmd/track.go
+++ b/internal/cmd/track.go
@@ -1,14 +1,14 @@
 package cmd
 
 import (
-	"bytes"
+	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
 	"strings"
 	"time"
 
+	"github.com/patflynn/klaus/internal/github"
 	"github.com/patflynn/klaus/internal/project"
 	"github.com/patflynn/klaus/internal/run"
 	"github.com/spf13/cobra"
@@ -172,27 +172,10 @@ func trackPR(ref, defaultRepo string, store run.StateStore, existingStates []*ru
 	return nil
 }
 
-// fetchPRMetadata fetches PR URL, title, head branch, and state from GitHub via gh CLI.
+// fetchPRMetadata fetches PR URL, title, head branch, and state from GitHub via the Client interface.
 func fetchPRMetadata(prNumber, repo string) (prURL, title, headBranch, state string, err error) {
-	args := []string{
-		"pr", "view", prNumber,
-		"--repo", repo,
-		"--json", "url,title,headRefName,state",
-		"-q", `(.url) + "\t" + (.title) + "\t" + (.headRefName) + "\t" + (.state)`,
-	}
-	cmd := exec.Command("gh", args...)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return "", "", "", "", fmt.Errorf("gh pr view: %s", strings.TrimSpace(stderr.String()))
-	}
-
-	parts := strings.SplitN(strings.TrimSpace(stdout.String()), "\t", 4)
-	if len(parts) < 4 {
-		return "", "", "", "", fmt.Errorf("unexpected gh output: %s", stdout.String())
-	}
-	return parts[0], parts[1], parts[2], parts[3], nil
+	client := github.NewGHCLIClient("")
+	return client.FetchPRMetadata(context.TODO(), prNumber, repo)
 }
 
 func init() {

--- a/internal/cmd/webhook_setup.go
+++ b/internal/cmd/webhook_setup.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -45,7 +46,9 @@ type webhookStatus struct {
 var (
 	webhookListHooks    = listRepoHooks
 	webhookCreateHook   = createRepoHook
-	webhookResolveRepo  = github.GetRepoOwnerAndNameFromDir
+	webhookResolveRepo  = func(dir string) (string, string, error) {
+		return github.NewGHCLIClient("").GetRepoOwnerAndNameFromDir(context.TODO(), dir)
+	}
 	webhookLoadConfig   = func() (config.Config, error) { return config.Load("") }
 	webhookLoadRegistry = project.Load
 	webhookReadFile     = os.ReadFile
@@ -256,7 +259,8 @@ func matchHook(hooks []ghHook, relayURL string) int64 {
 
 // listRepoHooks fetches webhooks for a repository via the GitHub API.
 func listRepoHooks(owner, repo string) ([]ghHook, error) {
-	data, err := github.APIGet(fmt.Sprintf("repos/%s/%s/hooks", owner, repo))
+	client := github.NewGHCLIClient("")
+	data, err := client.APIGet(context.TODO(), fmt.Sprintf("repos/%s/%s/hooks", owner, repo))
 	if err != nil {
 		return nil, err
 	}
@@ -269,6 +273,7 @@ func listRepoHooks(owner, repo string) ([]ghHook, error) {
 
 // createRepoHook creates a webhook on a GitHub repository.
 func createRepoHook(owner, repo, relayURL, secret string) error {
+	client := github.NewGHCLIClient("")
 	body := map[string]interface{}{
 		"name":   "web",
 		"active": true,
@@ -279,7 +284,7 @@ func createRepoHook(owner, repo, relayURL, secret string) error {
 			"secret":       secret,
 		},
 	}
-	_, err := github.APIPostJSON(fmt.Sprintf("repos/%s/%s/hooks", owner, repo), body)
+	_, err := client.APIPostJSON(context.TODO(), fmt.Sprintf("repos/%s/%s/hooks", owner, repo), body)
 	return err
 }
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -1,0 +1,42 @@
+package github
+
+import "context"
+
+// Client defines all GitHub operations Klaus uses.
+type Client interface {
+	// Repository info
+	GetRepoOwnerAndName(ctx context.Context) (owner string, repo string, err error)
+	GetRepoOwnerAndNameFromDir(ctx context.Context, dir string) (owner string, repo string, err error)
+
+	// PR queries
+	GetCI(ctx context.Context, prRef string) string
+	GetConflicts(ctx context.Context, prRef string) string
+	GetReviewDecision(ctx context.Context, prRef string) string
+	GetState(ctx context.Context, prRef string) string
+	GetBranch(ctx context.Context, prRef string) (string, error)
+	GetURL(ctx context.Context, prRef string) (string, error)
+	GetTitle(ctx context.Context, prRef string) string
+
+	// PR mutations
+	Merge(ctx context.Context, prNumber, mergeMethod string, deleteBranch bool) error
+
+	// Review operations
+	FetchPRReviewComments(ctx context.Context, owner, repo, prNumber string) ([]PRReviewComment, error)
+	ReplyToReviewComment(ctx context.Context, owner, repo, prNumber string, commentID int64, body string) error
+	FetchReviewThreads(ctx context.Context, owner, repo string, prNumber int) ([]ReviewThread, error)
+	ResolveReviewThread(ctx context.Context, threadID string) error
+
+	// Collaborators
+	FetchCollaborators(ctx context.Context, owner, repo string) ([]string, error)
+
+	// Generic API
+	APIGet(ctx context.Context, path string) ([]byte, error)
+	APIPost(ctx context.Context, path string, fields map[string]string) error
+	APIPostJSON(ctx context.Context, path string, body interface{}) ([]byte, error)
+
+	// PR metadata (multi-field fetch for track command)
+	FetchPRMetadata(ctx context.Context, prNumber, repo string) (prURL, title, headBranch, state string, err error)
+
+	// Repo operations
+	GetAuthenticatedUser(ctx context.Context) (login string, err error)
+}

--- a/internal/github/gh_cli_client.go
+++ b/internal/github/gh_cli_client.go
@@ -1,0 +1,415 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Verify GHCLIClient implements Client at compile time.
+var _ Client = (*GHCLIClient)(nil)
+
+// GHCLIClient implements Client by shelling out to the gh CLI.
+type GHCLIClient struct {
+	repo string // owner/repo, may be empty
+}
+
+// NewGHCLIClient creates a GHCLIClient. If repo is empty, gh will infer the
+// repo from the current git directory for commands that need one.
+func NewGHCLIClient(repo string) *GHCLIClient {
+	return &GHCLIClient{repo: repo}
+}
+
+// Repo returns the configured owner/repo string.
+func (c *GHCLIClient) Repo() string {
+	return c.repo
+}
+
+// ghArgs builds a base arg list with --repo injected when set.
+func (c *GHCLIClient) ghArgs(base []string, prRef string) []string {
+	args := make([]string, len(base))
+	copy(args, base)
+	if c.repo != "" {
+		args = append(args, "--repo", c.repo)
+	}
+	args = append(args, "--", prRef)
+	return args
+}
+
+// GetRepoOwnerAndName returns owner/repo by querying gh.
+func (c *GHCLIClient) GetRepoOwnerAndName(_ context.Context) (string, string, error) {
+	cmd := exec.Command("gh", "repo", "view", "--json", "owner,name", "-q", ".owner.login + \"/\" + .name")
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "", "", err
+	}
+	parts := strings.SplitN(strings.TrimSpace(stdout.String()), "/", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("unexpected repo format")
+	}
+	return parts[0], parts[1], nil
+}
+
+// GetRepoOwnerAndNameFromDir returns owner/repo for the git repo at the given directory.
+func (c *GHCLIClient) GetRepoOwnerAndNameFromDir(_ context.Context, dir string) (string, string, error) {
+	cmd := exec.Command("gh", "repo", "view", "--json", "owner,name", "-q", ".owner.login + \"/\" + .name")
+	cmd.Dir = dir
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "", "", fmt.Errorf("resolving repo for %s: %w", dir, err)
+	}
+	parts := strings.SplitN(strings.TrimSpace(stdout.String()), "/", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("unexpected repo format for %s", dir)
+	}
+	return parts[0], parts[1], nil
+}
+
+// GetCI checks CI status by running "gh pr checks" and summarizing pass/fail/pending.
+func (c *GHCLIClient) GetCI(_ context.Context, prRef string) string {
+	args := c.ghArgs([]string{"pr", "checks"}, prRef)
+	cmd := exec.Command("gh", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	output := stdout.String()
+
+	if err != nil && output == "" {
+		if strings.Contains(stderr.String(), "no checks reported") {
+			return "passing" // no checks configured — nothing to fail
+		}
+		return "unknown"
+	}
+
+	return ParseCIStatus(output)
+}
+
+// GetConflicts checks if a PR has merge conflicts.
+func (c *GHCLIClient) GetConflicts(_ context.Context, prRef string) string {
+	args := c.ghArgs([]string{"pr", "view", "--json", "mergeable", "-q", ".mergeable"}, prRef)
+	cmd := exec.Command("gh", args...)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "unknown"
+	}
+	val := strings.TrimSpace(stdout.String())
+	if strings.EqualFold(val, "CONFLICTING") {
+		return "yes"
+	}
+	if strings.EqualFold(val, "MERGEABLE") {
+		return "none"
+	}
+	return "unknown"
+}
+
+// GetReviewDecision fetches the review decision for a PR.
+func (c *GHCLIClient) GetReviewDecision(_ context.Context, prRef string) string {
+	args := c.ghArgs([]string{"pr", "view", "--json", "reviewDecision", "-q", ".reviewDecision"}, prRef)
+	cmd := exec.Command("gh", args...)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "unknown"
+	}
+	return strings.TrimSpace(stdout.String())
+}
+
+// GetState returns the PR state (e.g. "OPEN", "MERGED", "CLOSED").
+func (c *GHCLIClient) GetState(_ context.Context, prRef string) string {
+	args := c.ghArgs([]string{"pr", "view", "--json", "state", "-q", ".state"}, prRef)
+	cmd := exec.Command("gh", args...)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "UNKNOWN"
+	}
+	val := strings.TrimSpace(stdout.String())
+	if val == "" {
+		return "UNKNOWN"
+	}
+	return strings.ToUpper(val)
+}
+
+// GetBranch returns the head branch name for a PR.
+func (c *GHCLIClient) GetBranch(_ context.Context, prRef string) (string, error) {
+	args := c.ghArgs([]string{"pr", "view", "--json", "headRefName", "-q", ".headRefName"}, prRef)
+	cmd := exec.Command("gh", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("gh pr view: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	branch := strings.TrimSpace(stdout.String())
+	if branch == "" {
+		return "", fmt.Errorf("could not determine branch for PR %s", prRef)
+	}
+	return branch, nil
+}
+
+// GetURL returns the HTML URL for a PR.
+func (c *GHCLIClient) GetURL(_ context.Context, prRef string) (string, error) {
+	args := c.ghArgs([]string{"pr", "view", "--json", "url", "-q", ".url"}, prRef)
+	cmd := exec.Command("gh", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("gh pr view: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+// GetTitle fetches the title of a PR.
+func (c *GHCLIClient) GetTitle(_ context.Context, prRef string) string {
+	args := c.ghArgs([]string{"pr", "view", "--json", "title", "-q", ".title"}, prRef)
+	cmd := exec.Command("gh", args...)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "(unknown)"
+	}
+	title := strings.TrimSpace(stdout.String())
+	if title == "" {
+		return "(unknown)"
+	}
+	return title
+}
+
+// Merge merges a PR with the given method.
+func (c *GHCLIClient) Merge(_ context.Context, prNumber, mergeMethod string, deleteBranch bool) error {
+	args := MergeArgs(prNumber, mergeMethod, deleteBranch, c.repo)
+	cmd := exec.Command("gh", args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("gh pr merge: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+// FetchPRReviewComments fetches review comments for a PR.
+func (c *GHCLIClient) FetchPRReviewComments(ctx context.Context, owner, repo, prNumber string) ([]PRReviewComment, error) {
+	path := fmt.Sprintf("repos/%s/%s/pulls/%s/comments", owner, repo, prNumber)
+	data, err := c.APIGet(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	var comments []PRReviewComment
+	if err := json.Unmarshal(data, &comments); err != nil {
+		return nil, fmt.Errorf("parsing review comments: %w", err)
+	}
+	return comments, nil
+}
+
+// ReplyToReviewComment posts a reply to a specific PR review comment.
+func (c *GHCLIClient) ReplyToReviewComment(ctx context.Context, owner, repo, prNumber string, commentID int64, body string) error {
+	path := fmt.Sprintf("repos/%s/%s/pulls/%s/comments/%d/replies", owner, repo, prNumber, commentID)
+	return c.APIPost(ctx, path, map[string]string{"body": body})
+}
+
+// FetchReviewThreads fetches review threads for a PR using the GraphQL API.
+func (c *GHCLIClient) FetchReviewThreads(_ context.Context, owner, repo string, prNumber int) ([]ReviewThread, error) {
+	query := fmt.Sprintf(`{ repository(owner:%q, name:%q) { pullRequest(number: %d) { reviewThreads(first: 100) { nodes { id isResolved } } } } }`, owner, repo, prNumber)
+	return fetchReviewThreadsImpl(query, c.runGraphQL)
+}
+
+// ResolveReviewThread resolves a review thread by its GraphQL node ID.
+func (c *GHCLIClient) ResolveReviewThread(_ context.Context, threadID string) error {
+	return resolveReviewThreadImpl(threadID, c.runGraphQL)
+}
+
+// runGraphQL executes a GraphQL query via gh api.
+func (c *GHCLIClient) runGraphQL(query string) ([]byte, error) {
+	cmd := exec.Command("gh", "api", "graphql", "-f", "query="+query)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("gh api graphql: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
+}
+
+// fetchReviewThreadsImpl parses a GraphQL response for review threads.
+func fetchReviewThreadsImpl(query string, runner graphQLRunner) ([]ReviewThread, error) {
+	data, err := runner(query)
+	if err != nil {
+		return nil, err
+	}
+	var result struct {
+		Data struct {
+			Repository struct {
+				PullRequest struct {
+					ReviewThreads struct {
+						Nodes []ReviewThread `json:"nodes"`
+					} `json:"reviewThreads"`
+				} `json:"pullRequest"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("parsing review threads: %w", err)
+	}
+	return result.Data.Repository.PullRequest.ReviewThreads.Nodes, nil
+}
+
+// resolveReviewThreadImpl performs a resolve mutation and parses the response.
+func resolveReviewThreadImpl(threadID string, runner graphQLRunner) error {
+	query := fmt.Sprintf(`mutation { resolveReviewThread(input: {threadId: %q}) { thread { isResolved } } }`, threadID)
+	data, err := runner(query)
+	if err != nil {
+		return err
+	}
+	var result struct {
+		Data struct {
+			ResolveReviewThread struct {
+				Thread struct {
+					IsResolved bool `json:"isResolved"`
+				} `json:"thread"`
+			} `json:"resolveReviewThread"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return fmt.Errorf("parsing resolve response: %w", err)
+	}
+	if len(result.Errors) > 0 {
+		return fmt.Errorf("GraphQL error: %s", result.Errors[0].Message)
+	}
+	return nil
+}
+
+// FetchCollaborators returns the list of collaborator logins for a repo.
+func (c *GHCLIClient) FetchCollaborators(_ context.Context, owner, repo string) ([]string, error) {
+	cmd := exec.Command("gh", "api", fmt.Sprintf("repos/%s/%s/collaborators", owner, repo), "--jq", ".[].login")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("fetching collaborators: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	var logins []string
+	for _, line := range strings.Split(strings.TrimSpace(stdout.String()), "\n") {
+		if line != "" {
+			logins = append(logins, line)
+		}
+	}
+	return logins, nil
+}
+
+// APIGet runs gh api with the given path and returns raw bytes.
+func (c *GHCLIClient) APIGet(_ context.Context, path string) ([]byte, error) {
+	cmd := exec.Command("gh", "api", path)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("gh api %s: %w: %s", path, err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
+}
+
+// APIPost runs gh api with POST method and field arguments.
+func (c *GHCLIClient) APIPost(_ context.Context, path string, fields map[string]string) error {
+	args := []string{"api", path, "-X", "POST"}
+	for k, v := range fields {
+		args = append(args, "-f", k+"="+v)
+	}
+	cmd := exec.Command("gh", args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("gh api POST %s: %w: %s", path, err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+// APIPostJSON runs gh api with POST method and a raw JSON body via --input.
+func (c *GHCLIClient) APIPostJSON(_ context.Context, path string, body interface{}) ([]byte, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling request body: %w", err)
+	}
+	cmd := exec.Command("gh", "api", path, "-X", "POST", "--input", "-")
+	cmd.Stdin = bytes.NewReader(payload)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("gh api POST %s: %w: %s", path, err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
+}
+
+// FetchPRMetadata fetches PR URL, title, head branch, and state from GitHub via gh CLI.
+func (c *GHCLIClient) FetchPRMetadata(_ context.Context, prNumber, repo string) (prURL, title, headBranch, state string, err error) {
+	args := []string{
+		"pr", "view", prNumber,
+		"--repo", repo,
+		"--json", "url,title,headRefName,state",
+		"-q", `(.url) + "\t" + (.title) + "\t" + (.headRefName) + "\t" + (.state)`,
+	}
+	cmd := exec.Command("gh", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", "", "", "", fmt.Errorf("gh pr view: %s", strings.TrimSpace(stderr.String()))
+	}
+
+	parts := strings.SplitN(strings.TrimSpace(stdout.String()), "\t", 4)
+	if len(parts) < 4 {
+		return "", "", "", "", fmt.Errorf("unexpected gh output: %s", stdout.String())
+	}
+	return parts[0], parts[1], parts[2], parts[3], nil
+}
+
+// GetAuthenticatedUser returns the login of the currently authenticated GitHub user.
+func (c *GHCLIClient) GetAuthenticatedUser(_ context.Context) (string, error) {
+	cmd := exec.Command("gh", "api", "user", "-q", ".login")
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("gh api user: %w", err)
+	}
+	login := strings.TrimSpace(stdout.String())
+	if login == "" {
+		return "", fmt.Errorf("empty login from gh api user")
+	}
+	return login, nil
+}
+
+// ChecksArgs returns arguments for "gh pr checks". Exported for testing.
+func (c *GHCLIClient) ChecksArgs(prRef string) []string {
+	return c.ghArgs([]string{"pr", "checks"}, prRef)
+}
+
+// ViewStateArgs returns arguments for "gh pr view --json state". Exported for testing.
+func (c *GHCLIClient) ViewStateArgs(prRef string) []string {
+	return c.ghArgs([]string{"pr", "view", "--json", "state", "-q", ".state"}, prRef)
+}
+
+// ViewConflictsArgs returns arguments for "gh pr view --json mergeable". Exported for testing.
+func (c *GHCLIClient) ViewConflictsArgs(prRef string) []string {
+	return c.ghArgs([]string{"pr", "view", "--json", "mergeable", "-q", ".mergeable"}, prRef)
+}
+
+// ViewReviewDecisionArgs returns arguments for "gh pr view --json reviewDecision". Exported for testing.
+func (c *GHCLIClient) ViewReviewDecisionArgs(prRef string) []string {
+	return c.ghArgs([]string{"pr", "view", "--json", "reviewDecision", "-q", ".reviewDecision"}, prRef)
+}
+
+// ViewTitleArgs returns arguments for "gh pr view --json title". Exported for testing.
+func (c *GHCLIClient) ViewTitleArgs(prRef string) []string {
+	return c.ghArgs([]string{"pr", "view", "--json", "title", "-q", ".title"}, prRef)
+}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -1,94 +1,43 @@
 package github
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"os/exec"
-	"strings"
+	"context"
 )
+
+// Package-level functions are kept for backward compatibility.
+// They delegate to a default GHCLIClient.
 
 // GetRepoOwnerAndName returns owner/repo by querying gh.
 func GetRepoOwnerAndName() (string, string, error) {
-	cmd := exec.Command("gh", "repo", "view", "--json", "owner,name", "-q", ".owner.login + \"/\" + .name")
-	var stdout bytes.Buffer
-	cmd.Stdout = &stdout
-	if err := cmd.Run(); err != nil {
-		return "", "", err
-	}
-	parts := strings.SplitN(strings.TrimSpace(stdout.String()), "/", 2)
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("unexpected repo format")
-	}
-	return parts[0], parts[1], nil
+	return NewGHCLIClient("").GetRepoOwnerAndName(context.TODO())
 }
 
 // APIGet runs gh api with the given path and returns parsed JSON.
 func APIGet(path string) ([]byte, error) {
-	cmd := exec.Command("gh", "api", path)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("gh api %s: %w: %s", path, err, strings.TrimSpace(stderr.String()))
-	}
-	return stdout.Bytes(), nil
+	return NewGHCLIClient("").APIGet(context.TODO(), path)
 }
 
 // APIPost runs gh api with POST method and field arguments.
 func APIPost(path string, fields map[string]string) error {
-	args := []string{"api", path, "-X", "POST"}
-	for k, v := range fields {
-		args = append(args, "-f", k+"="+v)
-	}
-	cmd := exec.Command("gh", args...)
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("gh api POST %s: %w: %s", path, err, strings.TrimSpace(stderr.String()))
-	}
-	return nil
+	return NewGHCLIClient("").APIPost(context.TODO(), path, fields)
 }
 
 // APIPostJSON runs gh api with POST method and a raw JSON body via --input.
 func APIPostJSON(path string, body interface{}) ([]byte, error) {
-	payload, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling request body: %w", err)
-	}
-	cmd := exec.Command("gh", "api", path, "-X", "POST", "--input", "-")
-	cmd.Stdin = bytes.NewReader(payload)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("gh api POST %s: %w: %s", path, err, strings.TrimSpace(stderr.String()))
-	}
-	return stdout.Bytes(), nil
+	return NewGHCLIClient("").APIPostJSON(context.TODO(), path, body)
 }
 
 // GetRepoOwnerAndNameFromDir returns owner/repo for the git repo at the given directory.
 func GetRepoOwnerAndNameFromDir(dir string) (string, string, error) {
-	cmd := exec.Command("gh", "repo", "view", "--json", "owner,name", "-q", ".owner.login + \"/\" + .name")
-	cmd.Dir = dir
-	var stdout bytes.Buffer
-	cmd.Stdout = &stdout
-	if err := cmd.Run(); err != nil {
-		return "", "", fmt.Errorf("resolving repo for %s: %w", dir, err)
-	}
-	parts := strings.SplitN(strings.TrimSpace(stdout.String()), "/", 2)
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("unexpected repo format for %s", dir)
-	}
-	return parts[0], parts[1], nil
+	return NewGHCLIClient("").GetRepoOwnerAndNameFromDir(context.TODO(), dir)
 }
 
 // PRReviewComment represents a single PR review comment from the GitHub API.
 type PRReviewComment struct {
-	ID     int64  `json:"id"`
-	Body   string `json:"body"`
-	Path   string `json:"path"`
-	User   commentUser `json:"user"`
+	ID   int64       `json:"id"`
+	Body string      `json:"body"`
+	Path string      `json:"path"`
+	User commentUser `json:"user"`
 }
 
 type commentUser struct {
@@ -97,22 +46,12 @@ type commentUser struct {
 
 // FetchPRReviewComments fetches review comments for a PR.
 func FetchPRReviewComments(owner, repo, prNumber string) ([]PRReviewComment, error) {
-	path := fmt.Sprintf("repos/%s/%s/pulls/%s/comments", owner, repo, prNumber)
-	data, err := APIGet(path)
-	if err != nil {
-		return nil, err
-	}
-	var comments []PRReviewComment
-	if err := json.Unmarshal(data, &comments); err != nil {
-		return nil, fmt.Errorf("parsing review comments: %w", err)
-	}
-	return comments, nil
+	return NewGHCLIClient("").FetchPRReviewComments(context.TODO(), owner, repo, prNumber)
 }
 
 // ReplyToReviewComment posts a reply to a specific PR review comment.
 func ReplyToReviewComment(owner, repo, prNumber string, commentID int64, body string) error {
-	path := fmt.Sprintf("repos/%s/%s/pulls/%s/comments/%d/replies", owner, repo, prNumber, commentID)
-	return APIPost(path, map[string]string{"body": body})
+	return NewGHCLIClient("").ReplyToReviewComment(context.TODO(), owner, repo, prNumber, commentID, body)
 }
 
 // ReviewThread represents a GitHub PR review thread with its GraphQL node ID.
@@ -122,94 +61,31 @@ type ReviewThread struct {
 }
 
 // FetchReviewThreads fetches review threads for a PR using the GraphQL API.
-// Returns threads with their GraphQL node IDs and resolved status.
 func FetchReviewThreads(owner, repo string, prNumber int) ([]ReviewThread, error) {
-	query := fmt.Sprintf(`{ repository(owner:%q, name:%q) { pullRequest(number: %d) { reviewThreads(first: 100) { nodes { id isResolved } } } } }`, owner, repo, prNumber)
-	return fetchReviewThreadsWithRunner(query, defaultGraphQLRunner)
+	return NewGHCLIClient("").FetchReviewThreads(context.TODO(), owner, repo, prNumber)
 }
 
 // graphQLRunner abstracts the gh api graphql call for testing.
 type graphQLRunner func(query string) ([]byte, error)
 
 func defaultGraphQLRunner(query string) ([]byte, error) {
-	cmd := exec.Command("gh", "api", "graphql", "-f", "query="+query)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("gh api graphql: %w: %s", err, strings.TrimSpace(stderr.String()))
-	}
-	return stdout.Bytes(), nil
+	return NewGHCLIClient("").runGraphQL(query)
 }
 
 func fetchReviewThreadsWithRunner(query string, runner graphQLRunner) ([]ReviewThread, error) {
-	data, err := runner(query)
-	if err != nil {
-		return nil, err
-	}
-	var result struct {
-		Data struct {
-			Repository struct {
-				PullRequest struct {
-					ReviewThreads struct {
-						Nodes []ReviewThread `json:"nodes"`
-					} `json:"reviewThreads"`
-				} `json:"pullRequest"`
-			} `json:"repository"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal(data, &result); err != nil {
-		return nil, fmt.Errorf("parsing review threads: %w", err)
-	}
-	return result.Data.Repository.PullRequest.ReviewThreads.Nodes, nil
+	return fetchReviewThreadsImpl(query, runner)
+}
+
+func resolveReviewThreadWithRunner(threadID string, runner graphQLRunner) error {
+	return resolveReviewThreadImpl(threadID, runner)
 }
 
 // ResolveReviewThread resolves a review thread by its GraphQL node ID.
 func ResolveReviewThread(threadID string) error {
-	return resolveReviewThreadWithRunner(threadID, defaultGraphQLRunner)
-}
-
-func resolveReviewThreadWithRunner(threadID string, runner graphQLRunner) error {
-	query := fmt.Sprintf(`mutation { resolveReviewThread(input: {threadId: %q}) { thread { isResolved } } }`, threadID)
-	data, err := runner(query)
-	if err != nil {
-		return err
-	}
-	var result struct {
-		Data struct {
-			ResolveReviewThread struct {
-				Thread struct {
-					IsResolved bool `json:"isResolved"`
-				} `json:"thread"`
-			} `json:"resolveReviewThread"`
-		} `json:"data"`
-		Errors []struct {
-			Message string `json:"message"`
-		} `json:"errors"`
-	}
-	if err := json.Unmarshal(data, &result); err != nil {
-		return fmt.Errorf("parsing resolve response: %w", err)
-	}
-	if len(result.Errors) > 0 {
-		return fmt.Errorf("GraphQL error: %s", result.Errors[0].Message)
-	}
-	return nil
+	return NewGHCLIClient("").ResolveReviewThread(context.TODO(), threadID)
 }
 
 // FetchCollaborators returns the list of collaborator logins for a repo.
 func FetchCollaborators(owner, repo string) ([]string, error) {
-	cmd := exec.Command("gh", "api", fmt.Sprintf("repos/%s/%s/collaborators", owner, repo), "--jq", ".[].login")
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("fetching collaborators: %w: %s", err, strings.TrimSpace(stderr.String()))
-	}
-	var logins []string
-	for _, line := range strings.Split(strings.TrimSpace(stdout.String()), "\n") {
-		if line != "" {
-			logins = append(logins, line)
-		}
-	}
-	return logins, nil
+	return NewGHCLIClient("").FetchCollaborators(context.TODO(), owner, repo)
 }

--- a/internal/github/pr_client.go
+++ b/internal/github/pr_client.go
@@ -1,61 +1,22 @@
 package github
 
 import (
-	"bytes"
-	"fmt"
-	"os/exec"
 	"strings"
 )
 
 // PRClient provides methods for interacting with GitHub PRs via the gh CLI.
-// It holds repo context so that --repo is always passed automatically.
-type PRClient struct {
-	repo string // owner/repo
-}
+// Deprecated: Use GHCLIClient (which implements the Client interface) instead.
+// PRClient is kept for backward compatibility with existing test helpers.
+type PRClient = GHCLIClient
 
 // NewPRClient creates a PRClient for the given owner/repo.
-// If repo is empty, gh will infer the repo from the current git directory.
+// Deprecated: Use NewGHCLIClient instead.
 func NewPRClient(repo string) *PRClient {
-	return &PRClient{repo: repo}
-}
-
-// Repo returns the configured owner/repo string.
-func (c *PRClient) Repo() string {
-	return c.repo
-}
-
-// ghArgs builds a base arg list with --repo injected when set.
-func (c *PRClient) ghArgs(base []string, prRef string) []string {
-	args := make([]string, len(base))
-	copy(args, base)
-	if c.repo != "" {
-		args = append(args, "--repo", c.repo)
-	}
-	args = append(args, "--", prRef)
-	return args
-}
-
-// GetCI checks CI status by running "gh pr checks" and summarizing pass/fail/pending.
-func (c *PRClient) GetCI(prRef string) string {
-	args := c.ghArgs([]string{"pr", "checks"}, prRef)
-	cmd := exec.Command("gh", args...)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	output := stdout.String()
-
-	if err != nil && output == "" {
-		if strings.Contains(stderr.String(), "no checks reported") {
-			return "passing" // no checks configured — nothing to fail
-		}
-		return "unknown"
-	}
-
-	return ParseCIStatus(output)
+	return NewGHCLIClient(repo)
 }
 
 // ParseCIStatus categorizes "gh pr checks" output into passing/failing/pending/unknown.
+// This is a standalone pure-parsing function, not tied to any client.
 func ParseCIStatus(output string) string {
 	var passing, failing, pending int
 	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
@@ -85,111 +46,6 @@ func ParseCIStatus(output string) string {
 	return "passing"
 }
 
-// GetConflicts checks if a PR has merge conflicts.
-func (c *PRClient) GetConflicts(prRef string) string {
-	args := c.ghArgs([]string{"pr", "view", "--json", "mergeable", "-q", ".mergeable"}, prRef)
-	cmd := exec.Command("gh", args...)
-	var stdout bytes.Buffer
-	cmd.Stdout = &stdout
-	if err := cmd.Run(); err != nil {
-		return "unknown"
-	}
-	val := strings.TrimSpace(stdout.String())
-	if strings.EqualFold(val, "CONFLICTING") {
-		return "yes"
-	}
-	if strings.EqualFold(val, "MERGEABLE") {
-		return "none"
-	}
-	return "unknown"
-}
-
-// GetReviewDecision fetches the review decision for a PR.
-func (c *PRClient) GetReviewDecision(prRef string) string {
-	args := c.ghArgs([]string{"pr", "view", "--json", "reviewDecision", "-q", ".reviewDecision"}, prRef)
-	cmd := exec.Command("gh", args...)
-	var stdout bytes.Buffer
-	cmd.Stdout = &stdout
-	if err := cmd.Run(); err != nil {
-		return "unknown"
-	}
-	return strings.TrimSpace(stdout.String())
-}
-
-// GetState returns the PR state (e.g. "OPEN", "MERGED", "CLOSED").
-func (c *PRClient) GetState(prRef string) string {
-	args := c.ghArgs([]string{"pr", "view", "--json", "state", "-q", ".state"}, prRef)
-	cmd := exec.Command("gh", args...)
-	var stdout bytes.Buffer
-	cmd.Stdout = &stdout
-	if err := cmd.Run(); err != nil {
-		return "UNKNOWN"
-	}
-	val := strings.TrimSpace(stdout.String())
-	if val == "" {
-		return "UNKNOWN"
-	}
-	return strings.ToUpper(val)
-}
-
-// GetBranch returns the head branch name for a PR.
-func (c *PRClient) GetBranch(prRef string) (string, error) {
-	args := c.ghArgs([]string{"pr", "view", "--json", "headRefName", "-q", ".headRefName"}, prRef)
-	cmd := exec.Command("gh", args...)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("gh pr view: %w: %s", err, strings.TrimSpace(stderr.String()))
-	}
-	branch := strings.TrimSpace(stdout.String())
-	if branch == "" {
-		return "", fmt.Errorf("could not determine branch for PR %s", prRef)
-	}
-	return branch, nil
-}
-
-// GetURL returns the HTML URL for a PR.
-func (c *PRClient) GetURL(prRef string) (string, error) {
-	args := c.ghArgs([]string{"pr", "view", "--json", "url", "-q", ".url"}, prRef)
-	cmd := exec.Command("gh", args...)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("gh pr view: %w: %s", err, strings.TrimSpace(stderr.String()))
-	}
-	return strings.TrimSpace(stdout.String()), nil
-}
-
-// GetTitle fetches the title of a PR.
-func (c *PRClient) GetTitle(prRef string) string {
-	args := c.ghArgs([]string{"pr", "view", "--json", "title", "-q", ".title"}, prRef)
-	cmd := exec.Command("gh", args...)
-	var stdout bytes.Buffer
-	cmd.Stdout = &stdout
-	if err := cmd.Run(); err != nil {
-		return "(unknown)"
-	}
-	title := strings.TrimSpace(stdout.String())
-	if title == "" {
-		return "(unknown)"
-	}
-	return title
-}
-
-// Merge merges a PR with the given method.
-func (c *PRClient) Merge(prNumber, mergeMethod string, deleteBranch bool) error {
-	args := MergeArgs(prNumber, mergeMethod, deleteBranch, c.repo)
-	cmd := exec.Command("gh", args...)
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("gh pr merge: %w: %s", err, strings.TrimSpace(stderr.String()))
-	}
-	return nil
-}
-
 // MergeArgs returns arguments for merging a PR. Exported for testing.
 func MergeArgs(prNumber, mergeMethod string, deleteBranch bool, repo string) []string {
 	args := []string{"pr", "merge"}
@@ -209,29 +65,4 @@ func MergeArgs(prNumber, mergeMethod string, deleteBranch bool, repo string) []s
 	}
 	args = append(args, "--", prNumber)
 	return args
-}
-
-// ChecksArgs returns arguments for "gh pr checks". Exported for testing.
-func (c *PRClient) ChecksArgs(prRef string) []string {
-	return c.ghArgs([]string{"pr", "checks"}, prRef)
-}
-
-// ViewStateArgs returns arguments for "gh pr view --json state". Exported for testing.
-func (c *PRClient) ViewStateArgs(prRef string) []string {
-	return c.ghArgs([]string{"pr", "view", "--json", "state", "-q", ".state"}, prRef)
-}
-
-// ViewConflictsArgs returns arguments for "gh pr view --json mergeable". Exported for testing.
-func (c *PRClient) ViewConflictsArgs(prRef string) []string {
-	return c.ghArgs([]string{"pr", "view", "--json", "mergeable", "-q", ".mergeable"}, prRef)
-}
-
-// ViewReviewDecisionArgs returns arguments for "gh pr view --json reviewDecision". Exported for testing.
-func (c *PRClient) ViewReviewDecisionArgs(prRef string) []string {
-	return c.ghArgs([]string{"pr", "view", "--json", "reviewDecision", "-q", ".reviewDecision"}, prRef)
-}
-
-// ViewTitleArgs returns arguments for "gh pr view --json title". Exported for testing.
-func (c *PRClient) ViewTitleArgs(prRef string) []string {
-	return c.ghArgs([]string{"pr", "view", "--json", "title", "-q", ".title"}, prRef)
 }

--- a/internal/github/pr_client_test.go
+++ b/internal/github/pr_client_test.go
@@ -21,7 +21,7 @@ func TestNewPRClient(t *testing.T) {
 }
 
 func TestGHArgsWithRepo(t *testing.T) {
-	c := NewPRClient("owner/repo")
+	c := NewGHCLIClient("owner/repo")
 	got := c.ChecksArgs("42")
 	want := []string{"pr", "checks", "--repo", "owner/repo", "--", "42"}
 	if !reflect.DeepEqual(got, want) {
@@ -30,7 +30,7 @@ func TestGHArgsWithRepo(t *testing.T) {
 }
 
 func TestGHArgsWithoutRepo(t *testing.T) {
-	c := NewPRClient("")
+	c := NewGHCLIClient("")
 	got := c.ChecksArgs("42")
 	want := []string{"pr", "checks", "--", "42"}
 	if !reflect.DeepEqual(got, want) {
@@ -39,7 +39,7 @@ func TestGHArgsWithoutRepo(t *testing.T) {
 }
 
 func TestAllArgBuildersPlaceFlagsBeforeSeparator(t *testing.T) {
-	client := NewPRClient("owner/repo")
+	client := NewGHCLIClient("owner/repo")
 	builders := []struct {
 		name string
 		fn   func(string) []string
@@ -178,7 +178,7 @@ func TestParseCIStatus(t *testing.T) {
 
 func TestArgsAcceptFullURL(t *testing.T) {
 	url := "https://github.com/owner/repo/pull/42"
-	client := NewPRClient("")
+	client := NewGHCLIClient("")
 
 	builders := []struct {
 		name string
@@ -213,8 +213,8 @@ func TestGetCI_NoChecksConfigured(t *testing.T) {
 	origPath := os.Getenv("PATH")
 	t.Setenv("PATH", dir+string(filepath.ListSeparator)+origPath)
 
-	client := NewPRClient("")
-	got := client.GetCI("42")
+	client := NewGHCLIClient("")
+	got := client.GetCI(nil, "42")
 	if got != "passing" {
 		t.Errorf("GetCI() with no checks configured = %q, want %q", got, "passing")
 	}
@@ -231,8 +231,8 @@ func TestGetCI_GhCommandFails(t *testing.T) {
 	origPath := os.Getenv("PATH")
 	t.Setenv("PATH", dir+string(filepath.ListSeparator)+origPath)
 
-	client := NewPRClient("")
-	got := client.GetCI("42")
+	client := NewGHCLIClient("")
+	got := client.GetCI(nil, "42")
 	if got != "unknown" {
 		t.Errorf("GetCI() with gh failure = %q, want %q", got, "unknown")
 	}

--- a/internal/github/review_threads_test.go
+++ b/internal/github/review_threads_test.go
@@ -26,7 +26,7 @@ func TestFetchReviewThreads(t *testing.T) {
 		return []byte(responseJSON), nil
 	}
 
-	threads, err := fetchReviewThreadsWithRunner("ignored", runner)
+	threads, err := fetchReviewThreadsImpl("ignored", runner)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func TestFetchReviewThreadsEmpty(t *testing.T) {
 		return []byte(responseJSON), nil
 	}
 
-	threads, err := fetchReviewThreadsWithRunner("ignored", runner)
+	threads, err := fetchReviewThreadsImpl("ignored", runner)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +75,7 @@ func TestFetchReviewThreadsAPIError(t *testing.T) {
 		return nil, fmt.Errorf("gh api graphql: exit status 1: not found")
 	}
 
-	_, err := fetchReviewThreadsWithRunner("ignored", runner)
+	_, err := fetchReviewThreadsImpl("ignored", runner)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -98,7 +98,7 @@ func TestResolveReviewThread(t *testing.T) {
 		return []byte(responseJSON), nil
 	}
 
-	err := resolveReviewThreadWithRunner("RT_abc", runner)
+	err := resolveReviewThreadImpl("RT_abc", runner)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestResolveReviewThreadGraphQLError(t *testing.T) {
 		return []byte(responseJSON), nil
 	}
 
-	err := resolveReviewThreadWithRunner("RT_abc", runner)
+	err := resolveReviewThreadImpl("RT_abc", runner)
 	if err == nil {
 		t.Fatal("expected error from GraphQL error response")
 	}
@@ -131,7 +131,7 @@ func TestResolveReviewThreadAPIError(t *testing.T) {
 		return nil, fmt.Errorf("gh api graphql: exit status 1: forbidden")
 	}
 
-	err := resolveReviewThreadWithRunner("RT_abc", runner)
+	err := resolveReviewThreadImpl("RT_abc", runner)
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -92,7 +92,9 @@ func New(store run.StateStore, eventLog *event.Log, logger *slog.Logger) *Contro
 	c.launchAgent = c.defaultLaunchAgent
 	c.mergePRs = c.defaultMergePRs
 	c.snapshotThreads = c.defaultSnapshotThreads
-	c.resolveThread = ghutil.ResolveReviewThread
+	c.resolveThread = func(threadID string) error {
+		return ghutil.NewGHCLIClient("").ResolveReviewThread(context.TODO(), threadID)
+	}
 	return c
 }
 
@@ -678,7 +680,7 @@ func (c *Controller) defaultSnapshotThreads(repo, prNumber string) ([]string, er
 	if err != nil {
 		return nil, fmt.Errorf("invalid PR number: %s", prNumber)
 	}
-	threads, err := ghutil.FetchReviewThreads(parts[0], parts[1], prNum)
+	threads, err := ghutil.NewGHCLIClient("").FetchReviewThreads(context.TODO(), parts[0], parts[1], prNum)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Defines a `github.Client` interface covering all GitHub operations Klaus uses (PR queries, mutations, reviews, collaborators, generic API)
- Implements `GHCLIClient` backed by existing `gh` CLI calls — no behavioral changes
- Threads the interface through dashboard, pipeline controller, merge, status, launch, track, and webhook setup
- All I/O methods take `context.Context` as first parameter (sets up for #203 timeouts)
- `ParseCIStatus` kept as standalone exported function (pure parser, not API call)

Closes #194

## Key changes

| File | Change |
|------|--------|
| `internal/github/client.go` | New — 18-method `Client` interface |
| `internal/github/gh_cli_client.go` | New — `GHCLIClient` implementing the interface |
| `internal/github/github.go` | Thinned to backward-compat wrappers + types |
| `internal/github/pr_client.go` | `PRClient` aliased to `GHCLIClient` |
| `internal/cmd/dashboard.go` | Accepts `gh.Client` via constructor |
| `internal/cmd/merge.go` | Uses `GHCLIClient` with context |
| `internal/cmd/status.go` | Uses `GHCLIClient` with context |
| `internal/cmd/launch.go` | Uses `GHCLIClient` with context |
| `internal/cmd/track.go` | Delegates to `client.FetchPRMetadata` |
| `internal/pipeline/pipeline.go` | Uses `GHCLIClient` for thread operations |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` — all 13 packages pass
- [x] No behavioral changes — pure refactor