### PR TITLE
fix: log cleanup/finalization errors instead of swallowing them

### DIFF
--- a/internal/cmd/cleanup.go
+++ b/internal/cmd/cleanup.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/patflynn/klaus/internal/git"
@@ -101,6 +102,8 @@ func cleanupOne(root string, store run.StateStore, id string, force bool) error 
 	if state.TmuxPane != nil && tmux.PaneExists(*state.TmuxPane) {
 		if err := tmux.KillPane(*state.TmuxPane); err == nil {
 			fmt.Println("  killed tmux pane")
+		} else {
+			slog.Warn("failed to kill tmux pane", "id", id, "pane", *state.TmuxPane, "err", err)
 		}
 	}
 
@@ -108,6 +111,8 @@ func cleanupOne(root string, store run.StateStore, id string, force bool) error 
 	if state.DashboardPane != nil && tmux.PaneExists(*state.DashboardPane) {
 		if err := tmux.KillPane(*state.DashboardPane); err == nil {
 			fmt.Println("  killed dashboard pane")
+		} else {
+			slog.Warn("failed to kill dashboard pane", "id", id, "pane", *state.DashboardPane, "err", err)
 		}
 	}
 
@@ -121,6 +126,8 @@ func cleanupOne(root string, store run.StateStore, id string, force bool) error 
 	if state.Worktree != "" {
 		if err := git.WorktreeRemove(gitRoot, state.Worktree); err == nil {
 			fmt.Println("  removed worktree")
+		} else {
+			slog.Warn("failed to remove worktree", "id", id, "worktree", state.Worktree, "err", err)
 		}
 	}
 
@@ -128,12 +135,16 @@ func cleanupOne(root string, store run.StateStore, id string, force bool) error 
 	if state.Branch != "" {
 		if err := git.BranchDelete(gitRoot, state.Branch); err == nil {
 			fmt.Println("  deleted local branch")
+		} else {
+			slog.Warn("failed to delete local branch", "id", id, "branch", state.Branch, "err", err)
 		}
 	}
 
 	// Remove state file
 	if err := store.Delete(id); err == nil {
 		fmt.Println("  removed state file")
+	} else {
+		slog.Warn("failed to remove state file", "id", id, "err", err)
 	}
 
 	fmt.Println("  done.")

--- a/internal/cmd/hidden.go
+++ b/internal/cmd/hidden.go
@@ -120,7 +120,7 @@ func cleanupWorktree(store run.StateStore, state *run.State) {
 	}
 	if state.Branch != "" {
 		if err := git.BranchDelete(gitRoot, state.Branch); err != nil {
-			slog.Warn("failed to delete branch during cleanup", "branch", state.Branch, "err", err)
+			slog.Warn("failed to delete branch during cleanup", "id", state.ID, "branch", state.Branch, "err", err)
 		}
 	}
 	state.Worktree = ""

--- a/internal/cmd/hidden.go
+++ b/internal/cmd/hidden.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"regexp"
 
@@ -118,10 +119,14 @@ func cleanupWorktree(store run.StateStore, state *run.State) {
 		fmt.Fprintf(os.Stderr, "warning: worktree cleanup: %v\n", err)
 	}
 	if state.Branch != "" {
-		_ = git.BranchDelete(gitRoot, state.Branch)
+		if err := git.BranchDelete(gitRoot, state.Branch); err != nil {
+			slog.Warn("failed to delete branch during cleanup", "branch", state.Branch, "err", err)
+		}
 	}
 	state.Worktree = ""
-	_ = store.Save(state)
+	if err := store.Save(state); err != nil {
+		slog.Warn("failed to save state after worktree cleanup", "id", state.ID, "err", err)
+	}
 }
 
 func finalizeFromLog(store run.StateStore, state *run.State) error {

--- a/internal/cmd/merge.go
+++ b/internal/cmd/merge.go
@@ -291,7 +291,7 @@ func rebaseAndPush(prNumber string, repo string) error {
 		abortCmd := exec.Command("git", "rebase", "--abort")
 		abortCmd.Dir = worktreePath
 		if abortErr := abortCmd.Run(); abortErr != nil {
-			slog.Warn("failed to abort rebase", "worktree", worktreePath, "err", abortErr)
+			slog.Warn("failed to abort rebase", "pr", prNumber, "worktree", worktreePath, "err", abortErr)
 		}
 		return fmt.Errorf("rebase conflicts: %s", strings.TrimSpace(stderr.String()))
 	}

--- a/internal/cmd/merge.go
+++ b/internal/cmd/merge.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -171,7 +172,9 @@ func markRunsMerged(store run.StateStore) func(string) {
 		for _, s := range states {
 			if extractPRNumber(s) == prNumber {
 				s.MergedAt = &now
-				store.Save(s)
+				if err := store.Save(s); err != nil {
+					slog.Warn("failed to save merged state", "id", s.ID, "err", err)
+				}
 			}
 		}
 	}
@@ -287,7 +290,9 @@ func rebaseAndPush(prNumber string, repo string) error {
 	if err := rebaseCmd.Run(); err != nil {
 		abortCmd := exec.Command("git", "rebase", "--abort")
 		abortCmd.Dir = worktreePath
-		abortCmd.Run()
+		if abortErr := abortCmd.Run(); abortErr != nil {
+			slog.Warn("failed to abort rebase", "worktree", worktreePath, "err", abortErr)
+		}
 		return fmt.Errorf("rebase conflicts: %s", strings.TrimSpace(stderr.String()))
 	}
 

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"crypto/rand"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -179,7 +180,9 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 			modified = true
 		}
 		if modified {
-			_ = store.Save(state)
+			if err := store.Save(state); err != nil {
+				slog.Warn("failed to save state after clearing stale panes", "id", state.ID, "err", err)
+			}
 		}
 
 		fmt.Printf("Resuming coordinator session %s...\n", id)
@@ -321,7 +324,9 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 		if csID != "" {
 			claudeArgs = append(claudeArgs, "--session-id", csID)
 			state.ClaudeSessionID = &csID
-			_ = store.Save(state)
+			if err := store.Save(state); err != nil {
+				slog.Warn("failed to save state with claude session ID", "id", state.ID, "err", err)
+			}
 		}
 	}
 	claude := exec.Command("claude", claudeArgs...)
@@ -391,7 +396,9 @@ func waitForAgents(store run.StateStore) {
 
 			if !s.IsAgentRunning() {
 				fmt.Printf("  agent %s finished, closing pane\n", s.ID)
-				tmux.KillPane(*s.TmuxPane)
+				if err := tmux.KillPane(*s.TmuxPane); err != nil {
+					slog.Warn("failed to kill agent pane", "id", s.ID, "pane", *s.TmuxPane, "err", err)
+				}
 				continue
 			}
 


### PR DESCRIPTION
## Summary

- Replace `_ = fn()` patterns and unchecked errors in cleanup paths with `slog.Warn` calls
- All errors remain non-fatal — no control flow changes
- Adds structured context (id, branch, pane, worktree, err) to every warning

Closes #205

## Files changed

- `internal/cmd/hidden.go` — `cleanupWorktree`: branch delete, state save
- `internal/cmd/session.go` — stale pane clearing, session ID save, pane kill in `waitForAgents`
- `internal/cmd/cleanup.go` — all 5 cleanup operations (panes, worktree, branch, state file)
- `internal/cmd/merge.go` — `markRunsMerged` state save, rebase abort

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` — all packages pass
- [x] No behavioral changes — pure observability improvement