### PR TITLE
refactor: introduce git.Client interface

### DIFF
--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -1,0 +1,53 @@
+package git
+
+import "context"
+
+// Client defines the interface for all git operations Klaus uses.
+// Implementations must be safe for concurrent use.
+type Client interface {
+	// CommonDir returns the absolute path to the git common directory.
+	// This works from worktrees too (returns the main repo's .git dir).
+	CommonDir(ctx context.Context) (string, error)
+
+	// FetchAll fetches all branches and tags from origin, pruning deleted remote branches.
+	FetchAll(ctx context.Context, repoDir string) error
+
+	// FetchBranch fetches a single branch from origin.
+	FetchBranch(ctx context.Context, repoDir, branch string) error
+
+	// WorktreeAdd creates a new worktree at path on a new branch based on startPoint.
+	// If the branch is already checked out in a stale worktree, it prunes and retries once.
+	WorktreeAdd(ctx context.Context, repoDir, path, branch, startPoint string) error
+
+	// WorktreeRemove removes a worktree. repoDir is the main repo directory.
+	WorktreeRemove(ctx context.Context, repoDir, path string) error
+
+	// WorktreeAddTrack creates a worktree tracking an existing remote branch.
+	// If the branch is already checked out in a stale worktree, it prunes and retries once.
+	WorktreeAddTrack(ctx context.Context, repoDir, path, branch string) error
+
+	// WorktreePrune removes stale worktree tracking information.
+	WorktreePrune(ctx context.Context, repoDir string) error
+
+	// BranchDelete deletes a local branch.
+	BranchDelete(ctx context.Context, repoDir, branch string) error
+
+	// EnsureDataRef ensures the custom data ref exists. Creates it with an empty
+	// initial commit if it doesn't.
+	EnsureDataRef(ctx context.Context, repoDir, dataRef string) error
+
+	// SyncToDataRef commits files to the data ref using a temporary index.
+	// files is a map of path-in-tree -> local-file-path.
+	SyncToDataRef(ctx context.Context, repoDir, dataRef, commitMsg string, files map[string]string) error
+
+	// EnsureClone clones a repo to destDir if it doesn't already exist.
+	// If it already exists, fetches the latest from origin.
+	EnsureClone(ctx context.Context, cloneURL, destDir string) error
+
+	// PushDataRef pushes the data ref to origin.
+	PushDataRef(ctx context.Context, repoDir, dataRef string) error
+
+	// InstallCommitMsgHook installs a commit-msg hook in the given worktree that
+	// strips Claude/Anthropic attribution from commit messages.
+	InstallCommitMsgHook(ctx context.Context, worktreeDir string) error
+}

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -1,0 +1,64 @@
+package git
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestExecClientImplementsClient verifies ExecClient satisfies the Client
+// interface by running a representative subset of operations against a real
+// git repo.
+func TestExecClientImplementsClient(t *testing.T) {
+	repo := initTestRepo(t)
+	ctx := context.Background()
+
+	var c Client = NewExecClient()
+
+	// FetchAll — no remote configured in the test repo, so we expect an error
+	// but the method must exist and be callable.
+	_ = c.FetchAll(ctx, repo)
+
+	// WorktreeAdd / WorktreeRemove
+	wtPath := filepath.Join(t.TempDir(), "client-wt")
+	if err := c.WorktreeAdd(ctx, repo, wtPath, "client-branch", "main"); err != nil {
+		t.Fatalf("WorktreeAdd via Client: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(wtPath, "README.md")); err != nil {
+		t.Errorf("worktree should contain README.md: %v", err)
+	}
+
+	if err := c.WorktreeRemove(ctx, repo, wtPath); err != nil {
+		t.Fatalf("WorktreeRemove via Client: %v", err)
+	}
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Error("worktree directory should be removed")
+	}
+
+	// BranchDelete
+	if err := c.BranchDelete(ctx, repo, "client-branch"); err != nil {
+		t.Fatalf("BranchDelete via Client: %v", err)
+	}
+
+	// EnsureDataRef
+	ref := "refs/klaus/client-test"
+	if err := c.EnsureDataRef(ctx, repo, ref); err != nil {
+		t.Fatalf("EnsureDataRef via Client: %v", err)
+	}
+
+	// SyncToDataRef
+	tmpFile := filepath.Join(t.TempDir(), "data.json")
+	if err := os.WriteFile(tmpFile, []byte(`{"test":true}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	files := map[string]string{"test/data.json": tmpFile}
+	if err := c.SyncToDataRef(ctx, repo, ref, "test sync", files); err != nil {
+		t.Fatalf("SyncToDataRef via Client: %v", err)
+	}
+
+	// WorktreePrune — should succeed even with nothing to prune
+	if err := c.WorktreePrune(ctx, repo); err != nil {
+		t.Fatalf("WorktreePrune via Client: %v", err)
+	}
+}

--- a/internal/git/exec_client.go
+++ b/internal/git/exec_client.go
@@ -1,0 +1,66 @@
+package git
+
+import "context"
+
+// ExecClient implements Client by shelling out to the git binary.
+type ExecClient struct{}
+
+// NewExecClient returns a new ExecClient.
+func NewExecClient() *ExecClient {
+	return &ExecClient{}
+}
+
+func (c *ExecClient) CommonDir(_ context.Context) (string, error) {
+	return CommonDir()
+}
+
+func (c *ExecClient) FetchAll(_ context.Context, repoDir string) error {
+	return FetchAll(repoDir)
+}
+
+func (c *ExecClient) FetchBranch(_ context.Context, repoDir, branch string) error {
+	return FetchBranch(repoDir, branch)
+}
+
+func (c *ExecClient) WorktreeAdd(_ context.Context, repoDir, path, branch, startPoint string) error {
+	return WorktreeAdd(repoDir, path, branch, startPoint)
+}
+
+func (c *ExecClient) WorktreeRemove(_ context.Context, repoDir, path string) error {
+	return WorktreeRemove(repoDir, path)
+}
+
+func (c *ExecClient) WorktreeAddTrack(_ context.Context, repoDir, path, branch string) error {
+	return WorktreeAddTrack(repoDir, path, branch)
+}
+
+func (c *ExecClient) WorktreePrune(_ context.Context, repoDir string) error {
+	return WorktreePrune(repoDir)
+}
+
+func (c *ExecClient) BranchDelete(_ context.Context, repoDir, branch string) error {
+	return BranchDelete(repoDir, branch)
+}
+
+func (c *ExecClient) EnsureDataRef(_ context.Context, repoDir, dataRef string) error {
+	return EnsureDataRef(repoDir, dataRef)
+}
+
+func (c *ExecClient) SyncToDataRef(_ context.Context, repoDir, dataRef, commitMsg string, files map[string]string) error {
+	return SyncToDataRef(repoDir, dataRef, commitMsg, files)
+}
+
+func (c *ExecClient) EnsureClone(_ context.Context, cloneURL, destDir string) error {
+	return EnsureClone(cloneURL, destDir)
+}
+
+func (c *ExecClient) PushDataRef(_ context.Context, repoDir, dataRef string) error {
+	return PushDataRef(repoDir, dataRef)
+}
+
+func (c *ExecClient) InstallCommitMsgHook(_ context.Context, worktreeDir string) error {
+	return InstallCommitMsgHook(worktreeDir)
+}
+
+// compile-time check
+var _ Client = (*ExecClient)(nil)


### PR DESCRIPTION
## Summary

- Defines a `git.Client` interface covering 13 operations (worktree, branch, data ref, clone, fetch, hooks)
- Implements `ExecClient` backed by existing `exec.Command("git", ...)` calls
- Adds integration test exercising the interface against a real git repo
- Existing package-level functions preserved as backward-compatible wrappers for incremental migration
- `RepoRoot()` kept standalone (needed for bootstrapping before a client exists)
- All I/O methods take `context.Context` as first parameter

Closes #196

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` — all packages pass, including new `client_test.go`
- [x] No behavioral changes — pure refactor