### PR TITLE
fix: detect and recover stale agent runs

### DIFF
--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -240,6 +240,13 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case statesLoadedMsg:
 		m.states = msg.states
+		// Detect and finalize stale (orphaned) runs so they stop appearing as active.
+		for _, s := range m.states {
+			if s.IsStale() {
+				slog.Info("finalizing stale run", "id", s.ID)
+				markRunFailed(m.store, s)
+			}
+		}
 		return m, fetchGHStatusCmd(m.ghClient, m.states)
 
 	case ghStatusMsg:
@@ -956,6 +963,21 @@ func computeSessionDuration(states []*run.State) time.Duration {
 		return 0
 	}
 	return time.Since(oldest)
+}
+
+// markRunFailed sets sentinel finalization values on a stale run and
+// cleans up its worktree and branch. Errors during cleanup are logged
+// but do not prevent the state from being saved.
+func markRunFailed(store run.StateStore, s *run.State) {
+	cost := float64(-1)
+	dur := int64(0)
+	s.CostUSD = &cost
+	s.DurationMS = &dur
+	s.TmuxPane = nil
+	cleanupWorktree(store, s)
+	if err := store.Save(s); err != nil {
+		slog.Warn("failed to save stale run state", "id", s.ID, "err", err)
+	}
 }
 
 // isAgentRunning checks if a run's agent is currently active in tmux.

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -366,10 +366,14 @@ func waitForAgents(store run.StateStore) {
 		return
 	}
 
-	// Collect agent runs that still have live tmux panes
+	// Collect agent runs that still have live tmux panes, skipping stale ones.
 	var active []*run.State
 	for _, s := range states {
 		if s.Type == "session" {
+			continue
+		}
+		if s.IsStale() {
+			fmt.Printf("  agent %s is stale (orphaned), skipping\n", s.ID)
 			continue
 		}
 		if s.TmuxPane != nil && tmux.PaneExists(*s.TmuxPane) {

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -62,6 +62,43 @@ func (s *State) IsAgentRunning() bool {
 	return !PaneIsDead(*s.TmuxPane)
 }
 
+// StaleGracePeriod is how long after creation before a run can be considered stale.
+// This allows time for the agent pipeline to start up.
+var StaleGracePeriod = 2 * time.Minute
+
+// IsStale returns true if the run appears to have been orphaned — its pipeline
+// never ran _finalize. A run is stale when it has no finalization data (CostUSD
+// and DurationMS are both nil), its tmux pane no longer exists, and enough time
+// has passed since creation to rule out normal startup delays.
+func (s *State) IsStale() bool {
+	// Already finalized — not stale.
+	if s.CostUSD != nil || s.DurationMS != nil {
+		return false
+	}
+
+	// Sessions are not agent runs.
+	if s.Type == "session" {
+		return false
+	}
+
+	// If the pane reference is nil or the pane still exists, not stale.
+	if s.TmuxPane == nil {
+		// No pane reference at all — could be stale if old enough, but we
+		// require the pane to have existed and then disappeared.
+		return false
+	}
+	if PaneExists(*s.TmuxPane) {
+		return false
+	}
+
+	// Grace period: don't mark very recent runs as stale.
+	created, err := time.Parse(time.RFC3339, s.CreatedAt)
+	if err != nil {
+		return false
+	}
+	return time.Since(created) > StaleGracePeriod
+}
+
 // GenID generates a run ID in the format YYYYMMDD-HHMM-XXXX where XXXX is 4 hex chars.
 func GenID() (string, error) {
 	ts := time.Now().Format("20060102-1504")

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"testing"
+	"time"
 )
 
 func TestGenID(t *testing.T) {
@@ -267,4 +268,137 @@ func TestGitDirStoreListSkipsCorruptFiles(t *testing.T) {
 	if result[0].ID != "20260210-1430-aaaa" {
 		t.Errorf("result[0].ID = %q, want 20260210-1430-aaaa", result[0].ID)
 	}
+}
+
+func TestIsStale(t *testing.T) {
+	oldPaneExists := PaneExists
+	defer func() { PaneExists = oldPaneExists }()
+
+	oldGrace := StaleGracePeriod
+	defer func() { StaleGracePeriod = oldGrace }()
+	StaleGracePeriod = 0 // disable grace period for most sub-tests
+
+	paneGone := func(string) bool { return false }
+	paneAlive := func(string) bool { return true }
+
+	strp := func(s string) *string { return &s }
+	fptr := func(f float64) *float64 { return &f }
+	iptr := func(i int64) *int64 { return &i }
+
+	past := time.Now().Add(-10 * time.Minute).Format(time.RFC3339)
+
+	tests := []struct {
+		name     string
+		state    State
+		paneFunc func(string) bool
+		want     bool
+	}{
+		{
+			name: "unfinalized, pane gone, old enough => stale",
+			state: State{
+				ID:        "test-1",
+				TmuxPane:  strp("%1"),
+				CreatedAt: past,
+			},
+			paneFunc: paneGone,
+			want:     true,
+		},
+		{
+			name: "finalized with cost => not stale",
+			state: State{
+				ID:        "test-2",
+				TmuxPane:  strp("%1"),
+				CostUSD:   fptr(0.5),
+				CreatedAt: past,
+			},
+			paneFunc: paneGone,
+			want:     false,
+		},
+		{
+			name: "finalized with duration => not stale",
+			state: State{
+				ID:         "test-3",
+				TmuxPane:   strp("%1"),
+				DurationMS: iptr(1000),
+				CreatedAt:  past,
+			},
+			paneFunc: paneGone,
+			want:     false,
+		},
+		{
+			name: "pane still alive => not stale",
+			state: State{
+				ID:        "test-4",
+				TmuxPane:  strp("%1"),
+				CreatedAt: past,
+			},
+			paneFunc: paneAlive,
+			want:     false,
+		},
+		{
+			name: "no tmux pane reference => not stale",
+			state: State{
+				ID:        "test-5",
+				CreatedAt: past,
+			},
+			paneFunc: paneGone,
+			want:     false,
+		},
+		{
+			name: "session type => not stale",
+			state: State{
+				ID:        "test-6",
+				Type:      "session",
+				TmuxPane:  strp("%1"),
+				CreatedAt: past,
+			},
+			paneFunc: paneGone,
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			PaneExists = tt.paneFunc
+			got := tt.state.IsStale()
+			if got != tt.want {
+				t.Errorf("IsStale() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsStale_GracePeriod(t *testing.T) {
+	oldPaneExists := PaneExists
+	defer func() { PaneExists = oldPaneExists }()
+
+	oldGrace := StaleGracePeriod
+	defer func() { StaleGracePeriod = oldGrace }()
+
+	PaneExists = func(string) bool { return false }
+	StaleGracePeriod = 5 * time.Minute
+
+	strp := func(s string) *string { return &s }
+
+	t.Run("within grace period => not stale", func(t *testing.T) {
+		s := State{
+			ID:        "test-grace",
+			TmuxPane:  strp("%1"),
+			CreatedAt: time.Now().Add(-1 * time.Minute).Format(time.RFC3339),
+		}
+		if s.IsStale() {
+			t.Error("expected not stale within grace period")
+		}
+	})
+
+	t.Run("past grace period => stale", func(t *testing.T) {
+		s := State{
+			ID:        "test-grace-expired",
+			TmuxPane:  strp("%1"),
+			CreatedAt: time.Now().Add(-10 * time.Minute).Format(time.RFC3339),
+		}
+		if !s.IsStale() {
+			t.Error("expected stale past grace period")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- Adds `IsStale()` method to `run.State` — detects runs that are not finalized, have no live tmux pane, and are past a 2-minute grace period
- Dashboard auto-recovers stale runs on state load: marks them failed, cleans up worktrees/branches
- `waitForAgents()` in session.go skips stale runs instead of blocking indefinitely
- 8 test cases covering all `IsStale()` logic paths

Closes #199

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` — all packages pass including 8 new `IsStale()` tests
- [x] Stale detection excludes: finalized runs, live panes, sessions, runs within grace period