### PR TITLE
refactor: replace global mutable function pointers with DI

### DIFF
--- a/internal/cmd/cleanup.go
+++ b/internal/cmd/cleanup.go
@@ -25,13 +25,15 @@ by default; pass --force to remove them anyway.`,
 
 		root, _ := git.RepoRoot() // may be empty outside a repo
 
+		deps := DefaultCleanupDeps()
+
 		if all {
 			store, err := sessionStoreOrAll()
 			if err != nil {
 				return err
 			}
 			if store != nil {
-				return cleanupAll(root, store, force)
+				return cleanupAll(root, store, force, deps)
 			}
 			// No session env — could scan all, but require explicit session
 			return fmt.Errorf("KLAUS_SESSION_ID not set; specify a run ID or run inside a session")
@@ -46,11 +48,11 @@ by default; pass --force to remove them anyway.`,
 			return err
 		}
 		_ = state // cleanupOne will re-load
-		return cleanupOne(root, store, args[0], force)
+		return cleanupOne(root, store, args[0], force, deps)
 	},
 }
 
-func cleanupAll(root string, store run.StateStore, force bool) error {
+func cleanupAll(root string, store run.StateStore, force bool, deps CleanupDeps) error {
 	states, err := store.List()
 	if err != nil {
 		return err
@@ -60,15 +62,27 @@ func cleanupAll(root string, store run.StateStore, force bool) error {
 		return nil
 	}
 	for _, s := range states {
-		if err := cleanupOne(root, store, s.ID, force); err != nil {
+		if err := cleanupOne(root, store, s.ID, force, deps); err != nil {
 			fmt.Printf("  warning: failed to clean up %s: %v\n", s.ID, err)
 		}
 	}
 	return nil
 }
 
-// isRunActive reports whether the run has a live, non-idle tmux pane or is the current session.
-var isRunActive = func(state *run.State) bool {
+// CleanupDeps holds dependencies for cleanup operations.
+type CleanupDeps struct {
+	IsRunActive func(state *run.State) bool
+}
+
+// DefaultCleanupDeps returns CleanupDeps wired to real implementations.
+func DefaultCleanupDeps() CleanupDeps {
+	return CleanupDeps{
+		IsRunActive: defaultIsRunActive,
+	}
+}
+
+// defaultIsRunActive reports whether the run has a live, non-idle tmux pane or is the current session.
+func defaultIsRunActive(state *run.State) bool {
 	if state.Type == "session" {
 		if sid := os.Getenv(sessionIDEnv); sid != "" && state.ID == sid {
 			return true
@@ -85,13 +99,13 @@ var isRunActive = func(state *run.State) bool {
 	return false
 }
 
-func cleanupOne(root string, store run.StateStore, id string, force bool) error {
+func cleanupOne(root string, store run.StateStore, id string, force bool, deps CleanupDeps) error {
 	state, err := store.Load(id)
 	if err != nil {
 		return fmt.Errorf("no run found with id: %s", id)
 	}
 
-	if !force && isRunActive(state) {
+	if !force && deps.IsRunActive(state) {
 		fmt.Printf("skipping %s (still running) — use --force to remove\n", id)
 		return nil
 	}

--- a/internal/cmd/cleanup_test.go
+++ b/internal/cmd/cleanup_test.go
@@ -18,12 +18,10 @@ func TestCleanupAllSkipsActiveRuns(t *testing.T) {
 	)
 
 	// Make run-2 active
-	origIsRunActive := isRunActive
-	defer func() { isRunActive = origIsRunActive }()
-	isRunActive = func(s *run.State) bool { return s.ID == "run-2" }
+	deps := CleanupDeps{IsRunActive: func(s *run.State) bool { return s.ID == "run-2" }}
 
 	output := captureStdout(t, func() {
-		if err := cleanupAll("", store, false); err != nil {
+		if err := cleanupAll("", store, false, deps); err != nil {
 			t.Fatalf("cleanupAll() error: %v", err)
 		}
 	})
@@ -51,12 +49,10 @@ func TestCleanupAllForceRemovesActiveRuns(t *testing.T) {
 		&run.State{ID: "run-2", Prompt: "b", Branch: "b2", CreatedAt: "2026-01-01T00:01:00Z"},
 	)
 
-	origIsRunActive := isRunActive
-	defer func() { isRunActive = origIsRunActive }()
-	isRunActive = func(s *run.State) bool { return s.ID == "run-2" }
+	deps := CleanupDeps{IsRunActive: func(s *run.State) bool { return s.ID == "run-2" }}
 
 	output := captureStdout(t, func() {
-		if err := cleanupAll("", store, true); err != nil {
+		if err := cleanupAll("", store, true, deps); err != nil {
 			t.Fatalf("cleanupAll() error: %v", err)
 		}
 	})
@@ -80,12 +76,10 @@ func TestCleanupOneSkipsActiveRun(t *testing.T) {
 		&run.State{ID: "run-1", Prompt: "a", Branch: "b1", CreatedAt: "2026-01-01T00:00:00Z"},
 	)
 
-	origIsRunActive := isRunActive
-	defer func() { isRunActive = origIsRunActive }()
-	isRunActive = func(s *run.State) bool { return true }
+	deps := CleanupDeps{IsRunActive: func(s *run.State) bool { return true }}
 
 	output := captureStdout(t, func() {
-		if err := cleanupOne("", store, "run-1", false); err != nil {
+		if err := cleanupOne("", store, "run-1", false, deps); err != nil {
 			t.Fatalf("cleanupOne() error: %v", err)
 		}
 	})
@@ -103,12 +97,10 @@ func TestCleanupOneForceRemovesActiveRun(t *testing.T) {
 		&run.State{ID: "run-1", Prompt: "a", Branch: "b1", CreatedAt: "2026-01-01T00:00:00Z"},
 	)
 
-	origIsRunActive := isRunActive
-	defer func() { isRunActive = origIsRunActive }()
-	isRunActive = func(s *run.State) bool { return true }
+	deps := CleanupDeps{IsRunActive: func(s *run.State) bool { return true }}
 
 	captureStdout(t, func() {
-		if err := cleanupOne("", store, "run-1", true); err != nil {
+		if err := cleanupOne("", store, "run-1", true, deps); err != nil {
 			t.Fatalf("cleanupOne() error: %v", err)
 		}
 	})
@@ -119,47 +111,38 @@ func TestCleanupOneForceRemovesActiveRun(t *testing.T) {
 }
 
 func TestIsRunActiveWithSessionEnv(t *testing.T) {
-	origIsRunActive := isRunActive
-	defer func() { isRunActive = origIsRunActive }()
-	// Reset to the real implementation for this test
-	isRunActive = origIsRunActive
-
 	t.Setenv(sessionIDEnv, "sess-123")
 
 	// Session run matching current session ID should be active
 	s := &run.State{ID: "sess-123", Type: "session"}
-	if !isRunActive(s) {
+	if !defaultIsRunActive(s) {
 		t.Error("expected session run matching KLAUS_SESSION_ID to be active")
 	}
 
 	// Different session ID should not be active (no tmux pane)
 	s2 := &run.State{ID: "sess-456", Type: "session"}
-	if isRunActive(s2) {
+	if defaultIsRunActive(s2) {
 		t.Error("expected different session ID to not be active")
 	}
 
 	// Non-session run without tmux pane should not be active
 	s3 := &run.State{ID: "sess-123", Type: "launch"}
-	if isRunActive(s3) {
+	if defaultIsRunActive(s3) {
 		t.Error("expected non-session run without tmux pane to not be active")
 	}
 }
 
 func TestIsRunActiveWithDashboardPane(t *testing.T) {
-	origIsRunActive := isRunActive
-	defer func() { isRunActive = origIsRunActive }()
-	isRunActive = origIsRunActive
-
 	// A run with no panes should not be active
 	s := &run.State{ID: "run-1"}
-	if isRunActive(s) {
+	if defaultIsRunActive(s) {
 		t.Error("expected run without panes to not be active")
 	}
 
 	// A run with a DashboardPane that doesn't exist should not be active
 	fakePaneID := "%999999"
 	s2 := &run.State{ID: "run-2", DashboardPane: &fakePaneID}
-	if isRunActive(s2) {
+	if defaultIsRunActive(s2) {
 		t.Error("expected run with dead dashboard pane to not be active")
 	}
 }

--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -159,6 +159,7 @@ type repoGroup struct {
 type dashboardModel struct {
 	store          run.StateStore
 	ghClient       gh.Client
+	tmuxDeps       run.TmuxDeps
 	states         []*run.State
 	ghStatus       map[string]*prStatus // keyed by PR number
 	sandboxHosts   map[string]bool      // host -> reachable
@@ -195,6 +196,7 @@ func newDashboardModel(store run.StateStore, cfg config.Config, ghClient gh.Clie
 	return dashboardModel{
 		store:          store,
 		ghClient:       ghClient,
+		tmuxDeps:       run.DefaultTmuxDeps(),
 		ghStatus:       make(map[string]*prStatus),
 		sandboxHosts:   make(map[string]bool),
 		pipelineCtrl:   ctrl,
@@ -242,7 +244,7 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.states = msg.states
 		// Detect and finalize stale (orphaned) runs so they stop appearing as active.
 		for _, s := range m.states {
-			if s.IsStale() {
+			if s.IsStaleWith(m.tmuxDeps) {
 				slog.Info("finalizing stale run", "id", s.ID)
 				markRunFailed(m.store, s)
 			}
@@ -402,7 +404,7 @@ func (m dashboardModel) View() string {
 	}
 
 	totalCost := computeTotalCost(m.states)
-	runningCount, totalCount := countAgents(m.states)
+	runningCount, totalCount := m.countAgents(m.states)
 	sessionDur := computeSessionDuration(m.states)
 
 	var b strings.Builder
@@ -528,7 +530,7 @@ func (m dashboardModel) renderGroup(g repoGroup) string {
 		b.WriteString(m.renderPRLine(prNum, agents, g.PRMap[prNum]))
 		b.WriteString("\n")
 		for _, s := range agents {
-			if isAgentRunning(s) {
+			if m.isAgentRunning(s) {
 				b.WriteString(renderAgentSubline(s))
 				b.WriteString("\n")
 			}
@@ -537,7 +539,7 @@ func (m dashboardModel) renderGroup(g repoGroup) string {
 
 	// Render bare agents
 	for _, s := range bareAgents {
-		b.WriteString(renderBareAgentLine(s))
+		b.WriteString(m.renderBareAgentLine(s))
 		b.WriteString("\n")
 	}
 
@@ -603,14 +605,14 @@ func renderAgentSubline(s *run.State) string {
 	return yellowStyle.Render(fmt.Sprintf("   └─ agent:%s %s...%s", shortID, prompt, hostTag))
 }
 
-func renderBareAgentLine(s *run.State) string {
+func (m *dashboardModel) renderBareAgentLine(s *run.State) string {
 	shortID := shortRunID(s.ID)
 	status := agentStatusLabel(s)
 	cost := formatCost(s)
 	prompt := truncate(s.Prompt, 20)
 	hostTag := sandboxTag(s)
 
-	if isAgentRunning(s) {
+	if m.isAgentRunning(s) {
 		return yellowStyle.Render(fmt.Sprintf("  agent:%s  %-20s  RUNNING   %s", shortID, prompt, cost)) + hostTag
 	}
 	return dimStyle.Render(fmt.Sprintf("  agent:%s  %-20s  %s   %s", shortID, prompt, status, cost)) + hostTag
@@ -849,14 +851,14 @@ func computeTotalCost(states []*run.State) float64 {
 }
 
 // countAgents returns (running, total) agent counts (excludes sessions).
-func countAgents(states []*run.State) (int, int) {
+func (m *dashboardModel) countAgents(states []*run.State) (int, int) {
 	var running, total int
 	for _, s := range states {
 		if s.Type == "session" {
 			continue
 		}
 		total++
-		if isAgentRunning(s) {
+		if m.isAgentRunning(s) {
 			running++
 		}
 	}
@@ -900,8 +902,8 @@ func markRunFailed(store run.StateStore, s *run.State) {
 }
 
 // isAgentRunning checks if a run's agent is currently active in tmux.
-func isAgentRunning(s *run.State) bool {
-	return s.IsAgentRunning()
+func (m *dashboardModel) isAgentRunning(s *run.State) bool {
+	return s.IsAgentRunningWith(m.tmuxDeps)
 }
 
 // agentStatusLabel returns a display label for a non-running agent.

--- a/internal/cmd/dashboard_test.go
+++ b/internal/cmd/dashboard_test.go
@@ -17,16 +17,15 @@ import (
 	"github.com/patflynn/klaus/internal/webhook"
 )
 
-func init() {
-	// Mock tmux functions in run package for tests.
-	run.PaneExists = func(paneID string) bool {
-		return strings.HasPrefix(paneID, "%")
-	}
-	run.PaneIsIdle = func(paneID string) bool {
-		return true
-	}
-	run.PaneIsDead = func(paneID string) bool {
-		return false
+// testDashboardTmuxDeps returns TmuxDeps for dashboard tests:
+// panes starting with "%" exist, all are idle (finalized), none dead.
+func testDashboardTmuxDeps() run.TmuxDeps {
+	return run.TmuxDeps{
+		PaneExists: func(paneID string) bool {
+			return strings.HasPrefix(paneID, "%")
+		},
+		PaneIsIdle: func(string) bool { return true },
+		PaneIsDead: func(string) bool { return false },
 	}
 }
 
@@ -209,6 +208,7 @@ func TestComputeTotalCost_Empty(t *testing.T) {
 }
 
 func TestCountAgents(t *testing.T) {
+	m := &dashboardModel{tmuxDeps: testDashboardTmuxDeps()}
 	states := []*run.State{
 		{ID: "1", Type: "launch"},                                                           // not running (no pane)
 		{ID: "2", Type: "launch", TmuxPane: strPtr("%2"), CostUSD: float64Ptr(1.0)},         // finished
@@ -217,7 +217,7 @@ func TestCountAgents(t *testing.T) {
 		{ID: "5", Type: "launch", TmuxPane: strPtr("%5"), DurationMS: int64Ptr(5000)},       // finished
 		{ID: "6", Type: "launch", TmuxPane: strPtr("%6")},                                   // running
 	}
-	running, total := countAgents(states)
+	running, total := m.countAgents(states)
 	if total != 5 {
 		t.Errorf("total = %d, want 5", total)
 	}
@@ -227,6 +227,7 @@ func TestCountAgents(t *testing.T) {
 }
 
 func TestIsAgentRunning(t *testing.T) {
+	m := &dashboardModel{tmuxDeps: testDashboardTmuxDeps()}
 	tests := []struct {
 		name string
 		s    *run.State
@@ -239,7 +240,7 @@ func TestIsAgentRunning(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isAgentRunning(tt.s)
+			got := m.isAgentRunning(tt.s)
 			if got != tt.want {
 				t.Errorf("isAgentRunning() = %v, want %v", got, tt.want)
 			}
@@ -433,6 +434,7 @@ func TestDashboardViewRender(t *testing.T) {
 
 	m := dashboardModel{
 		states:   states,
+		tmuxDeps: testDashboardTmuxDeps(),
 		ghStatus: map[string]*prStatus{},
 		width:    80,
 		height:   24,
@@ -458,6 +460,7 @@ func TestDashboardViewRender(t *testing.T) {
 func TestDashboardViewNoRuns(t *testing.T) {
 	m := dashboardModel{
 		states:   []*run.State{},
+		tmuxDeps: testDashboardTmuxDeps(),
 		ghStatus: map[string]*prStatus{},
 		width:    80,
 		height:   24,
@@ -470,6 +473,7 @@ func TestDashboardViewNoRuns(t *testing.T) {
 
 func TestDashboardViewLoading(t *testing.T) {
 	m := dashboardModel{
+		tmuxDeps: testDashboardTmuxDeps(),
 		ghStatus: map[string]*prStatus{},
 		width:    80,
 		height:   24,
@@ -521,7 +525,7 @@ func TestCILabel(t *testing.T) {
 }
 
 func TestRenderPRLine(t *testing.T) {
-	m := dashboardModel{width: 80, ghStatus: map[string]*prStatus{}}
+	m := dashboardModel{width: 80, tmuxDeps: testDashboardTmuxDeps(), ghStatus: map[string]*prStatus{}}
 	s := &run.State{
 		ID:     "20260307-0900-aaaa",
 		Prompt: "fix bug",
@@ -567,6 +571,7 @@ func TestRenderPRLine(t *testing.T) {
 func TestRenderPRLineApproval(t *testing.T) {
 	m := dashboardModel{
 		width:          80,
+		tmuxDeps:       testDashboardTmuxDeps(),
 		pipelineStates: map[string]*pipeline.PRPipelineState{},
 	}
 
@@ -611,7 +616,7 @@ func TestRenderPRLineApproval(t *testing.T) {
 }
 
 func TestRenderGroupCounts(t *testing.T) {
-	m := dashboardModel{width: 80, ghStatus: map[string]*prStatus{}}
+	m := dashboardModel{width: 80, tmuxDeps: testDashboardTmuxDeps(), ghStatus: map[string]*prStatus{}}
 	g := repoGroup{
 		Repo: "owner/repo",
 		Runs: []*run.State{
@@ -696,6 +701,7 @@ func TestHostFieldOmittedWhenNil(t *testing.T) {
 }
 
 func TestRenderBareAgentLineWithHost(t *testing.T) {
+	m := &dashboardModel{tmuxDeps: testDashboardTmuxDeps()}
 	host := "klaus-worker-0"
 	s := &run.State{
 		ID:       "20260328-1915-e4b3",
@@ -704,20 +710,21 @@ func TestRenderBareAgentLineWithHost(t *testing.T) {
 		Host:     &host,
 	}
 
-	line := renderBareAgentLine(s)
+	line := m.renderBareAgentLine(s)
 	if !strings.Contains(line, "[sandbox]") {
 		t.Error("bare agent with Host set should show [sandbox], got:", line)
 	}
 }
 
 func TestRenderBareAgentLineWithoutHost(t *testing.T) {
+	m := &dashboardModel{tmuxDeps: testDashboardTmuxDeps()}
 	s := &run.State{
 		ID:       "20260328-1915-e4b3",
 		Prompt:   "fix tests",
 		TmuxPane: strPtr("%5"),
 	}
 
-	line := renderBareAgentLine(s)
+	line := m.renderBareAgentLine(s)
 	if strings.Contains(line, "[sandbox]") {
 		t.Error("bare agent without Host should not show [sandbox], got:", line)
 	}
@@ -796,6 +803,7 @@ func TestDashboardViewWithSandboxAgent(t *testing.T) {
 
 	m := dashboardModel{
 		states:       states,
+		tmuxDeps:     testDashboardTmuxDeps(),
 		ghStatus:     map[string]*prStatus{},
 		sandboxHosts: map[string]bool{"klaus-worker-0": true},
 		width:        80,

--- a/internal/cmd/new.go
+++ b/internal/cmd/new.go
@@ -112,15 +112,17 @@ func runNew(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	scaffoldDeps := DefaultScaffoldDeps()
+
 	// Create GitHub repo and clone it
 	fmt.Printf("Creating repository %s...\n", name)
-	ghOutput, err := runGHRepoCreate(name)
+	ghOutput, err := scaffoldDeps.RunGHRepoCreate(name)
 	if err != nil {
 		return fmt.Errorf("creating GitHub repo: %w", err)
 	}
 	fmt.Println(ghOutput)
 
-	repoDir, err := resolveNewRepoDir(cloneDir, name)
+	repoDir, err := scaffoldDeps.ResolveNewRepoDir(cloneDir, name)
 	if err != nil {
 		return err
 	}
@@ -255,16 +257,29 @@ Your task:
 		projectType, name, description, principles, projectType)
 }
 
-// runGHRepoCreate calls 'gh repo create' and returns its output.
-// Extracted as a variable for testing.
-var runGHRepoCreate = func(name string) (string, error) {
+// ScaffoldDeps holds dependencies for the scaffold (new) command.
+type ScaffoldDeps struct {
+	RunGHRepoCreate func(name string) (string, error)
+	ResolveNewRepoDir func(cwd, name string) (string, error)
+}
+
+// DefaultScaffoldDeps returns ScaffoldDeps wired to real implementations.
+func DefaultScaffoldDeps() ScaffoldDeps {
+	return ScaffoldDeps{
+		RunGHRepoCreate:   defaultRunGHRepoCreate,
+		ResolveNewRepoDir: defaultResolveNewRepoDir,
+	}
+}
+
+// defaultRunGHRepoCreate calls 'gh repo create' and returns its output.
+func defaultRunGHRepoCreate(name string) (string, error) {
 	cmd := exec.Command("gh", "repo", "create", name, "--public", "--clone")
 	out, err := cmd.CombinedOutput()
 	return strings.TrimSpace(string(out)), err
 }
 
-// resolveNewRepoDir returns the absolute path to the newly cloned repo directory.
-var resolveNewRepoDir = func(cwd, name string) (string, error) {
+// defaultResolveNewRepoDir returns the absolute path to the newly cloned repo directory.
+func defaultResolveNewRepoDir(cwd, name string) (string, error) {
 	dir := filepath.Join(cwd, name)
 	info, err := os.Stat(dir)
 	if err != nil {

--- a/internal/cmd/new_test.go
+++ b/internal/cmd/new_test.go
@@ -157,14 +157,6 @@ func TestLoadPrinciplesReadError(t *testing.T) {
 }
 
 func TestNewCmdTypeValidation(t *testing.T) {
-	// Save and restore the GH mock
-	origGH := runGHRepoCreate
-	origResolve := resolveNewRepoDir
-	defer func() {
-		runGHRepoCreate = origGH
-		resolveNewRepoDir = origResolve
-	}()
-
 	cmd := scaffoldCmd
 	cmd.SetArgs([]string{"test-proj"})
 

--- a/internal/cmd/project.go
+++ b/internal/cmd/project.go
@@ -71,6 +71,7 @@ func runProjectAdd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	deps := DefaultProjectDeps()
 	var owner, repoName, cloneURL string
 
 	if strings.Contains(ref, "/") {
@@ -82,7 +83,7 @@ func runProjectAdd(cmd *cobra.Command, args []string) error {
 	} else {
 		// Bare name — search GitHub repos
 		repoName = ref
-		ghOwner, ghURL, err := resolveGitHubRepo(ref)
+		ghOwner, ghURL, err := deps.ResolveGitHubRepo(ref)
 		if err != nil {
 			return err
 		}
@@ -126,7 +127,7 @@ func runProjectAdd(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(cmd.OutOrStdout(), "Already cloned at %s\n", targetDir)
 	} else {
 		fmt.Fprintf(cmd.OutOrStdout(), "Cloning %s/%s into %s...\n", owner, repoName, targetDir)
-		if err := gitClone(cloneURL, targetDir); err != nil {
+		if err := deps.GitClone(cloneURL, targetDir); err != nil {
 			return fmt.Errorf("cloning: %w", err)
 		}
 	}
@@ -214,9 +215,23 @@ type ghRepoEntry struct {
 	URL           string `json:"url"`
 }
 
-// resolveGitHubRepo searches the user's GitHub repos for a name match.
+// ProjectDeps holds dependencies for project commands.
+type ProjectDeps struct {
+	ResolveGitHubRepo func(name string) (string, string, error)
+	GitClone          func(url, targetDir string) error
+}
+
+// DefaultProjectDeps returns ProjectDeps wired to real implementations.
+func DefaultProjectDeps() ProjectDeps {
+	return ProjectDeps{
+		ResolveGitHubRepo: defaultResolveGitHubRepo,
+		GitClone:          defaultGitClone,
+	}
+}
+
+// defaultResolveGitHubRepo searches the user's GitHub repos for a name match.
 // Returns (owner, cloneURL, error).
-var resolveGitHubRepo = func(name string) (string, string, error) {
+func defaultResolveGitHubRepo(name string) (string, string, error) {
 	out, err := exec.Command("gh", "repo", "list", "--json", "name,nameWithOwner,url", "--limit", "200").Output()
 	if err != nil {
 		return "", "", fmt.Errorf("running gh repo list: %w", err)
@@ -258,8 +273,8 @@ func isGitRepo(dir string) bool {
 	return info.IsDir()
 }
 
-// gitClone clones a repository to the target directory.
-var gitClone = func(url, targetDir string) error {
+// defaultGitClone clones a repository to the target directory.
+func defaultGitClone(url, targetDir string) error {
 	c := exec.Command("git", "clone", url, targetDir)
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr

--- a/internal/cmd/review_check.go
+++ b/internal/cmd/review_check.go
@@ -47,10 +47,7 @@ type ghCommitAuthor struct {
 
 // hasUnaddressedTrustedComments checks whether a PR has review comments from
 // trusted reviewers that haven't been addressed by a subsequent push.
-// It is a variable so tests can replace the implementation.
-var hasUnaddressedTrustedComments = hasUnaddressedTrustedCommentsImpl
-
-func hasUnaddressedTrustedCommentsImpl(ownerRepo, prNumber string) bool {
+func hasUnaddressedTrustedComments(ownerRepo, prNumber string) bool {
 	cfg, err := config.Load("")
 	if err != nil || len(cfg.TrustedReviewers) == 0 {
 		return false

--- a/internal/cmd/webhook_setup.go
+++ b/internal/cmd/webhook_setup.go
@@ -42,17 +42,30 @@ type webhookStatus struct {
 	Error   string // non-empty on failure
 }
 
-// Function variables for testing.
-var (
-	webhookListHooks    = listRepoHooks
-	webhookCreateHook   = createRepoHook
-	webhookResolveRepo  = func(dir string) (string, string, error) {
-		return github.NewGHCLIClient("").GetRepoOwnerAndNameFromDir(context.TODO(), dir)
+// WebhookDeps holds injectable dependencies for webhook commands.
+type WebhookDeps struct {
+	ListHooks    func(owner, repo string) ([]ghHook, error)
+	CreateHook   func(owner, repo, relayURL, secret string) error
+	ResolveRepo  func(dir string) (string, string, error)
+	LoadConfig   func() (config.Config, error)
+	LoadRegistry func() (*project.Registry, error)
+	ReadFile     func(name string) ([]byte, error)
+}
+
+// DefaultWebhookDeps returns WebhookDeps wired to real implementations.
+func DefaultWebhookDeps() WebhookDeps {
+	return WebhookDeps{
+		ListHooks:  listRepoHooks,
+		CreateHook: createRepoHook,
+		ResolveRepo: func(dir string) (string, string, error) {
+			return github.NewGHCLIClient("").GetRepoOwnerAndNameFromDir(context.TODO(), dir)
+		},
+		LoadConfig:   func() (config.Config, error) { return config.Load("") },
+		LoadRegistry: project.Load,
+		ReadFile:     os.ReadFile,
 	}
-	webhookLoadConfig   = func() (config.Config, error) { return config.Load("") }
-	webhookLoadRegistry = project.Load
-	webhookReadFile     = os.ReadFile
-)
+}
+
 
 var webhookCmd = &cobra.Command{
 	Use:   "webhook",
@@ -76,7 +89,9 @@ var webhookCheckCmd = &cobra.Command{
 	Use:   "check",
 	Short: "Check if webhooks are configured for registered projects",
 	Args:  cobra.NoArgs,
-	RunE:  runWebhookCheck,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runWebhookCheck(cmd, args, DefaultWebhookDeps())
+	},
 }
 
 var webhookSetupCmd = &cobra.Command{
@@ -89,11 +104,13 @@ that are missing. With a project name, sets up the webhook for that project only
 
 Requires relay_url and secret_file in the webhook config.`,
 	Args: cobra.MaximumNArgs(1),
-	RunE: runWebhookSetup,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runWebhookSetup(cmd, args, DefaultWebhookDeps())
+	},
 }
 
-func runWebhookCheck(cmd *cobra.Command, _ []string) error {
-	cfg, err := webhookLoadConfig()
+func runWebhookCheck(cmd *cobra.Command, _ []string, deps WebhookDeps) error {
+	cfg, err := deps.LoadConfig()
 	if err != nil {
 		return err
 	}
@@ -101,7 +118,7 @@ func runWebhookCheck(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("webhook.relay_url is not configured; add it to your klaus config")
 	}
 
-	statuses, err := checkAllProjects(cfg.Webhook.RelayURL)
+	statuses, err := checkAllProjects(cfg.Webhook.RelayURL, deps)
 	if err != nil {
 		return err
 	}
@@ -123,8 +140,8 @@ func runWebhookCheck(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func runWebhookSetup(cmd *cobra.Command, args []string) error {
-	cfg, err := webhookLoadConfig()
+func runWebhookSetup(cmd *cobra.Command, args []string, deps WebhookDeps) error {
+	cfg, err := deps.LoadConfig()
 	if err != nil {
 		return err
 	}
@@ -135,7 +152,7 @@ func runWebhookSetup(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("webhook.secret_file is not configured; add it to your klaus config")
 	}
 
-	secretBytes, err := webhookReadFile(cfg.Webhook.SecretFile)
+	secretBytes, err := deps.ReadFile(cfg.Webhook.SecretFile)
 	if err != nil {
 		return fmt.Errorf("reading webhook secret: %w", err)
 	}
@@ -144,7 +161,7 @@ func runWebhookSetup(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("webhook secret file is empty: %s", cfg.Webhook.SecretFile)
 	}
 
-	reg, err := webhookLoadRegistry()
+	reg, err := deps.LoadRegistry()
 	if err != nil {
 		return err
 	}
@@ -168,14 +185,14 @@ func runWebhookSetup(cmd *cobra.Command, args []string) error {
 	var created, skipped, errored int
 
 	for name, localPath := range projects {
-		owner, repo, err := webhookResolveRepo(localPath)
+		owner, repo, err := deps.ResolveRepo(localPath)
 		if err != nil {
 			fmt.Fprintf(cmd.OutOrStdout(), "%-20s error resolving repo: %v\n", name, err)
 			errored++
 			continue
 		}
 
-		hookID, err := findMatchingHook(owner, repo, relayURL)
+		hookID, err := findMatchingHookWith(deps, owner, repo, relayURL)
 		if err != nil {
 			fmt.Fprintf(cmd.OutOrStdout(), "%-20s %s/%s  error checking hooks: %v\n", name, owner, repo, err)
 			errored++
@@ -187,7 +204,7 @@ func runWebhookSetup(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		if err := webhookCreateHook(owner, repo, relayURL, secret); err != nil {
+		if err := deps.CreateHook(owner, repo, relayURL, secret); err != nil {
 			fmt.Fprintf(cmd.OutOrStdout(), "%-20s %s/%s  error creating webhook: %v\n", name, owner, repo, err)
 			errored++
 			continue
@@ -201,8 +218,8 @@ func runWebhookSetup(cmd *cobra.Command, args []string) error {
 }
 
 // checkAllProjects checks webhook status for all registered projects.
-func checkAllProjects(relayURL string) ([]webhookStatus, error) {
-	reg, err := webhookLoadRegistry()
+func checkAllProjects(relayURL string, deps WebhookDeps) ([]webhookStatus, error) {
+	reg, err := deps.LoadRegistry()
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +229,7 @@ func checkAllProjects(relayURL string) ([]webhookStatus, error) {
 	for name, localPath := range projects {
 		s := webhookStatus{Project: name}
 
-		owner, repo, err := webhookResolveRepo(localPath)
+		owner, repo, err := deps.ResolveRepo(localPath)
 		if err != nil {
 			s.Error = fmt.Sprintf("resolving repo: %v", err)
 			statuses = append(statuses, s)
@@ -221,7 +238,7 @@ func checkAllProjects(relayURL string) ([]webhookStatus, error) {
 		s.Owner = owner
 		s.Repo = repo
 
-		hookID, err := findMatchingHook(owner, repo, relayURL)
+		hookID, err := findMatchingHookWith(deps, owner, repo, relayURL)
 		if err != nil {
 			s.Error = fmt.Sprintf("listing hooks: %v", err)
 			statuses = append(statuses, s)
@@ -233,10 +250,10 @@ func checkAllProjects(relayURL string) ([]webhookStatus, error) {
 	return statuses, nil
 }
 
-// findMatchingHook checks if a repo has a webhook whose URL matches the relay URL.
+// findMatchingHookWith checks if a repo has a webhook whose URL matches the relay URL.
 // Returns the hook ID if found, 0 if not.
-func findMatchingHook(owner, repo, relayURL string) (int64, error) {
-	hooks, err := webhookListHooks(owner, repo)
+func findMatchingHookWith(deps WebhookDeps, owner, repo, relayURL string) (int64, error) {
+	hooks, err := deps.ListHooks(owner, repo)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/cmd/webhook_setup_test.go
+++ b/internal/cmd/webhook_setup_test.go
@@ -117,45 +117,37 @@ func TestMatchHook(t *testing.T) {
 }
 
 func TestWebhookCheck_NoRelayURL(t *testing.T) {
-	orig := webhookLoadConfig
-	defer func() { webhookLoadConfig = orig }()
-
-	webhookLoadConfig = func() (config.Config, error) {
-		return config.Config{}, nil
+	deps := WebhookDeps{
+		LoadConfig: func() (config.Config, error) { return config.Config{}, nil },
 	}
 
 	var buf bytes.Buffer
 	webhookCheckCmd.SetOut(&buf)
 	webhookCheckCmd.SetErr(&buf)
 
-	err := webhookCheckCmd.RunE(webhookCheckCmd, nil)
+	err := runWebhookCheck(webhookCheckCmd, nil, deps)
 	if err == nil || err.Error() != "webhook.relay_url is not configured; add it to your klaus config" {
 		t.Errorf("expected relay_url error, got: %v", err)
 	}
 }
 
 func TestWebhookCheck_NoProjects(t *testing.T) {
-	origConfig := webhookLoadConfig
-	origRegistry := webhookLoadRegistry
-	defer func() {
-		webhookLoadConfig = origConfig
-		webhookLoadRegistry = origRegistry
-	}()
-
-	webhookLoadConfig = func() (config.Config, error) {
-		return config.Config{
-			Webhook: &config.WebhookConfig{RelayURL: "https://relay.example.com"},
-		}, nil
-	}
-	webhookLoadRegistry = func() (*project.Registry, error) {
-		return &project.Registry{Projects: map[string]string{}}, nil
+	deps := WebhookDeps{
+		LoadConfig: func() (config.Config, error) {
+			return config.Config{
+				Webhook: &config.WebhookConfig{RelayURL: "https://relay.example.com"},
+			}, nil
+		},
+		LoadRegistry: func() (*project.Registry, error) {
+			return &project.Registry{Projects: map[string]string{}}, nil
+		},
 	}
 
 	var buf bytes.Buffer
 	webhookCheckCmd.SetOut(&buf)
 	webhookCheckCmd.SetErr(&buf)
 
-	if err := webhookCheckCmd.RunE(webhookCheckCmd, nil); err != nil {
+	if err := runWebhookCheck(webhookCheckCmd, nil, deps); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if out := buf.String(); out != "No projects registered. Use 'klaus project add' to register one.\n" {
@@ -164,54 +156,45 @@ func TestWebhookCheck_NoProjects(t *testing.T) {
 }
 
 func TestWebhookCheck_MixedStatuses(t *testing.T) {
-	origConfig := webhookLoadConfig
-	origRegistry := webhookLoadRegistry
-	origResolve := webhookResolveRepo
-	origList := webhookListHooks
-	defer func() {
-		webhookLoadConfig = origConfig
-		webhookLoadRegistry = origRegistry
-		webhookResolveRepo = origResolve
-		webhookListHooks = origList
-	}()
-
-	webhookLoadConfig = func() (config.Config, error) {
-		return config.Config{
-			Webhook: &config.WebhookConfig{RelayURL: "https://relay.example.com"},
-		}, nil
-	}
-	webhookLoadRegistry = func() (*project.Registry, error) {
-		return &project.Registry{Projects: map[string]string{
-			"proj-a": "/tmp/proj-a",
-			"proj-b": "/tmp/proj-b",
-		}}, nil
-	}
-	webhookResolveRepo = func(dir string) (string, string, error) {
-		switch dir {
-		case "/tmp/proj-a":
-			return "owner", "proj-a", nil
-		case "/tmp/proj-b":
-			return "owner", "proj-b", nil
-		}
-		return "", "", nil
-	}
-	webhookListHooks = func(owner, repo string) ([]ghHook, error) {
-		if repo == "proj-a" {
-			return []ghHook{
-				{ID: 42, Config: struct {
-					URL         string `json:"url"`
-					ContentType string `json:"content_type"`
-				}{URL: "https://relay.example.com/webhook"}},
+	deps := WebhookDeps{
+		LoadConfig: func() (config.Config, error) {
+			return config.Config{
+				Webhook: &config.WebhookConfig{RelayURL: "https://relay.example.com"},
 			}, nil
-		}
-		return nil, nil
+		},
+		LoadRegistry: func() (*project.Registry, error) {
+			return &project.Registry{Projects: map[string]string{
+				"proj-a": "/tmp/proj-a",
+				"proj-b": "/tmp/proj-b",
+			}}, nil
+		},
+		ResolveRepo: func(dir string) (string, string, error) {
+			switch dir {
+			case "/tmp/proj-a":
+				return "owner", "proj-a", nil
+			case "/tmp/proj-b":
+				return "owner", "proj-b", nil
+			}
+			return "", "", nil
+		},
+		ListHooks: func(owner, repo string) ([]ghHook, error) {
+			if repo == "proj-a" {
+				return []ghHook{
+					{ID: 42, Config: struct {
+						URL         string `json:"url"`
+						ContentType string `json:"content_type"`
+					}{URL: "https://relay.example.com/webhook"}},
+				}, nil
+			}
+			return nil, nil
+		},
 	}
 
 	var buf bytes.Buffer
 	webhookCheckCmd.SetOut(&buf)
 	webhookCheckCmd.SetErr(&buf)
 
-	if err := webhookCheckCmd.RunE(webhookCheckCmd, nil); err != nil {
+	if err := runWebhookCheck(webhookCheckCmd, nil, deps); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	out := buf.String()
@@ -224,61 +207,47 @@ func TestWebhookCheck_MixedStatuses(t *testing.T) {
 }
 
 func TestWebhookSetup_CreatesHook(t *testing.T) {
-	origConfig := webhookLoadConfig
-	origRegistry := webhookLoadRegistry
-	origResolve := webhookResolveRepo
-	origList := webhookListHooks
-	origCreate := webhookCreateHook
-	origRead := webhookReadFile
-	defer func() {
-		webhookLoadConfig = origConfig
-		webhookLoadRegistry = origRegistry
-		webhookResolveRepo = origResolve
-		webhookListHooks = origList
-		webhookCreateHook = origCreate
-		webhookReadFile = origRead
-	}()
-
 	// Write a temp secret file.
 	tmpDir := t.TempDir()
 	secretPath := filepath.Join(tmpDir, "secret")
 	os.WriteFile(secretPath, []byte("my-secret\n"), 0o644)
 
-	webhookLoadConfig = func() (config.Config, error) {
-		return config.Config{
-			Webhook: &config.WebhookConfig{
-				RelayURL:   "https://relay.example.com",
-				SecretFile: secretPath,
-			},
-		}, nil
-	}
-	webhookReadFile = os.ReadFile
-	webhookLoadRegistry = func() (*project.Registry, error) {
-		return &project.Registry{Projects: map[string]string{
-			"myproject": "/tmp/myproject",
-		}}, nil
-	}
-	webhookResolveRepo = func(dir string) (string, string, error) {
-		return "owner", "myproject", nil
-	}
-	webhookListHooks = func(owner, repo string) ([]ghHook, error) {
-		return nil, nil // no existing hooks
-	}
-
 	var createdOwner, createdRepo, createdURL, createdSecret string
-	webhookCreateHook = func(owner, repo, relayURL, secret string) error {
-		createdOwner = owner
-		createdRepo = repo
-		createdURL = relayURL
-		createdSecret = secret
-		return nil
+	deps := WebhookDeps{
+		LoadConfig: func() (config.Config, error) {
+			return config.Config{
+				Webhook: &config.WebhookConfig{
+					RelayURL:   "https://relay.example.com",
+					SecretFile: secretPath,
+				},
+			}, nil
+		},
+		ReadFile: os.ReadFile,
+		LoadRegistry: func() (*project.Registry, error) {
+			return &project.Registry{Projects: map[string]string{
+				"myproject": "/tmp/myproject",
+			}}, nil
+		},
+		ResolveRepo: func(dir string) (string, string, error) {
+			return "owner", "myproject", nil
+		},
+		ListHooks: func(owner, repo string) ([]ghHook, error) {
+			return nil, nil // no existing hooks
+		},
+		CreateHook: func(owner, repo, relayURL, secret string) error {
+			createdOwner = owner
+			createdRepo = repo
+			createdURL = relayURL
+			createdSecret = secret
+			return nil
+		},
 	}
 
 	var buf bytes.Buffer
 	webhookSetupCmd.SetOut(&buf)
 	webhookSetupCmd.SetErr(&buf)
 
-	if err := webhookSetupCmd.RunE(webhookSetupCmd, nil); err != nil {
+	if err := runWebhookSetup(webhookSetupCmd, nil, deps); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -297,62 +266,48 @@ func TestWebhookSetup_CreatesHook(t *testing.T) {
 }
 
 func TestWebhookSetup_SkipsExisting(t *testing.T) {
-	origConfig := webhookLoadConfig
-	origRegistry := webhookLoadRegistry
-	origResolve := webhookResolveRepo
-	origList := webhookListHooks
-	origCreate := webhookCreateHook
-	origRead := webhookReadFile
-	defer func() {
-		webhookLoadConfig = origConfig
-		webhookLoadRegistry = origRegistry
-		webhookResolveRepo = origResolve
-		webhookListHooks = origList
-		webhookCreateHook = origCreate
-		webhookReadFile = origRead
-	}()
-
 	tmpDir := t.TempDir()
 	secretPath := filepath.Join(tmpDir, "secret")
 	os.WriteFile(secretPath, []byte("s3cret"), 0o644)
 
-	webhookLoadConfig = func() (config.Config, error) {
-		return config.Config{
-			Webhook: &config.WebhookConfig{
-				RelayURL:   "https://relay.example.com",
-				SecretFile: secretPath,
-			},
-		}, nil
-	}
-	webhookReadFile = os.ReadFile
-	webhookLoadRegistry = func() (*project.Registry, error) {
-		return &project.Registry{Projects: map[string]string{
-			"myproject": "/tmp/myproject",
-		}}, nil
-	}
-	webhookResolveRepo = func(dir string) (string, string, error) {
-		return "owner", "myproject", nil
-	}
-	webhookListHooks = func(owner, repo string) ([]ghHook, error) {
-		return []ghHook{
-			{ID: 100, Config: struct {
-				URL         string `json:"url"`
-				ContentType string `json:"content_type"`
-			}{URL: "https://relay.example.com"}},
-		}, nil
-	}
-
 	createCalled := false
-	webhookCreateHook = func(owner, repo, relayURL, secret string) error {
-		createCalled = true
-		return nil
+	deps := WebhookDeps{
+		LoadConfig: func() (config.Config, error) {
+			return config.Config{
+				Webhook: &config.WebhookConfig{
+					RelayURL:   "https://relay.example.com",
+					SecretFile: secretPath,
+				},
+			}, nil
+		},
+		ReadFile: os.ReadFile,
+		LoadRegistry: func() (*project.Registry, error) {
+			return &project.Registry{Projects: map[string]string{
+				"myproject": "/tmp/myproject",
+			}}, nil
+		},
+		ResolveRepo: func(dir string) (string, string, error) {
+			return "owner", "myproject", nil
+		},
+		ListHooks: func(owner, repo string) ([]ghHook, error) {
+			return []ghHook{
+				{ID: 100, Config: struct {
+					URL         string `json:"url"`
+					ContentType string `json:"content_type"`
+				}{URL: "https://relay.example.com"}},
+			}, nil
+		},
+		CreateHook: func(owner, repo, relayURL, secret string) error {
+			createCalled = true
+			return nil
+		},
 	}
 
 	var buf bytes.Buffer
 	webhookSetupCmd.SetOut(&buf)
 	webhookSetupCmd.SetErr(&buf)
 
-	if err := webhookSetupCmd.RunE(webhookSetupCmd, nil); err != nil {
+	if err := runWebhookSetup(webhookSetupCmd, nil, deps); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -365,82 +320,63 @@ func TestWebhookSetup_SkipsExisting(t *testing.T) {
 }
 
 func TestWebhookSetup_MissingSecretFile(t *testing.T) {
-	origConfig := webhookLoadConfig
-	origRead := webhookReadFile
-	defer func() {
-		webhookLoadConfig = origConfig
-		webhookReadFile = origRead
-	}()
-
-	webhookLoadConfig = func() (config.Config, error) {
-		return config.Config{
-			Webhook: &config.WebhookConfig{
-				RelayURL:   "https://relay.example.com",
-				SecretFile: "/nonexistent/secret",
-			},
-		}, nil
+	deps := WebhookDeps{
+		LoadConfig: func() (config.Config, error) {
+			return config.Config{
+				Webhook: &config.WebhookConfig{
+					RelayURL:   "https://relay.example.com",
+					SecretFile: "/nonexistent/secret",
+				},
+			}, nil
+		},
+		ReadFile: os.ReadFile,
 	}
-	webhookReadFile = os.ReadFile
 
-	err := webhookSetupCmd.RunE(webhookSetupCmd, nil)
+	err := runWebhookSetup(webhookSetupCmd, nil, deps)
 	if err == nil || !containsSubstring(err.Error(), "reading webhook secret") {
 		t.Errorf("expected secret file error, got: %v", err)
 	}
 }
 
 func TestWebhookSetup_SpecificProject(t *testing.T) {
-	origConfig := webhookLoadConfig
-	origRegistry := webhookLoadRegistry
-	origResolve := webhookResolveRepo
-	origList := webhookListHooks
-	origCreate := webhookCreateHook
-	origRead := webhookReadFile
-	defer func() {
-		webhookLoadConfig = origConfig
-		webhookLoadRegistry = origRegistry
-		webhookResolveRepo = origResolve
-		webhookListHooks = origList
-		webhookCreateHook = origCreate
-		webhookReadFile = origRead
-	}()
-
 	tmpDir := t.TempDir()
 	secretPath := filepath.Join(tmpDir, "secret")
 	os.WriteFile(secretPath, []byte("s3cret"), 0o644)
 
-	webhookLoadConfig = func() (config.Config, error) {
-		return config.Config{
-			Webhook: &config.WebhookConfig{
-				RelayURL:   "https://relay.example.com",
-				SecretFile: secretPath,
-			},
-		}, nil
-	}
-	webhookReadFile = os.ReadFile
-	webhookLoadRegistry = func() (*project.Registry, error) {
-		return &project.Registry{Projects: map[string]string{
-			"proj-a": "/tmp/proj-a",
-			"proj-b": "/tmp/proj-b",
-		}}, nil
-	}
-
 	var resolvedDirs []string
-	webhookResolveRepo = func(dir string) (string, string, error) {
-		resolvedDirs = append(resolvedDirs, dir)
-		return "owner", filepath.Base(dir), nil
-	}
-	webhookListHooks = func(owner, repo string) ([]ghHook, error) {
-		return nil, nil
-	}
-	webhookCreateHook = func(owner, repo, relayURL, secret string) error {
-		return nil
+	deps := WebhookDeps{
+		LoadConfig: func() (config.Config, error) {
+			return config.Config{
+				Webhook: &config.WebhookConfig{
+					RelayURL:   "https://relay.example.com",
+					SecretFile: secretPath,
+				},
+			}, nil
+		},
+		ReadFile: os.ReadFile,
+		LoadRegistry: func() (*project.Registry, error) {
+			return &project.Registry{Projects: map[string]string{
+				"proj-a": "/tmp/proj-a",
+				"proj-b": "/tmp/proj-b",
+			}}, nil
+		},
+		ResolveRepo: func(dir string) (string, string, error) {
+			resolvedDirs = append(resolvedDirs, dir)
+			return "owner", filepath.Base(dir), nil
+		},
+		ListHooks: func(owner, repo string) ([]ghHook, error) {
+			return nil, nil
+		},
+		CreateHook: func(owner, repo, relayURL, secret string) error {
+			return nil
+		},
 	}
 
 	var buf bytes.Buffer
 	webhookSetupCmd.SetOut(&buf)
 	webhookSetupCmd.SetErr(&buf)
 
-	if err := webhookSetupCmd.RunE(webhookSetupCmd, []string{"proj-a"}); err != nil {
+	if err := runWebhookSetup(webhookSetupCmd, []string{"proj-a"}, deps); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -450,35 +386,28 @@ func TestWebhookSetup_SpecificProject(t *testing.T) {
 }
 
 func TestWebhookSetup_UnknownProject(t *testing.T) {
-	origConfig := webhookLoadConfig
-	origRegistry := webhookLoadRegistry
-	origRead := webhookReadFile
-	defer func() {
-		webhookLoadConfig = origConfig
-		webhookLoadRegistry = origRegistry
-		webhookReadFile = origRead
-	}()
-
 	tmpDir := t.TempDir()
 	secretPath := filepath.Join(tmpDir, "secret")
 	os.WriteFile(secretPath, []byte("s3cret"), 0o644)
 
-	webhookLoadConfig = func() (config.Config, error) {
-		return config.Config{
-			Webhook: &config.WebhookConfig{
-				RelayURL:   "https://relay.example.com",
-				SecretFile: secretPath,
-			},
-		}, nil
-	}
-	webhookReadFile = os.ReadFile
-	webhookLoadRegistry = func() (*project.Registry, error) {
-		return &project.Registry{Projects: map[string]string{
-			"proj-a": "/tmp/proj-a",
-		}}, nil
+	deps := WebhookDeps{
+		LoadConfig: func() (config.Config, error) {
+			return config.Config{
+				Webhook: &config.WebhookConfig{
+					RelayURL:   "https://relay.example.com",
+					SecretFile: secretPath,
+				},
+			}, nil
+		},
+		ReadFile: os.ReadFile,
+		LoadRegistry: func() (*project.Registry, error) {
+			return &project.Registry{Projects: map[string]string{
+				"proj-a": "/tmp/proj-a",
+			}}, nil
+		},
 	}
 
-	err := webhookSetupCmd.RunE(webhookSetupCmd, []string{"nonexistent"})
+	err := runWebhookSetup(webhookSetupCmd, []string{"nonexistent"}, deps)
 	if err == nil || err.Error() != `project "nonexistent" is not registered` {
 		t.Errorf("expected not registered error, got: %v", err)
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -222,14 +222,26 @@ var (
 	ghProtocolSSH  bool
 )
 
-// detectGHProtocol runs "gh config get git_protocol" and returns true if SSH.
-// Exported as a variable so tests can override it.
-var detectGHProtocol = func() bool {
+// DetectGHProtocol runs "gh config get git_protocol" and returns true if SSH.
+var detectGHProtocol = defaultDetectGHProtocol
+
+// defaultDetectGHProtocol is the real implementation.
+func defaultDetectGHProtocol() bool {
 	out, err := exec.Command("gh", "config", "get", "git_protocol").Output()
 	if err != nil {
 		return false
 	}
 	return strings.TrimSpace(string(out)) == "ssh"
+}
+
+// SetDetectGHProtocol overrides the protocol detection function (for testing).
+func SetDetectGHProtocol(fn func() bool) {
+	detectGHProtocol = fn
+}
+
+// ResetDetectGHProtocol restores the default protocol detection function.
+func ResetDetectGHProtocol() {
+	detectGHProtocol = defaultDetectGHProtocol
 }
 
 // useSSHProtocol returns true if the user has configured gh to use SSH.

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -213,15 +213,14 @@ func resetProtocolCache() {
 }
 
 func TestCloneURL(t *testing.T) {
-	origDetect := detectGHProtocol
 	defer func() {
-		detectGHProtocol = origDetect
+		ResetDetectGHProtocol()
 		resetProtocolCache()
 	}()
 
 	t.Run("https", func(t *testing.T) {
 		resetProtocolCache()
-		detectGHProtocol = func() bool { return false }
+		SetDetectGHProtocol(func() bool { return false })
 		got := CloneURL("owner", "repo")
 		want := "https://github.com/owner/repo.git"
 		if got != want {
@@ -231,7 +230,7 @@ func TestCloneURL(t *testing.T) {
 
 	t.Run("ssh", func(t *testing.T) {
 		resetProtocolCache()
-		detectGHProtocol = func() bool { return true }
+		SetDetectGHProtocol(func() bool { return true })
 		got := CloneURL("owner", "repo")
 		want := "git@github.com:owner/repo.git"
 		if got != want {
@@ -242,13 +241,12 @@ func TestCloneURL(t *testing.T) {
 
 func TestParseRepoRef(t *testing.T) {
 	// Force HTTPS protocol for deterministic test results.
-	origDetect := detectGHProtocol
 	defer func() {
-		detectGHProtocol = origDetect
+		ResetDetectGHProtocol()
 		resetProtocolCache()
 	}()
 	resetProtocolCache()
-	detectGHProtocol = func() bool { return false }
+	SetDetectGHProtocol(func() bool { return false })
 
 	tests := []struct {
 		input     string
@@ -349,13 +347,12 @@ func TestParseRepoRef(t *testing.T) {
 }
 
 func TestParseRepoRefSSH(t *testing.T) {
-	origDetect := detectGHProtocol
 	defer func() {
-		detectGHProtocol = origDetect
+		ResetDetectGHProtocol()
 		resetProtocolCache()
 	}()
 	resetProtocolCache()
-	detectGHProtocol = func() bool { return true }
+	SetDetectGHProtocol(func() bool { return true })
 
 	owner, repo, url, err := ParseRepoRef("patflynn/cosmo")
 	if err != nil {

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -98,6 +98,8 @@ type Controller struct {
 
 	autoMergeOnApproval bool // whether to auto-merge approved PRs
 
+	tmuxDeps run.TmuxDeps // tmux operations for checking pane state
+
 	// Injectable runners for testing.
 	launchAgent     func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error)
 	mergePRs        func(ctx context.Context, repo string, prNumbers []string) error
@@ -112,6 +114,7 @@ func New(store run.StateStore, eventLog *event.Log, logger *slog.Logger) *Contro
 		eventLog: eventLog,
 		logger:   logger,
 		prStates: make(map[string]*PRPipelineState),
+		tmuxDeps: run.DefaultTmuxDeps(),
 	}
 	c.launchAgent = c.defaultLaunchAgent
 	c.mergePRs = c.defaultMergePRs
@@ -120,6 +123,11 @@ func New(store run.StateStore, eventLog *event.Log, logger *slog.Logger) *Contro
 		return ghutil.NewGHCLIClient("").ResolveReviewThread(context.TODO(), threadID)
 	}
 	return c
+}
+
+// SetTmuxDeps overrides the tmux dependencies used for pane state checks.
+func (c *Controller) SetTmuxDeps(td run.TmuxDeps) {
+	c.tmuxDeps = td
 }
 
 // SetAutoMergeOnApproval controls whether approved PRs are automatically merged.
@@ -176,7 +184,7 @@ func (c *Controller) HandleGHStatus(ctx context.Context, statuses map[string]*PR
 	// Build a set of running agent run IDs from current run states.
 	runningAgents := make(map[string]bool)
 	for _, s := range runStates {
-		if isRunning(s) {
+		if c.isRunning(s) {
 			runningAgents[s.ID] = true
 		}
 	}
@@ -597,7 +605,7 @@ func (c *Controller) cleanupStaleWorktrees(prNumber string, runStates []*run.Sta
 		if s.PR == nil || *s.PR != prNumber {
 			continue
 		}
-		if isRunning(s) {
+		if c.isRunning(s) {
 			continue
 		}
 		if s.Worktree == "" {
@@ -733,8 +741,8 @@ func extractAgentID(output string) string {
 }
 
 // isRunning checks if a run is still active (has tmux pane, not finalized).
-func isRunning(s *run.State) bool {
-	return s.IsAgentRunning()
+func (c *Controller) isRunning(s *run.State) bool {
+	return s.IsAgentRunningWith(c.tmuxDeps)
 }
 
 // truncateError returns a short, single-line version of an error message.

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -14,13 +14,13 @@ import (
 	"github.com/patflynn/klaus/internal/run"
 )
 
-func TestMain(m *testing.M) {
-	// Mock tmux pane functions so tests don't need a real tmux session.
-	// By default, all panes "exist" and are alive (not dead, not idle).
-	run.PaneExists = func(string) bool { return true }
-	run.PaneIsDead = func(string) bool { return false }
-	run.PaneIsIdle = func(string) bool { return true }
-	os.Exit(m.Run())
+// testTmuxDeps returns TmuxDeps where all panes "exist" and are alive (not dead, idle).
+func testTmuxDeps() run.TmuxDeps {
+	return run.TmuxDeps{
+		PaneExists: func(string) bool { return true },
+		PaneIsDead: func(string) bool { return false },
+		PaneIsIdle: func(string) bool { return true },
+	}
 }
 
 func newTestController(t *testing.T) (*Controller, string) {
@@ -37,6 +37,7 @@ func newTestController(t *testing.T) (*Controller, string) {
 	store := run.NewGitDirStore(stateDir)
 
 	c := New(store, eventLog, logger)
+	c.SetTmuxDeps(testTmuxDeps())
 	return c, dir
 }
 
@@ -1638,33 +1639,35 @@ func TestKlausApprovalWithConflictsDispatchesRebase(t *testing.T) {
 }
 
 func TestIsRunning_DeadPane(t *testing.T) {
+	c, _ := newTestController(t)
 	pane := "dead-pane"
 
 	// Pane does not exist (agent crashed without finalizing).
-	run.PaneExists = func(string) bool { return false }
-	run.PaneIsDead = func(string) bool { return true }
-	t.Cleanup(func() {
-		// Restore TestMain defaults.
-		run.PaneExists = func(string) bool { return true }
-		run.PaneIsDead = func(string) bool { return false }
+	c.SetTmuxDeps(run.TmuxDeps{
+		PaneExists: func(string) bool { return false },
+		PaneIsDead: func(string) bool { return true },
+		PaneIsIdle: func(string) bool { return false },
 	})
 
 	s := &run.State{TmuxPane: &pane}
-	if isRunning(s) {
+	if c.isRunning(s) {
 		t.Error("expected isRunning=false when pane does not exist")
 	}
 
 	// Pane exists and is alive (agent still running).
-	run.PaneExists = func(string) bool { return true }
-	run.PaneIsDead = func(string) bool { return false }
+	c.SetTmuxDeps(run.TmuxDeps{
+		PaneExists: func(string) bool { return true },
+		PaneIsDead: func(string) bool { return false },
+		PaneIsIdle: func(string) bool { return false },
+	})
 
-	if !isRunning(s) {
+	if !c.isRunning(s) {
 		t.Error("expected isRunning=true when pane exists and is alive")
 	}
 
 	// No tmux pane at all.
 	s2 := &run.State{}
-	if isRunning(s2) {
+	if c.isRunning(s2) {
 		t.Error("expected isRunning=false when TmuxPane is nil")
 	}
 }

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -38,28 +38,42 @@ type State struct {
 	RepoRoot         *string  `json:"repo_root,omitempty"`         // absolute path to base repo for worktree recreation
 }
 
-// Tmux dependency injection for testing.
-var (
-	PaneExists = tmux.PaneExists
-	PaneIsIdle = tmux.PaneIsIdle
-	PaneIsDead = tmux.PaneIsDead
-)
+// TmuxDeps abstracts tmux pane operations so callers can inject test doubles.
+type TmuxDeps struct {
+	PaneExists func(string) bool
+	PaneIsIdle func(string) bool
+	PaneIsDead func(string) bool
+}
+
+// DefaultTmuxDeps returns TmuxDeps wired to the real tmux package.
+func DefaultTmuxDeps() TmuxDeps {
+	return TmuxDeps{
+		PaneExists: tmux.PaneExists,
+		PaneIsIdle: tmux.PaneIsIdle,
+		PaneIsDead: tmux.PaneIsDead,
+	}
+}
 
 // IsAgentRunning checks if the agent's tmux pane is still active and
 // executing its command pipeline.
 func (s *State) IsAgentRunning() bool {
-	if s.TmuxPane == nil || !PaneExists(*s.TmuxPane) {
+	return s.IsAgentRunningWith(DefaultTmuxDeps())
+}
+
+// IsAgentRunningWith is like IsAgentRunning but uses the provided TmuxDeps.
+func (s *State) IsAgentRunningWith(td TmuxDeps) bool {
+	if s.TmuxPane == nil || !td.PaneExists(*s.TmuxPane) {
 		return false
 	}
 
 	// Finalized runs (cost/duration set) are running only if their pane
 	// is not idle (e.g. still showing output before the user closes it).
 	if s.CostUSD != nil || s.DurationMS != nil {
-		return !PaneIsIdle(*s.TmuxPane)
+		return !td.PaneIsIdle(*s.TmuxPane)
 	}
 
 	// Active (unfinalized) runs are running unless the pane is explicitly dead.
-	return !PaneIsDead(*s.TmuxPane)
+	return !td.PaneIsDead(*s.TmuxPane)
 }
 
 // StaleGracePeriod is how long after creation before a run can be considered stale.
@@ -71,6 +85,11 @@ var StaleGracePeriod = 2 * time.Minute
 // and DurationMS are both nil), its tmux pane no longer exists, and enough time
 // has passed since creation to rule out normal startup delays.
 func (s *State) IsStale() bool {
+	return s.IsStaleWith(DefaultTmuxDeps())
+}
+
+// IsStaleWith is like IsStale but uses the provided TmuxDeps.
+func (s *State) IsStaleWith(td TmuxDeps) bool {
 	// Already finalized — not stale.
 	if s.CostUSD != nil || s.DurationMS != nil {
 		return false
@@ -87,7 +106,7 @@ func (s *State) IsStale() bool {
 		// require the pane to have existed and then disappeared.
 		return false
 	}
-	if PaneExists(*s.TmuxPane) {
+	if td.PaneExists(*s.TmuxPane) {
 		return false
 	}
 

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -271,9 +271,6 @@ func TestGitDirStoreListSkipsCorruptFiles(t *testing.T) {
 }
 
 func TestIsStale(t *testing.T) {
-	oldPaneExists := PaneExists
-	defer func() { PaneExists = oldPaneExists }()
-
 	oldGrace := StaleGracePeriod
 	defer func() { StaleGracePeriod = oldGrace }()
 	StaleGracePeriod = 0 // disable grace period for most sub-tests
@@ -359,8 +356,12 @@ func TestIsStale(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			PaneExists = tt.paneFunc
-			got := tt.state.IsStale()
+			td := TmuxDeps{
+				PaneExists: tt.paneFunc,
+				PaneIsIdle: func(string) bool { return false },
+				PaneIsDead: func(string) bool { return false },
+			}
+			got := tt.state.IsStaleWith(td)
 			if got != tt.want {
 				t.Errorf("IsStale() = %v, want %v", got, tt.want)
 			}
@@ -369,13 +370,14 @@ func TestIsStale(t *testing.T) {
 }
 
 func TestIsStale_GracePeriod(t *testing.T) {
-	oldPaneExists := PaneExists
-	defer func() { PaneExists = oldPaneExists }()
-
 	oldGrace := StaleGracePeriod
 	defer func() { StaleGracePeriod = oldGrace }()
 
-	PaneExists = func(string) bool { return false }
+	td := TmuxDeps{
+		PaneExists: func(string) bool { return false },
+		PaneIsIdle: func(string) bool { return false },
+		PaneIsDead: func(string) bool { return false },
+	}
 	StaleGracePeriod = 5 * time.Minute
 
 	strp := func(s string) *string { return &s }
@@ -386,7 +388,7 @@ func TestIsStale_GracePeriod(t *testing.T) {
 			TmuxPane:  strp("%1"),
 			CreatedAt: time.Now().Add(-1 * time.Minute).Format(time.RFC3339),
 		}
-		if s.IsStale() {
+		if s.IsStaleWith(td) {
 			t.Error("expected not stale within grace period")
 		}
 	})
@@ -397,7 +399,7 @@ func TestIsStale_GracePeriod(t *testing.T) {
 			TmuxPane:  strp("%1"),
 			CreatedAt: time.Now().Add(-10 * time.Minute).Format(time.RFC3339),
 		}
-		if !s.IsStale() {
+		if !s.IsStaleWith(td) {
 			t.Error("expected stale past grace period")
 		}
 	})


### PR DESCRIPTION
## Summary
- Replace all `var funcName = funcImpl` patterns with struct-based dependency injection
- `run.TmuxDeps` replaces `PaneExists`/`PaneIsIdle`/`PaneIsDead` globals, threaded through State, pipeline Controller, and dashboard model
- `CleanupDeps`, `WebhookDeps`, `ScaffoldDeps`, `ProjectDeps` replace their respective globals in cmd package
- `hasUnaddressedTrustedComments` converted from var to plain function (no tests override it)
- `git.SetDetectGHProtocol`/`ResetDetectGHProtocol` provides proper API for the one remaining var (required by sync.Once caching)
- Tests construct deps structs directly instead of save/restore global patterns

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 14 test packages)
- [ ] Verify no behavioral changes in manual testing

Closes #202