### PR TITLE
refactor: thread git.Client interface through all consumers

### DIFF
--- a/docs/project/ROBUSTNESS.md
+++ b/docs/project/ROBUSTNESS.md
@@ -2,7 +2,7 @@
 
 **Status:** In Progress
 **Filed:** 2026-04-09
-**Updated:** 2026-04-09
+**Updated:** 2026-04-13
 
 ## Motivation
 
@@ -51,12 +51,13 @@ Two cross-cutting principles guide this work:
 | [#198](https://github.com/patflynn/klaus/issues/198) | #215 | Pipeline decide/execute split — mutex no longer held during I/O |
 | [#199](https://github.com/patflynn/klaus/issues/199) | #216 | Stale run detection and recovery |
 | [#205](https://github.com/patflynn/klaus/issues/205) | #210 | Log cleanup/finalization errors |
+| [#202](https://github.com/patflynn/klaus/issues/202) | #219 | Remove global mutable function pointers — use DI |
 
 ### In Progress
 
-| Issue | Title |
-|-------|-------|
-| [#202](https://github.com/patflynn/klaus/issues/202) | Remove global mutable function pointers |
+| Issue | PR | Title |
+|-------|-----|-------|
+| [#217](https://github.com/patflynn/klaus/issues/217) | — | Thread git.Client through all consumers |
 
 ### Remaining — Interface Consumer Migration
 
@@ -65,7 +66,6 @@ functions directly. These issues complete the decoupling:
 
 | Issue | Title | Key Concern |
 |-------|-------|-------------|
-| [#217](https://github.com/patflynn/klaus/issues/217) | Thread git.Client through consumers | launch, cleanup, finalize, merge |
 | [#218](https://github.com/patflynn/klaus/issues/218) | Thread tmux.Client through consumers | launch, cleanup, session, dashboard, run.State |
 
 ### Remaining — Structural Cleanup
@@ -95,7 +95,7 @@ functions directly. These issues complete the decoupling:
 ```
 #217 (git consumer migration)  ─┐
 #218 (tmux consumer migration)  ├─→ #200 (Split dashboard)
-#202 (Remove globals)           ─┘
+✅ #202 (Remove globals)        ─┘
 
 Independent (any time):
   #201 (Canonicalize store)

--- a/internal/cmd/cleanup.go
+++ b/internal/cmd/cleanup.go
@@ -26,6 +26,7 @@ by default; pass --force to remove them anyway.`,
 
 		root, _ := git.RepoRoot() // may be empty outside a repo
 		gitClient := git.NewExecClient()
+		ctx := cmd.Context()
 
 		deps := DefaultCleanupDeps()
 
@@ -35,7 +36,7 @@ by default; pass --force to remove them anyway.`,
 				return err
 			}
 			if store != nil {
-				return cleanupAll(root, store, gitClient, force, deps)
+				return cleanupAll(ctx, root, store, gitClient, force, deps)
 			}
 			// No session env — could scan all, but require explicit session
 			return fmt.Errorf("KLAUS_SESSION_ID not set; specify a run ID or run inside a session")
@@ -50,11 +51,11 @@ by default; pass --force to remove them anyway.`,
 			return err
 		}
 		_ = state // cleanupOne will re-load
-		return cleanupOne(root, store, gitClient, args[0], force, deps)
+		return cleanupOne(ctx, root, store, gitClient, args[0], force, deps)
 	},
 }
 
-func cleanupAll(root string, store run.StateStore, gitClient git.Client, force bool, deps CleanupDeps) error {
+func cleanupAll(ctx context.Context, root string, store run.StateStore, gitClient git.Client, force bool, deps CleanupDeps) error {
 	states, err := store.List()
 	if err != nil {
 		return err
@@ -64,7 +65,7 @@ func cleanupAll(root string, store run.StateStore, gitClient git.Client, force b
 		return nil
 	}
 	for _, s := range states {
-		if err := cleanupOne(root, store, gitClient, s.ID, force, deps); err != nil {
+		if err := cleanupOne(ctx, root, store, gitClient, s.ID, force, deps); err != nil {
 			fmt.Printf("  warning: failed to clean up %s: %v\n", s.ID, err)
 		}
 	}
@@ -101,7 +102,7 @@ func defaultIsRunActive(state *run.State) bool {
 	return false
 }
 
-func cleanupOne(root string, store run.StateStore, gitClient git.Client, id string, force bool, deps CleanupDeps) error {
+func cleanupOne(ctx context.Context, root string, store run.StateStore, gitClient git.Client, id string, force bool, deps CleanupDeps) error {
 	state, err := store.Load(id)
 	if err != nil {
 		return fmt.Errorf("no run found with id: %s", id)
@@ -113,8 +114,6 @@ func cleanupOne(root string, store run.StateStore, gitClient git.Client, id stri
 	}
 
 	fmt.Printf("Cleaning up %s...\n", id)
-
-	ctx := context.TODO()
 
 	// Kill tmux pane if alive
 	if state.TmuxPane != nil && tmux.PaneExists(*state.TmuxPane) {

--- a/internal/cmd/cleanup.go
+++ b/internal/cmd/cleanup.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -24,6 +25,7 @@ by default; pass --force to remove them anyway.`,
 		force, _ := cmd.Flags().GetBool("force")
 
 		root, _ := git.RepoRoot() // may be empty outside a repo
+		gitClient := git.NewExecClient()
 
 		deps := DefaultCleanupDeps()
 
@@ -33,7 +35,7 @@ by default; pass --force to remove them anyway.`,
 				return err
 			}
 			if store != nil {
-				return cleanupAll(root, store, force, deps)
+				return cleanupAll(root, store, gitClient, force, deps)
 			}
 			// No session env — could scan all, but require explicit session
 			return fmt.Errorf("KLAUS_SESSION_ID not set; specify a run ID or run inside a session")
@@ -48,11 +50,11 @@ by default; pass --force to remove them anyway.`,
 			return err
 		}
 		_ = state // cleanupOne will re-load
-		return cleanupOne(root, store, args[0], force, deps)
+		return cleanupOne(root, store, gitClient, args[0], force, deps)
 	},
 }
 
-func cleanupAll(root string, store run.StateStore, force bool, deps CleanupDeps) error {
+func cleanupAll(root string, store run.StateStore, gitClient git.Client, force bool, deps CleanupDeps) error {
 	states, err := store.List()
 	if err != nil {
 		return err
@@ -62,7 +64,7 @@ func cleanupAll(root string, store run.StateStore, force bool, deps CleanupDeps)
 		return nil
 	}
 	for _, s := range states {
-		if err := cleanupOne(root, store, s.ID, force, deps); err != nil {
+		if err := cleanupOne(root, store, gitClient, s.ID, force, deps); err != nil {
 			fmt.Printf("  warning: failed to clean up %s: %v\n", s.ID, err)
 		}
 	}
@@ -99,7 +101,7 @@ func defaultIsRunActive(state *run.State) bool {
 	return false
 }
 
-func cleanupOne(root string, store run.StateStore, id string, force bool, deps CleanupDeps) error {
+func cleanupOne(root string, store run.StateStore, gitClient git.Client, id string, force bool, deps CleanupDeps) error {
 	state, err := store.Load(id)
 	if err != nil {
 		return fmt.Errorf("no run found with id: %s", id)
@@ -111,6 +113,8 @@ func cleanupOne(root string, store run.StateStore, id string, force bool, deps C
 	}
 
 	fmt.Printf("Cleaning up %s...\n", id)
+
+	ctx := context.TODO()
 
 	// Kill tmux pane if alive
 	if state.TmuxPane != nil && tmux.PaneExists(*state.TmuxPane) {
@@ -138,7 +142,7 @@ func cleanupOne(root string, store run.StateStore, id string, force bool, deps C
 
 	// Remove worktree
 	if state.Worktree != "" {
-		if err := git.WorktreeRemove(gitRoot, state.Worktree); err == nil {
+		if err := gitClient.WorktreeRemove(ctx, gitRoot, state.Worktree); err == nil {
 			fmt.Println("  removed worktree")
 		} else {
 			slog.Warn("failed to remove worktree", "id", id, "worktree", state.Worktree, "err", err)
@@ -147,7 +151,7 @@ func cleanupOne(root string, store run.StateStore, id string, force bool, deps C
 
 	// Delete local branch
 	if state.Branch != "" {
-		if err := git.BranchDelete(gitRoot, state.Branch); err == nil {
+		if err := gitClient.BranchDelete(ctx, gitRoot, state.Branch); err == nil {
 			fmt.Println("  deleted local branch")
 		} else {
 			slog.Warn("failed to delete local branch", "id", id, "branch", state.Branch, "err", err)

--- a/internal/cmd/cleanup_test.go
+++ b/internal/cmd/cleanup_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -22,7 +23,7 @@ func TestCleanupAllSkipsActiveRuns(t *testing.T) {
 	deps := CleanupDeps{IsRunActive: func(s *run.State) bool { return s.ID == "run-2" }}
 
 	output := captureStdout(t, func() {
-		if err := cleanupAll("", store, git.NewExecClient(), false, deps); err != nil {
+		if err := cleanupAll(context.Background(), "", store, git.NewExecClient(), false, deps); err != nil {
 			t.Fatalf("cleanupAll() error: %v", err)
 		}
 	})
@@ -53,7 +54,7 @@ func TestCleanupAllForceRemovesActiveRuns(t *testing.T) {
 	deps := CleanupDeps{IsRunActive: func(s *run.State) bool { return s.ID == "run-2" }}
 
 	output := captureStdout(t, func() {
-		if err := cleanupAll("", store, git.NewExecClient(), true, deps); err != nil {
+		if err := cleanupAll(context.Background(), "", store, git.NewExecClient(), true, deps); err != nil {
 			t.Fatalf("cleanupAll() error: %v", err)
 		}
 	})
@@ -80,7 +81,7 @@ func TestCleanupOneSkipsActiveRun(t *testing.T) {
 	deps := CleanupDeps{IsRunActive: func(s *run.State) bool { return true }}
 
 	output := captureStdout(t, func() {
-		if err := cleanupOne("", store, git.NewExecClient(), "run-1", false, deps); err != nil {
+		if err := cleanupOne(context.Background(), "", store, git.NewExecClient(), "run-1", false, deps); err != nil {
 			t.Fatalf("cleanupOne() error: %v", err)
 		}
 	})
@@ -101,7 +102,7 @@ func TestCleanupOneForceRemovesActiveRun(t *testing.T) {
 	deps := CleanupDeps{IsRunActive: func(s *run.State) bool { return true }}
 
 	captureStdout(t, func() {
-		if err := cleanupOne("", store, git.NewExecClient(), "run-1", true, deps); err != nil {
+		if err := cleanupOne(context.Background(), "", store, git.NewExecClient(), "run-1", true, deps); err != nil {
 			t.Fatalf("cleanupOne() error: %v", err)
 		}
 	})

--- a/internal/cmd/cleanup_test.go
+++ b/internal/cmd/cleanup_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/patflynn/klaus/internal/git"
 	"github.com/patflynn/klaus/internal/run"
 )
 
@@ -21,7 +22,7 @@ func TestCleanupAllSkipsActiveRuns(t *testing.T) {
 	deps := CleanupDeps{IsRunActive: func(s *run.State) bool { return s.ID == "run-2" }}
 
 	output := captureStdout(t, func() {
-		if err := cleanupAll("", store, false, deps); err != nil {
+		if err := cleanupAll("", store, git.NewExecClient(), false, deps); err != nil {
 			t.Fatalf("cleanupAll() error: %v", err)
 		}
 	})
@@ -52,7 +53,7 @@ func TestCleanupAllForceRemovesActiveRuns(t *testing.T) {
 	deps := CleanupDeps{IsRunActive: func(s *run.State) bool { return s.ID == "run-2" }}
 
 	output := captureStdout(t, func() {
-		if err := cleanupAll("", store, true, deps); err != nil {
+		if err := cleanupAll("", store, git.NewExecClient(), true, deps); err != nil {
 			t.Fatalf("cleanupAll() error: %v", err)
 		}
 	})
@@ -79,7 +80,7 @@ func TestCleanupOneSkipsActiveRun(t *testing.T) {
 	deps := CleanupDeps{IsRunActive: func(s *run.State) bool { return true }}
 
 	output := captureStdout(t, func() {
-		if err := cleanupOne("", store, "run-1", false, deps); err != nil {
+		if err := cleanupOne("", store, git.NewExecClient(), "run-1", false, deps); err != nil {
 			t.Fatalf("cleanupOne() error: %v", err)
 		}
 	})
@@ -100,7 +101,7 @@ func TestCleanupOneForceRemovesActiveRun(t *testing.T) {
 	deps := CleanupDeps{IsRunActive: func(s *run.State) bool { return true }}
 
 	captureStdout(t, func() {
-		if err := cleanupOne("", store, "run-1", true, deps); err != nil {
+		if err := cleanupOne("", store, git.NewExecClient(), "run-1", true, deps); err != nil {
 			t.Fatalf("cleanupOne() error: %v", err)
 		}
 	})

--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -895,7 +895,7 @@ func markRunFailed(store run.StateStore, s *run.State) {
 	s.CostUSD = &cost
 	s.DurationMS = &dur
 	s.TmuxPane = nil
-	cleanupWorktree(store, s)
+	cleanupWorktree(store, git.NewExecClient(), s)
 	if err := store.Save(s); err != nil {
 		slog.Warn("failed to save stale run state", "id", s.ID, "err", err)
 	}

--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -895,7 +895,7 @@ func markRunFailed(store run.StateStore, s *run.State) {
 	s.CostUSD = &cost
 	s.DurationMS = &dur
 	s.TmuxPane = nil
-	cleanupWorktree(store, git.NewExecClient(), s)
+	cleanupWorktree(context.Background(), store, git.NewExecClient(), s)
 	if err := store.Save(s); err != nil {
 		slog.Warn("failed to save stale run state", "id", s.ID, "err", err)
 	}

--- a/internal/cmd/hidden.go
+++ b/internal/cmd/hidden.go
@@ -92,11 +92,12 @@ var finalizeCmd = &cobra.Command{
 			return nil
 		}
 
+		ctx := cmd.Context()
 		gitClient := git.NewExecClient()
 
-		syncRunToDataRef(syncRoot, store, gitClient, cfg.DataRef, state)
+		syncRunToDataRef(ctx, syncRoot, store, gitClient, cfg.DataRef, state)
 
-		cleanupWorktree(store, gitClient, state)
+		cleanupWorktree(ctx, store, gitClient, state)
 
 		return nil
 	},
@@ -105,7 +106,7 @@ var finalizeCmd = &cobra.Command{
 // cleanupWorktree removes the agent's worktree and local branch after
 // completion. The state file and logs are preserved. It is idempotent —
 // if the worktree is already gone, the state is still cleared.
-func cleanupWorktree(store run.StateStore, gitClient git.Client, state *run.State) {
+func cleanupWorktree(ctx context.Context, store run.StateStore, gitClient git.Client, state *run.State) {
 	if state.Worktree == "" {
 		return
 	}
@@ -118,7 +119,6 @@ func cleanupWorktree(store run.StateStore, gitClient git.Client, state *run.Stat
 	if gitRoot == "" {
 		return
 	}
-	ctx := context.TODO()
 	if err := gitClient.WorktreeRemove(ctx, gitRoot, state.Worktree); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: worktree cleanup: %v\n", err)
 	}
@@ -267,7 +267,7 @@ func ExtractClaudeSessionID(logPath string) string {
 	return ""
 }
 
-func syncRunToDataRef(root string, store run.StateStore, gitClient git.Client, dataRef string, state *run.State) {
+func syncRunToDataRef(ctx context.Context, root string, store run.StateStore, gitClient git.Client, dataRef string, state *run.State) {
 	stateFile := store.StateDir() + "/" + state.ID + ".json"
 	files := map[string]string{
 		"runs/" + state.ID + ".json": stateFile,
@@ -292,7 +292,6 @@ func syncRunToDataRef(root string, store run.StateStore, gitClient git.Client, d
 		}
 	}
 
-	ctx := context.TODO()
 	if err := gitClient.SyncToDataRef(ctx, root, dataRef, "Run "+state.ID, files); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: sync to data ref: %v\n", err)
 		return

--- a/internal/cmd/hidden.go
+++ b/internal/cmd/hidden.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -91,9 +92,11 @@ var finalizeCmd = &cobra.Command{
 			return nil
 		}
 
-		syncRunToDataRef(syncRoot, store, cfg.DataRef, state)
+		gitClient := git.NewExecClient()
 
-		cleanupWorktree(store, state)
+		syncRunToDataRef(syncRoot, store, gitClient, cfg.DataRef, state)
+
+		cleanupWorktree(store, gitClient, state)
 
 		return nil
 	},
@@ -102,7 +105,7 @@ var finalizeCmd = &cobra.Command{
 // cleanupWorktree removes the agent's worktree and local branch after
 // completion. The state file and logs are preserved. It is idempotent —
 // if the worktree is already gone, the state is still cleared.
-func cleanupWorktree(store run.StateStore, state *run.State) {
+func cleanupWorktree(store run.StateStore, gitClient git.Client, state *run.State) {
 	if state.Worktree == "" {
 		return
 	}
@@ -115,11 +118,12 @@ func cleanupWorktree(store run.StateStore, state *run.State) {
 	if gitRoot == "" {
 		return
 	}
-	if err := git.WorktreeRemove(gitRoot, state.Worktree); err != nil {
+	ctx := context.TODO()
+	if err := gitClient.WorktreeRemove(ctx, gitRoot, state.Worktree); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: worktree cleanup: %v\n", err)
 	}
 	if state.Branch != "" {
-		if err := git.BranchDelete(gitRoot, state.Branch); err != nil {
+		if err := gitClient.BranchDelete(ctx, gitRoot, state.Branch); err != nil {
 			slog.Warn("failed to delete branch during cleanup", "id", state.ID, "branch", state.Branch, "err", err)
 		}
 	}
@@ -263,7 +267,7 @@ func ExtractClaudeSessionID(logPath string) string {
 	return ""
 }
 
-func syncRunToDataRef(root string, store run.StateStore, dataRef string, state *run.State) {
+func syncRunToDataRef(root string, store run.StateStore, gitClient git.Client, dataRef string, state *run.State) {
 	stateFile := store.StateDir() + "/" + state.ID + ".json"
 	files := map[string]string{
 		"runs/" + state.ID + ".json": stateFile,
@@ -288,12 +292,13 @@ func syncRunToDataRef(root string, store run.StateStore, dataRef string, state *
 		}
 	}
 
-	if err := git.SyncToDataRef(root, dataRef, "Run "+state.ID, files); err != nil {
+	ctx := context.TODO()
+	if err := gitClient.SyncToDataRef(ctx, root, dataRef, "Run "+state.ID, files); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: sync to data ref: %v\n", err)
 		return
 	}
 
-	if err := git.PushDataRef(root, dataRef); err != nil {
+	if err := gitClient.PushDataRef(ctx, root, dataRef); err != nil {
 		// Silently ignore push failures (no remote, etc.)
 	}
 }

--- a/internal/cmd/hidden_test.go
+++ b/internal/cmd/hidden_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/patflynn/klaus/internal/git"
 	"github.com/patflynn/klaus/internal/run"
 )
 
@@ -38,7 +39,7 @@ func TestFinalizeWorktreeCleanup(t *testing.T) {
 		store := &testStateStore{dir: stateDir, state: state}
 
 		// Simulate the cleanup logic from _finalize.
-		cleanupWorktree(store, state)
+		cleanupWorktree(store, git.NewExecClient(), state)
 
 		if state.Worktree != "" {
 			t.Errorf("expected Worktree to be cleared, got %q", state.Worktree)
@@ -67,7 +68,7 @@ func TestFinalizeWorktreeCleanup(t *testing.T) {
 		store := &testStateStore{dir: stateDir, state: state}
 
 		// Should not panic or fail — just clears state.
-		cleanupWorktree(store, state)
+		cleanupWorktree(store, git.NewExecClient(), state)
 
 		if state.Worktree != "" {
 			t.Errorf("expected Worktree to be cleared, got %q", state.Worktree)
@@ -78,7 +79,7 @@ func TestFinalizeWorktreeCleanup(t *testing.T) {
 		state := &run.State{ID: "test-run", Worktree: ""}
 		store := &testStateStore{state: state}
 
-		cleanupWorktree(store, state)
+		cleanupWorktree(store, git.NewExecClient(), state)
 
 		if state.Worktree != "" {
 			t.Errorf("expected empty worktree, got %q", state.Worktree)

--- a/internal/cmd/hidden_test.go
+++ b/internal/cmd/hidden_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -39,7 +40,7 @@ func TestFinalizeWorktreeCleanup(t *testing.T) {
 		store := &testStateStore{dir: stateDir, state: state}
 
 		// Simulate the cleanup logic from _finalize.
-		cleanupWorktree(store, git.NewExecClient(), state)
+		cleanupWorktree(context.Background(), store, git.NewExecClient(), state)
 
 		if state.Worktree != "" {
 			t.Errorf("expected Worktree to be cleared, got %q", state.Worktree)
@@ -68,7 +69,7 @@ func TestFinalizeWorktreeCleanup(t *testing.T) {
 		store := &testStateStore{dir: stateDir, state: state}
 
 		// Should not panic or fail — just clears state.
-		cleanupWorktree(store, git.NewExecClient(), state)
+		cleanupWorktree(context.Background(), store, git.NewExecClient(), state)
 
 		if state.Worktree != "" {
 			t.Errorf("expected Worktree to be cleared, got %q", state.Worktree)
@@ -79,7 +80,7 @@ func TestFinalizeWorktreeCleanup(t *testing.T) {
 		state := &run.State{ID: "test-run", Worktree: ""}
 		store := &testStateStore{state: state}
 
-		cleanupWorktree(store, git.NewExecClient(), state)
+		cleanupWorktree(context.Background(), store, git.NewExecClient(), state)
 
 		if state.Worktree != "" {
 			t.Errorf("expected empty worktree, got %q", state.Worktree)

--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -55,7 +54,7 @@ are synced back after completion. Use --local to force local execution, or
 		// Host repo — optional when --repo is specified or session target is set
 		hostRoot, _ := git.RepoRoot()
 		gitClient := git.NewExecClient()
-		ctx := context.TODO()
+		ctx := cmd.Context()
 
 		// Load session target (if any) to feed into resolution
 		var sessionTarget string

--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -54,6 +54,8 @@ are synced back after completion. Use --local to force local execution, or
 
 		// Host repo — optional when --repo is specified or session target is set
 		hostRoot, _ := git.RepoRoot()
+		gitClient := git.NewExecClient()
+		ctx := context.TODO()
 
 		// Load session target (if any) to feed into resolution
 		var sessionTarget string
@@ -132,7 +134,7 @@ are synced back after completion. Use --local to force local execution, or
 			cloneDir := filepath.Join(hostCfg.WorktreeBase, ".repos", owner, repo)
 
 			fmt.Printf("Cloning/fetching %s/%s...\n", owner, repo)
-			if err := git.EnsureClone(cloneURL, cloneDir); err != nil {
+			if err := gitClient.EnsureClone(ctx, cloneURL, cloneDir); err != nil {
 				return fmt.Errorf("cloning %s: %w", repoRef, err)
 			}
 
@@ -161,7 +163,7 @@ are synced back after completion. Use --local to force local execution, or
 		// Skip when EnsureClone was already called — it fetches with the
 		// same flags (--prune --tags), so a second fetch is redundant.
 		if repoRef == "" || projectLocalPath != "" {
-			if err := git.FetchAll(repoRoot); err != nil {
+			if err := gitClient.FetchAll(ctx, repoRoot); err != nil {
 				return fmt.Errorf("fetching origin: %w", err)
 			}
 		}
@@ -174,7 +176,6 @@ are synced back after completion. Use --local to force local execution, or
 		if prNumber != "" {
 			ghRepo := resolveGHRepo(repoRef, repoRoot)
 			ghClient := gh.NewGHCLIClient(ghRepo)
-			ctx := context.TODO()
 			prBranch, err := ghClient.GetBranch(ctx, prNumber)
 			if err != nil {
 				return fmt.Errorf("getting PR branch: %w", err)
@@ -194,7 +195,7 @@ are synced back after completion. Use --local to force local execution, or
 			}
 
 			// Create worktree tracking the PR branch
-			if err := git.WorktreeAddTrack(repoRoot, worktree, prBranch); err != nil {
+			if err := gitClient.WorktreeAddTrack(ctx, repoRoot, worktree, prBranch); err != nil {
 				return fmt.Errorf("creating worktree: %w", err)
 			}
 		} else {
@@ -207,7 +208,7 @@ are synced back after completion. Use --local to force local execution, or
 
 			// Create worktree
 			startPoint := "origin/" + defaultBranch
-			if err := git.WorktreeAdd(repoRoot, worktree, branch, startPoint); err != nil {
+			if err := gitClient.WorktreeAdd(ctx, repoRoot, worktree, branch, startPoint); err != nil {
 				return fmt.Errorf("creating worktree: %w", err)
 			}
 		}
@@ -218,7 +219,7 @@ are synced back after completion. Use --local to force local execution, or
 			fmt.Fprintf(os.Stderr, "warning: could not write .claude/settings.json: %v\n", err)
 		}
 
-		if err := git.InstallCommitMsgHook(worktree); err != nil {
+		if err := gitClient.InstallCommitMsgHook(ctx, worktree); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: could not install commit-msg hook: %v\n", err)
 		}
 

--- a/internal/cmd/merge.go
+++ b/internal/cmd/merge.go
@@ -250,7 +250,8 @@ func validateMergeMethod(method string) error {
 // rebaseAndPush rebases a PR branch onto origin/main, verifies compilation,
 // and force-pushes using a temporary worktree.
 func rebaseAndPush(prNumber string, repo string) error {
-	branch, err := gh.NewGHCLIClient(repo).GetBranch(context.TODO(), prNumber)
+	ctx := context.TODO()
+	branch, err := gh.NewGHCLIClient(repo).GetBranch(ctx, prNumber)
 	if err != nil {
 		return fmt.Errorf("getting branch: %w", err)
 	}
@@ -260,10 +261,12 @@ func rebaseAndPush(prNumber string, repo string) error {
 		return fmt.Errorf("could not determine git repository root: %w", err)
 	}
 
-	if err := git.FetchBranch(repoRoot, "main"); err != nil {
+	gitClient := git.NewExecClient()
+
+	if err := gitClient.FetchBranch(ctx, repoRoot, "main"); err != nil {
 		return fmt.Errorf("fetching main: %w", err)
 	}
-	if err := git.FetchBranch(repoRoot, branch); err != nil {
+	if err := gitClient.FetchBranch(ctx, repoRoot, branch); err != nil {
 		return fmt.Errorf("fetching %s: %w", branch, err)
 	}
 
@@ -273,7 +276,7 @@ func rebaseAndPush(prNumber string, repo string) error {
 	}
 	worktreePath := filepath.Join(tmpDir, "rebase")
 	defer func() {
-		if err := git.WorktreeRemove(repoRoot, worktreePath); err != nil {
+		if err := gitClient.WorktreeRemove(ctx, repoRoot, worktreePath); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to remove worktree: %v\n", err)
 		}
 		if err := os.RemoveAll(tmpDir); err != nil {
@@ -281,7 +284,7 @@ func rebaseAndPush(prNumber string, repo string) error {
 		}
 	}()
 
-	if err := git.WorktreeAddTrack(repoRoot, worktreePath, branch); err != nil {
+	if err := gitClient.WorktreeAddTrack(ctx, repoRoot, worktreePath, branch); err != nil {
 		return fmt.Errorf("creating worktree: %w", err)
 	}
 

--- a/internal/cmd/pushlog.go
+++ b/internal/cmd/pushlog.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -43,18 +44,21 @@ warnings. Use after reviewing the log and confirming it's safe.`,
 
 		fmt.Printf("Force-pushing log for %s (bypassing sensitivity check)...\n", id)
 
+		ctx := context.TODO()
+		gitClient := git.NewExecClient()
+
 		stateFile := store.StateDir() + "/" + id + ".json"
 		files := map[string]string{
 			"runs/" + id + ".json":  stateFile,
 			"logs/" + id + ".jsonl": *state.LogFile,
 		}
 
-		if err := git.SyncToDataRef(root, cfg.DataRef, "Run "+id, files); err != nil {
+		if err := gitClient.SyncToDataRef(ctx, root, cfg.DataRef, "Run "+id, files); err != nil {
 			return fmt.Errorf("syncing to data ref: %w", err)
 		}
 
 		// Push to remote
-		if err := git.PushDataRef(root, cfg.DataRef); err != nil {
+		if err := gitClient.PushDataRef(ctx, root, cfg.DataRef); err != nil {
 			fmt.Printf("  warning: push to remote failed: %v\n", err)
 		}
 

--- a/internal/cmd/pushlog.go
+++ b/internal/cmd/pushlog.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -44,7 +43,7 @@ warnings. Use after reviewing the log and confirming it's safe.`,
 
 		fmt.Printf("Force-pushing log for %s (bypassing sensitivity check)...\n", id)
 
-		ctx := context.TODO()
+		ctx := cmd.Context()
 		gitClient := git.NewExecClient()
 
 		stateFile := store.StateDir() + "/" + id + ".json"

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"crypto/rand"
 	"fmt"
 	"log/slog"
@@ -64,6 +65,8 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 	// Git repo is optional — session can run without one
 	root, _ := git.RepoRoot()
 	inRepo := root != ""
+	gitClient := git.NewExecClient()
+	ctx := context.TODO()
 
 	cfg, err := config.Load(root)
 	if err != nil {
@@ -158,11 +161,11 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 					return fmt.Errorf("session worktree no longer exists and no repo root available: %s", worktree)
 				}
 				defaultBranch := cfg.DefaultBranch
-				if err := git.FetchBranch(baseRepo, defaultBranch); err != nil {
+				if err := gitClient.FetchBranch(ctx, baseRepo, defaultBranch); err != nil {
 					return fmt.Errorf("fetching %s: %w", defaultBranch, err)
 				}
 				startPoint := "origin/" + defaultBranch
-				if err := git.WorktreeAdd(baseRepo, worktree, branch, startPoint); err != nil {
+				if err := gitClient.WorktreeAdd(ctx, baseRepo, worktree, branch, startPoint); err != nil {
 					return fmt.Errorf("recreating worktree: %w", err)
 				}
 			}
@@ -199,12 +202,12 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 
 			fmt.Printf("Creating coordinator session %s...\n", id)
 
-			if err := git.FetchBranch(root, defaultBranch); err != nil {
+			if err := gitClient.FetchBranch(ctx, root, defaultBranch); err != nil {
 				return fmt.Errorf("fetching %s: %w", defaultBranch, err)
 			}
 
 			startPoint := "origin/" + defaultBranch
-			if err := git.WorktreeAdd(root, worktree, branch, startPoint); err != nil {
+			if err := gitClient.WorktreeAdd(ctx, root, worktree, branch, startPoint); err != nil {
 				return fmt.Errorf("creating worktree: %w", err)
 			}
 			fmt.Printf("  worktree: %s\n", worktree)

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"crypto/rand"
 	"fmt"
 	"log/slog"
@@ -66,7 +65,7 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 	root, _ := git.RepoRoot()
 	inRepo := root != ""
 	gitClient := git.NewExecClient()
-	ctx := context.TODO()
+	ctx := cmd.Context()
 
 	cfg, err := config.Load(root)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Replace all direct package-level git function calls in cmd/ with calls through `git.Client` instances (`git.NewExecClient()`), completing issue #217
- Thread `git.Client` through function signatures where needed (`cleanupOne`, `cleanupAll`, `cleanupWorktree`, `syncRunToDataRef`)
- Update ROBUSTNESS.md: mark #202 as done (PR #219), move #217 to in-progress

Utility functions (`RepoRoot`, `ParseRepoRef`, `CloneURL`, `CleanGitHubRef`) remain as package-level calls — they are pure functions or bootstrapping helpers not on the `Client` interface.

Closes #217

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (updated cleanup_test.go and hidden_test.go for new signatures)
- [x] Verified no remaining direct calls to git interface methods in cmd/ via grep