### PR TITLE
refactor: thread tmux.Client through all cmd/ consumers

### DIFF
--- a/internal/cmd/cleanup.go
+++ b/internal/cmd/cleanup.go
@@ -23,12 +23,13 @@ by default; pass --force to remove them anyway.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		all, _ := cmd.Flags().GetBool("all")
 		force, _ := cmd.Flags().GetBool("force")
+		ctx := cmd.Context()
+		tmuxClient := tmux.NewExecClient()
+		gitClient := git.NewExecClient()
 
 		root, _ := git.RepoRoot() // may be empty outside a repo
-		gitClient := git.NewExecClient()
-		ctx := cmd.Context()
 
-		deps := DefaultCleanupDeps()
+		deps := DefaultCleanupDeps(tmuxClient)
 
 		if all {
 			store, err := sessionStoreOrAll()
@@ -36,7 +37,7 @@ by default; pass --force to remove them anyway.`,
 				return err
 			}
 			if store != nil {
-				return cleanupAll(ctx, root, store, gitClient, force, deps)
+				return cleanupAll(ctx, root, store, gitClient, force, deps, tmuxClient)
 			}
 			// No session env — could scan all, but require explicit session
 			return fmt.Errorf("KLAUS_SESSION_ID not set; specify a run ID or run inside a session")
@@ -51,11 +52,11 @@ by default; pass --force to remove them anyway.`,
 			return err
 		}
 		_ = state // cleanupOne will re-load
-		return cleanupOne(ctx, root, store, gitClient, args[0], force, deps)
+		return cleanupOne(ctx, root, store, gitClient, args[0], force, deps, tmuxClient)
 	},
 }
 
-func cleanupAll(ctx context.Context, root string, store run.StateStore, gitClient git.Client, force bool, deps CleanupDeps) error {
+func cleanupAll(ctx context.Context, root string, store run.StateStore, gitClient git.Client, force bool, deps CleanupDeps, tc tmux.Client) error {
 	states, err := store.List()
 	if err != nil {
 		return err
@@ -65,7 +66,10 @@ func cleanupAll(ctx context.Context, root string, store run.StateStore, gitClien
 		return nil
 	}
 	for _, s := range states {
-		if err := cleanupOne(ctx, root, store, gitClient, s.ID, force, deps); err != nil {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := cleanupOne(ctx, root, store, gitClient, s.ID, force, deps, tc); err != nil {
 			fmt.Printf("  warning: failed to clean up %s: %v\n", s.ID, err)
 		}
 	}
@@ -78,14 +82,17 @@ type CleanupDeps struct {
 }
 
 // DefaultCleanupDeps returns CleanupDeps wired to real implementations.
-func DefaultCleanupDeps() CleanupDeps {
+func DefaultCleanupDeps(tc tmux.Client) CleanupDeps {
 	return CleanupDeps{
-		IsRunActive: defaultIsRunActive,
+		IsRunActive: func(state *run.State) bool {
+			return defaultIsRunActive(state, tc)
+		},
 	}
 }
 
 // defaultIsRunActive reports whether the run has a live, non-idle tmux pane or is the current session.
-func defaultIsRunActive(state *run.State) bool {
+func defaultIsRunActive(state *run.State, tc tmux.Client) bool {
+	ctx := context.Background()
 	if state.Type == "session" {
 		if sid := os.Getenv(sessionIDEnv); sid != "" && state.ID == sid {
 			return true
@@ -96,13 +103,13 @@ func defaultIsRunActive(state *run.State) bool {
 		return true
 	}
 
-	if state.DashboardPane != nil && tmux.PaneExists(*state.DashboardPane) {
+	if state.DashboardPane != nil && tc.PaneExists(ctx, *state.DashboardPane) {
 		return true
 	}
 	return false
 }
 
-func cleanupOne(ctx context.Context, root string, store run.StateStore, gitClient git.Client, id string, force bool, deps CleanupDeps) error {
+func cleanupOne(ctx context.Context, root string, store run.StateStore, gitClient git.Client, id string, force bool, deps CleanupDeps, tc tmux.Client) error {
 	state, err := store.Load(id)
 	if err != nil {
 		return fmt.Errorf("no run found with id: %s", id)
@@ -116,8 +123,8 @@ func cleanupOne(ctx context.Context, root string, store run.StateStore, gitClien
 	fmt.Printf("Cleaning up %s...\n", id)
 
 	// Kill tmux pane if alive
-	if state.TmuxPane != nil && tmux.PaneExists(*state.TmuxPane) {
-		if err := tmux.KillPane(*state.TmuxPane); err == nil {
+	if state.TmuxPane != nil && tc.PaneExists(ctx, *state.TmuxPane) {
+		if err := tc.KillPane(ctx, *state.TmuxPane); err == nil {
 			fmt.Println("  killed tmux pane")
 		} else {
 			slog.Warn("failed to kill tmux pane", "id", id, "pane", *state.TmuxPane, "err", err)
@@ -125,8 +132,8 @@ func cleanupOne(ctx context.Context, root string, store run.StateStore, gitClien
 	}
 
 	// Kill dashboard pane if alive
-	if state.DashboardPane != nil && tmux.PaneExists(*state.DashboardPane) {
-		if err := tmux.KillPane(*state.DashboardPane); err == nil {
+	if state.DashboardPane != nil && tc.PaneExists(ctx, *state.DashboardPane) {
+		if err := tc.KillPane(ctx, *state.DashboardPane); err == nil {
 			fmt.Println("  killed dashboard pane")
 		} else {
 			slog.Warn("failed to kill dashboard pane", "id", id, "pane", *state.DashboardPane, "err", err)

--- a/internal/cmd/cleanup_test.go
+++ b/internal/cmd/cleanup_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/patflynn/klaus/internal/git"
 	"github.com/patflynn/klaus/internal/run"
+	"github.com/patflynn/klaus/internal/tmux"
 )
 
 func TestCleanupAllSkipsActiveRuns(t *testing.T) {
@@ -19,11 +20,14 @@ func TestCleanupAllSkipsActiveRuns(t *testing.T) {
 		&run.State{ID: "run-3", Prompt: "c", Branch: "b3", CreatedAt: "2026-01-01T00:02:00Z"},
 	)
 
+	ctx := context.Background()
+	tc := tmux.NewExecClient()
+
 	// Make run-2 active
 	deps := CleanupDeps{IsRunActive: func(s *run.State) bool { return s.ID == "run-2" }}
 
 	output := captureStdout(t, func() {
-		if err := cleanupAll(context.Background(), "", store, git.NewExecClient(), false, deps); err != nil {
+		if err := cleanupAll(ctx, "", store, git.NewExecClient(), false, deps, tc); err != nil {
 			t.Fatalf("cleanupAll() error: %v", err)
 		}
 	})
@@ -51,10 +55,12 @@ func TestCleanupAllForceRemovesActiveRuns(t *testing.T) {
 		&run.State{ID: "run-2", Prompt: "b", Branch: "b2", CreatedAt: "2026-01-01T00:01:00Z"},
 	)
 
+	ctx := context.Background()
+	tc := tmux.NewExecClient()
 	deps := CleanupDeps{IsRunActive: func(s *run.State) bool { return s.ID == "run-2" }}
 
 	output := captureStdout(t, func() {
-		if err := cleanupAll(context.Background(), "", store, git.NewExecClient(), true, deps); err != nil {
+		if err := cleanupAll(ctx, "", store, git.NewExecClient(), true, deps, tc); err != nil {
 			t.Fatalf("cleanupAll() error: %v", err)
 		}
 	})
@@ -78,10 +84,12 @@ func TestCleanupOneSkipsActiveRun(t *testing.T) {
 		&run.State{ID: "run-1", Prompt: "a", Branch: "b1", CreatedAt: "2026-01-01T00:00:00Z"},
 	)
 
+	ctx := context.Background()
+	tc := tmux.NewExecClient()
 	deps := CleanupDeps{IsRunActive: func(s *run.State) bool { return true }}
 
 	output := captureStdout(t, func() {
-		if err := cleanupOne(context.Background(), "", store, git.NewExecClient(), "run-1", false, deps); err != nil {
+		if err := cleanupOne(ctx, "", store, git.NewExecClient(), "run-1", false, deps, tc); err != nil {
 			t.Fatalf("cleanupOne() error: %v", err)
 		}
 	})
@@ -99,10 +107,12 @@ func TestCleanupOneForceRemovesActiveRun(t *testing.T) {
 		&run.State{ID: "run-1", Prompt: "a", Branch: "b1", CreatedAt: "2026-01-01T00:00:00Z"},
 	)
 
+	ctx := context.Background()
+	tc := tmux.NewExecClient()
 	deps := CleanupDeps{IsRunActive: func(s *run.State) bool { return true }}
 
 	captureStdout(t, func() {
-		if err := cleanupOne(context.Background(), "", store, git.NewExecClient(), "run-1", true, deps); err != nil {
+		if err := cleanupOne(ctx, "", store, git.NewExecClient(), "run-1", true, deps, tc); err != nil {
 			t.Fatalf("cleanupOne() error: %v", err)
 		}
 	})
@@ -114,37 +124,40 @@ func TestCleanupOneForceRemovesActiveRun(t *testing.T) {
 
 func TestIsRunActiveWithSessionEnv(t *testing.T) {
 	t.Setenv(sessionIDEnv, "sess-123")
+	tc := tmux.NewExecClient()
 
 	// Session run matching current session ID should be active
 	s := &run.State{ID: "sess-123", Type: "session"}
-	if !defaultIsRunActive(s) {
+	if !defaultIsRunActive(s, tc) {
 		t.Error("expected session run matching KLAUS_SESSION_ID to be active")
 	}
 
 	// Different session ID should not be active (no tmux pane)
 	s2 := &run.State{ID: "sess-456", Type: "session"}
-	if defaultIsRunActive(s2) {
+	if defaultIsRunActive(s2, tc) {
 		t.Error("expected different session ID to not be active")
 	}
 
 	// Non-session run without tmux pane should not be active
 	s3 := &run.State{ID: "sess-123", Type: "launch"}
-	if defaultIsRunActive(s3) {
+	if defaultIsRunActive(s3, tc) {
 		t.Error("expected non-session run without tmux pane to not be active")
 	}
 }
 
 func TestIsRunActiveWithDashboardPane(t *testing.T) {
+	tc := tmux.NewExecClient()
+
 	// A run with no panes should not be active
 	s := &run.State{ID: "run-1"}
-	if defaultIsRunActive(s) {
+	if defaultIsRunActive(s, tc) {
 		t.Error("expected run without panes to not be active")
 	}
 
 	// A run with a DashboardPane that doesn't exist should not be active
 	fakePaneID := "%999999"
 	s2 := &run.State{ID: "run-2", DashboardPane: &fakePaneID}
-	if defaultIsRunActive(s2) {
+	if defaultIsRunActive(s2, tc) {
 		t.Error("expected run with dead dashboard pane to not be active")
 	}
 }

--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -46,6 +47,8 @@ are synced back after completion. Use --local to force local execution, or
 		forceLocal, _ := cmd.Flags().GetBool("local")
 		hostOverride, _ := cmd.Flags().GetString("host")
 		resumeFrom, _ := cmd.Flags().GetString("resume-from")
+		ctx := cmd.Context()
+		tmuxClient := tmux.NewExecClient()
 
 		if !tmux.InSession() {
 			return fmt.Errorf("klaus launch must be run inside a tmux session")
@@ -54,7 +57,6 @@ are synced back after completion. Use --local to force local execution, or
 		// Host repo — optional when --repo is specified or session target is set
 		hostRoot, _ := git.RepoRoot()
 		gitClient := git.NewExecClient()
-		ctx := cmd.Context()
 
 		// Load session target (if any) to feed into resolution
 		var sessionTarget string
@@ -306,21 +308,21 @@ are synced back after completion. Use --local to force local execution, or
 
 		// Launch in tmux pane, targeting the pane that ran this command
 		currentPane := os.Getenv("TMUX_PANE")
-		paneID, err := tmux.SplitWindow(currentPane, worktree, paneCmd)
+		paneID, err := tmuxClient.SplitWindow(ctx, currentPane, worktree, paneCmd)
 		if err != nil {
 			return fmt.Errorf("creating tmux pane: %w", err)
 		}
 
-		if err := tmux.SetPaneTitle(paneID, FormatPaneTitle(id, issue, prompt)); err != nil {
+		if err := tmuxClient.SetPaneTitle(ctx, paneID, FormatPaneTitle(id, issue, prompt)); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to set pane title: %v\n", err)
 		}
-		if err := tmux.SetWindowOption(paneID, "automatic-rename", "off"); err != nil {
+		if err := tmuxClient.SetWindowOption(ctx, paneID, "automatic-rename", "off"); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to disable automatic rename: %v\n", err)
 		}
-		if err := tmux.LockPaneTitle(paneID); err != nil {
+		if err := tmuxClient.LockPaneTitle(ctx, paneID); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to lock pane title: %v\n", err)
 		}
-		if err := tmux.RebalanceLayout(currentPane); err != nil {
+		if err := tmuxClient.RebalanceLayout(ctx, currentPane); err != nil {
 			return fmt.Errorf("rebalancing tmux layout: %w", err)
 		}
 
@@ -328,7 +330,7 @@ are synced back after completion. Use --local to force local execution, or
 		// even-vertical which treats all panes equally, so the dashboard may
 		// end up in the middle. Load the session state to find the dashboard
 		// pane, then swap it to the last position if needed.
-		pinDashboardToBottom(currentPane, store)
+		pinDashboardToBottom(ctx, currentPane, store, tmuxClient)
 
 		// Write state
 		createdAt := time.Now().Format(time.RFC3339)
@@ -600,7 +602,7 @@ func buildSandboxPaneCommand(host, worktree, claudeCmd, logFile, selfBin, finali
 // pinDashboardToBottom ensures the dashboard pane is the last (bottom-most)
 // pane in the window. This is called after RebalanceLayout which may have
 // moved the dashboard out of position.
-func pinDashboardToBottom(currentPane string, store run.StateStore) {
+func pinDashboardToBottom(ctx context.Context, currentPane string, store run.StateStore, tc tmux.Client) {
 	// Load the session state directly via KLAUS_SESSION_ID
 	sessionID := os.Getenv("KLAUS_SESSION_ID")
 	if sessionID == "" {
@@ -612,7 +614,7 @@ func pinDashboardToBottom(currentPane string, store run.StateStore) {
 	}
 	dashPane := *s.DashboardPane
 
-	panes, err := tmux.ListWindowPanes(currentPane)
+	panes, err := tc.ListWindowPanes(ctx, currentPane)
 	if err != nil || len(panes) < 2 {
 		return
 	}
@@ -634,7 +636,7 @@ func pinDashboardToBottom(currentPane string, store run.StateStore) {
 		return
 	}
 
-	if err := tmux.SwapPane(dashPane, lastPane); err != nil {
+	if err := tc.SwapPane(ctx, dashPane, lastPane); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: could not pin dashboard to bottom: %v\n", err)
 	}
 }

--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -26,6 +27,8 @@ Modes:
 		id := args[0]
 		raw, _ := cmd.Flags().GetBool("raw")
 		replay, _ := cmd.Flags().GetBool("replay")
+		ctx := cmd.Context()
+		tmuxClient := tmux.NewExecClient()
 
 		state, _, err := loadStateFromEnvOrAll(id)
 		if err != nil {
@@ -38,7 +41,7 @@ Modes:
 		if replay {
 			return replayLog(state)
 		}
-		return showLive(state)
+		return showLive(ctx, state, tmuxClient)
 	},
 }
 
@@ -67,10 +70,10 @@ func replayLog(s *run.State) error {
 	return stream.FormatStream(f, os.Stdout)
 }
 
-func showLive(s *run.State) error {
+func showLive(ctx context.Context, s *run.State, tc tmux.Client) error {
 	// Try live tmux pane first
-	if s.TmuxPane != nil && tmux.PaneExists(*s.TmuxPane) {
-		output, err := tmux.CapturePane(*s.TmuxPane, 500)
+	if s.TmuxPane != nil && tc.PaneExists(ctx, *s.TmuxPane) {
+		output, err := tc.CapturePane(ctx, *s.TmuxPane, 500)
 		if err != nil {
 			return fmt.Errorf("capturing pane: %w", err)
 		}

--- a/internal/cmd/new.go
+++ b/internal/cmd/new.go
@@ -36,6 +36,8 @@ Must be run inside a tmux session.`,
 
 func runNew(cmd *cobra.Command, args []string) error {
 	name := args[0]
+	ctx := cmd.Context()
+	tmuxClient := tmux.NewExecClient()
 
 	if !ValidProjectName(name) {
 		return fmt.Errorf("invalid project name %q: must start with alphanumeric character and contain only alphanumeric characters, hyphens, underscores, or dots", name)
@@ -173,21 +175,21 @@ func runNew(cmd *cobra.Command, args []string) error {
 
 	// Launch in tmux pane
 	currentPane := os.Getenv("TMUX_PANE")
-	paneID, err := tmux.SplitWindow(currentPane, repoDir, paneCmd)
+	paneID, err := tmuxClient.SplitWindow(ctx, currentPane, repoDir, paneCmd)
 	if err != nil {
 		return fmt.Errorf("creating tmux pane: %w", err)
 	}
 
-	if err := tmux.SetPaneTitle(paneID, FormatPaneTitle(id, "", "new "+name)); err != nil {
+	if err := tmuxClient.SetPaneTitle(ctx, paneID, FormatPaneTitle(id, "", "new "+name)); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: failed to set pane title: %v\n", err)
 	}
-	if err := tmux.SetWindowOption(paneID, "automatic-rename", "off"); err != nil {
+	if err := tmuxClient.SetWindowOption(ctx, paneID, "automatic-rename", "off"); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: failed to disable automatic rename: %v\n", err)
 	}
-	if err := tmux.LockPaneTitle(paneID); err != nil {
+	if err := tmuxClient.LockPaneTitle(ctx, paneID); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: failed to lock pane title: %v\n", err)
 	}
-	if err := tmux.RebalanceLayout(currentPane); err != nil {
+	if err := tmuxClient.RebalanceLayout(ctx, currentPane); err != nil {
 		return fmt.Errorf("rebalancing tmux layout: %w", err)
 	}
 

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"crypto/rand"
 	"fmt"
 	"log/slog"
@@ -54,6 +55,9 @@ want to start clean instead of resuming the most recent session.`,
 }
 
 func runSession(cmd *cobra.Command, forceNew bool) error {
+	ctx := cmd.Context()
+	tmuxClient := tmux.NewExecClient()
+
 	if !tmux.InSession() {
 		return fmt.Errorf("klaus session must be run inside a tmux session")
 	}
@@ -65,7 +69,6 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 	root, _ := git.RepoRoot()
 	inRepo := root != ""
 	gitClient := git.NewExecClient()
-	ctx := cmd.Context()
 
 	cfg, err := config.Load(root)
 	if err != nil {
@@ -173,11 +176,11 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 
 		// Clear stale tmux pane references and persist immediately
 		modified := false
-		if state.TmuxPane != nil && !tmux.PaneExists(*state.TmuxPane) {
+		if state.TmuxPane != nil && !tmuxClient.PaneExists(ctx, *state.TmuxPane) {
 			state.TmuxPane = nil
 			modified = true
 		}
-		if state.DashboardPane != nil && !tmux.PaneExists(*state.DashboardPane) {
+		if state.DashboardPane != nil && !tmuxClient.PaneExists(ctx, *state.DashboardPane) {
 			state.DashboardPane = nil
 			modified = true
 		}
@@ -277,10 +280,10 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 		if windowTitle == "" {
 			windowTitle = "klaus"
 		}
-		tmux.SetWindowOption(currentPane, "automatic-rename", "off")
-		tmux.RenameWindow(currentPane, windowTitle)
-		tmux.SetWindowOption(currentPane, "pane-border-status", "top")
-		tmux.SetWindowOption(currentPane, "pane-border-format", "#{pane_title}")
+		tmuxClient.SetWindowOption(ctx, currentPane, "automatic-rename", "off")
+		tmuxClient.RenameWindow(ctx, currentPane, windowTitle)
+		tmuxClient.SetWindowOption(ctx, currentPane, "pane-border-status", "top")
+		tmuxClient.SetWindowOption(ctx, currentPane, "pane-border-format", "#{pane_title}")
 	}
 
 	fmt.Println()
@@ -292,11 +295,11 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 	// If a dashboard pane already exists from a prior run, reuse it.
 	var dashPane string
 	if currentPane != "" {
-		if state.DashboardPane != nil && tmux.PaneExists(*state.DashboardPane) {
+		if state.DashboardPane != nil && tmuxClient.PaneExists(ctx, *state.DashboardPane) {
 			dashPane = *state.DashboardPane
 		} else {
 			dashCmd := fmt.Sprintf("KLAUS_SESSION_ID=%s klaus dashboard", id)
-			paneID, err := tmux.SplitWindowSized(currentPane, worktree, dashCmd, "-v", "30%")
+			paneID, err := tmuxClient.SplitWindowSized(ctx, currentPane, worktree, dashCmd, "-v", "30%")
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "warning: could not open dashboard pane: %v\n", err)
 			} else {
@@ -343,10 +346,10 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 	fmt.Printf("Session %s ended.\n", id)
 
 	// Wait for any running agents to finish, then clean up their panes
-	waitForAgents(store)
+	waitForAgents(ctx, store, tmuxClient)
 
 	if dashPane != "" {
-		if err := tmux.KillPane(dashPane); err != nil {
+		if err := tmuxClient.KillPane(ctx, dashPane); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: could not kill dashboard pane %s: %v\n", dashPane, err)
 		}
 	}
@@ -362,7 +365,7 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 // finish before returning. Panes that have completed their work but
 // are still alive (e.g. stuck on a shell prompt) are killed so the
 // session can exit cleanly.
-func waitForAgents(store run.StateStore) {
+func waitForAgents(ctx context.Context, store run.StateStore, tc tmux.Client) {
 	states, err := store.List()
 	if err != nil {
 		return
@@ -378,7 +381,7 @@ func waitForAgents(store run.StateStore) {
 			fmt.Printf("  agent %s is stale (orphaned), skipping\n", s.ID)
 			continue
 		}
-		if s.TmuxPane != nil && tmux.PaneExists(*s.TmuxPane) {
+		if s.TmuxPane != nil && tc.PaneExists(ctx, *s.TmuxPane) {
 			active = append(active, s)
 		}
 	}
@@ -402,7 +405,7 @@ func waitForAgents(store run.StateStore) {
 
 			if !s.IsAgentRunning() {
 				fmt.Printf("  agent %s finished, closing pane\n", s.ID)
-				if err := tmux.KillPane(*s.TmuxPane); err != nil {
+				if err := tc.KillPane(ctx, *s.TmuxPane); err != nil {
 					slog.Warn("failed to kill agent pane", "id", s.ID, "pane", *s.TmuxPane, "err", err)
 				}
 				continue

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -37,6 +37,9 @@ var statusCmd = &cobra.Command{
 			"------", "------", "----", "-----", "----", "----", "--", "--", "---------", "-----", "------")
 
 		for _, s := range states {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			status := determineStatus(ctx, s, tmuxClient)
 			cost := formatCost(s)
 			issue := "-"

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -16,6 +16,9 @@ var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show all runs and their current state",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		tmuxClient := tmux.NewExecClient()
+
 		states, _, err := listStatesFromEnvOrAll()
 		if err != nil {
 			return err
@@ -33,9 +36,8 @@ var statusCmd = &cobra.Command{
 		fmt.Fprintf(os.Stdout, "%-22s  %-10s  %-8s  %-6s  %-20s  %-15s  %-6s  %-10s  %-10s  %-10s  %s\n",
 			"------", "------", "----", "-----", "----", "----", "--", "--", "---------", "-----", "------")
 
-		ctx := context.TODO()
 		for _, s := range states {
-			status := determineStatus(s)
+			status := determineStatus(ctx, s, tmuxClient)
 			cost := formatCost(s)
 			issue := "-"
 			if s.Issue != nil {
@@ -76,7 +78,7 @@ var statusCmd = &cobra.Command{
 	},
 }
 
-func determineStatus(s *run.State) string {
+func determineStatus(ctx context.Context, s *run.State, tc tmux.Client) string {
 	if s.Type == "session" {
 		if _, err := os.Stat(s.Worktree); err == nil {
 			return "active"
@@ -91,7 +93,7 @@ func determineStatus(s *run.State) string {
 		return "tracking"
 	}
 
-	if s.TmuxPane != nil && tmux.PaneExists(*s.TmuxPane) {
+	if s.TmuxPane != nil && tc.PaneExists(ctx, *s.TmuxPane) {
 		return "running"
 	}
 

--- a/internal/cmd/status_test.go
+++ b/internal/cmd/status_test.go
@@ -1,11 +1,13 @@
 package cmd
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
 	gh "github.com/patflynn/klaus/internal/github"
 	"github.com/patflynn/klaus/internal/run"
+	"github.com/patflynn/klaus/internal/tmux"
 )
 
 func TestComputeMergeStatus(t *testing.T) {
@@ -109,9 +111,11 @@ func TestDetermineStatus(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+	tc := tmux.NewExecClient()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := determineStatus(tt.s)
+			got := determineStatus(ctx, tt.s, tc)
 			if got != tt.want {
 				t.Errorf("determineStatus() = %q, want %q", got, tt.want)
 			}

--- a/internal/cmd/track_test.go
+++ b/internal/cmd/track_test.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"context"
 	"testing"
 
 	"github.com/patflynn/klaus/internal/run"
+	"github.com/patflynn/klaus/internal/tmux"
 )
 
 func TestParsePRRef(t *testing.T) {
@@ -236,9 +238,11 @@ func TestDetermineStatusTrack(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+	tc := tmux.NewExecClient()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := determineStatus(tt.s)
+			got := determineStatus(ctx, tt.s, tc)
 			if got != tt.want {
 				t.Errorf("determineStatus() = %q, want %q", got, tt.want)
 			}


### PR DESCRIPTION
## Summary
- Replace direct `tmux.SplitWindow()`, `tmux.PaneExists()`, `tmux.KillPane()`, etc. package-level calls in `cmd/` handlers with `tmux.Client` interface method calls
- Each cobra `RunE` handler creates `tmux.NewExecClient()` and threads it through helper functions (`pinDashboardToBottom`, `waitForAgents`, `cleanupOne`, `cleanupAll`, `showLive`, `determineStatus`)
- `tmux.InSession()` remains a package-level call as a bootstrapping check (same pattern as `git.RepoRoot()`)
- Add `tmux.Client` parameter to `CleanupDeps.DefaultCleanupDeps()` so `defaultIsRunActive` uses the client instead of calling `tmux.PaneExists` directly

## Files changed
- **launch.go** — tmuxClient in RunE; `pinDashboardToBottom` takes `tmux.Client`
- **cleanup.go** — `DefaultCleanupDeps(tc)`, `cleanupOne`/`cleanupAll` take `ctx` + `tmux.Client`
- **session.go** — tmuxClient in `runSession`; `waitForAgents` takes `tmux.Client`
- **new.go** — tmuxClient in `runNew`
- **status.go** — `determineStatus` takes `ctx` + `tmux.Client`
- **logs.go** — `showLive` takes `ctx` + `tmux.Client`
- **cleanup_test.go**, **status_test.go**, **track_test.go** — updated call sites

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing tests updated and green)
- [ ] Manual: `klaus launch`, `klaus status`, `klaus logs`, `klaus cleanup` still work in tmux

Closes #218