### PR TITLE
fix: add graceful shutdown coordination

### DIFF
--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -65,27 +65,34 @@ Keyboard shortcuts:
 			fmt.Fprintf(os.Stderr, "warning: loading config: %v\n", err)
 		}
 
+		// Shared context for coordinating graceful shutdown of all subsystems.
+		_, cancel := context.WithCancel(cmd.Context())
+		defer cancel()
+
 		ghClient := gh.NewGHCLIClient("")
 		model := newDashboardModel(store, cfg, ghClient)
+		model.shutdownCancel = cancel
+
+		var webhookSrv *webhook.Server
 		if cfg.Webhook != nil {
 			ch := make(chan webhook.Event, 64)
 			port := cfg.Webhook.Port
 			if port == 0 {
 				port = 9800
 			}
-			srv := webhook.NewServer(port, cfg.Webhook.Path, ch)
+			webhookSrv = webhook.NewServer(port, cfg.Webhook.Path, ch)
 
-			if err := srv.Listen(); err != nil {
+			if err := webhookSrv.Listen(); err != nil {
 				return fmt.Errorf("webhook server: %w", err)
 			}
 
 			model.webhookCh = ch
 			model.useWebhook = true
 			model.pollEnabled = cfg.Webhook.PollFallback
-			model.webhookAddr = srv.Addr()
+			model.webhookAddr = webhookSrv.Addr()
 
 			go func() {
-				if err := srv.Serve(); err != nil && err != http.ErrServerClosed {
+				if err := webhookSrv.Serve(); err != nil && err != http.ErrServerClosed {
 					fmt.Fprintf(os.Stderr, "webhook server error: %v\n", err)
 				}
 			}()
@@ -95,6 +102,19 @@ Keyboard shortcuts:
 
 		p := tea.NewProgram(model, tea.WithAltScreen())
 		_, err = p.Run()
+
+		// BubbleTea has exited — tear down all subsystems.
+		cancel()
+
+		// Gracefully shut down the webhook server so the port is released promptly.
+		if webhookSrv != nil {
+			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer shutdownCancel()
+			if err := webhookSrv.Shutdown(shutdownCtx); err != nil {
+				fmt.Fprintf(os.Stderr, "webhook server shutdown: %v\n", err)
+			}
+		}
+
 		return err
 	},
 }
@@ -171,6 +191,7 @@ type dashboardModel struct {
 	err            error
 	watcher        *fsnotify.Watcher
 	logFile        *os.File
+	shutdownCancel context.CancelFunc  // cancels the shared shutdown context
 	webhookCh      <-chan webhook.Event // non-nil when webhook mode is active
 	webhookAddr    string              // e.g. "127.0.0.1:9800"
 	useWebhook     bool                // true when webhook server is running
@@ -222,6 +243,10 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "q", "ctrl+c":
+			// Cancel the shared context to signal all subsystems to stop.
+			if m.shutdownCancel != nil {
+				m.shutdownCancel()
+			}
 			if m.watcher != nil {
 				m.watcher.Close()
 			}

--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -66,8 +66,7 @@ Keyboard shortcuts:
 		}
 
 		// Shared context for coordinating graceful shutdown of all subsystems.
-		_, cancel := context.WithCancel(cmd.Context())
-		defer cancel()
+		ctx, cancel := context.WithCancel(cmd.Context())
 
 		ghClient := gh.NewGHCLIClient("")
 		model := newDashboardModel(store, cfg, ghClient)
@@ -100,11 +99,19 @@ Keyboard shortcuts:
 			model.pollEnabled = true
 		}
 
-		p := tea.NewProgram(model, tea.WithAltScreen())
-		_, err = p.Run()
-
-		// BubbleTea has exited — tear down all subsystems.
+		p := tea.NewProgram(model, tea.WithAltScreen(), tea.WithContext(ctx))
+		finalModel, err := p.Run()
 		cancel()
+
+		// BubbleTea has exited — centralize cleanup of watcher and log file.
+		if m, ok := finalModel.(dashboardModel); ok {
+			if m.watcher != nil {
+				m.watcher.Close()
+			}
+			if m.logFile != nil {
+				m.logFile.Close()
+			}
+		}
 
 		// Gracefully shut down the webhook server so the port is released promptly.
 		if webhookSrv != nil {
@@ -246,12 +253,6 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Cancel the shared context to signal all subsystems to stop.
 			if m.shutdownCancel != nil {
 				m.shutdownCancel()
-			}
-			if m.watcher != nil {
-				m.watcher.Close()
-			}
-			if m.logFile != nil {
-				m.logFile.Close()
 			}
 			return m, tea.Quit
 		case "r":

--- a/internal/cmd/dashboard_test.go
+++ b/internal/cmd/dashboard_test.go
@@ -969,6 +969,29 @@ func TestWebhookPushTriggersFullRefetch(t *testing.T) {
 	}
 }
 
+func TestQuitCancelsShutdownContext(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := run.NewGitDirStore(tmpDir)
+	cfg := config.Config{}
+	ghClient := gh.NewGHCLIClient("")
+	model := newDashboardModel(store, cfg, ghClient)
+	model.tmuxDeps = testDashboardTmuxDeps()
+
+	cancelled := false
+	model.shutdownCancel = func() { cancelled = true }
+
+	// Simulate pressing 'q'.
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	_ = updated
+
+	if !cancelled {
+		t.Error("expected shutdownCancel to be called on quit")
+	}
+	if cmd == nil {
+		t.Error("expected tea.Quit command")
+	}
+}
+
 // Helper functions for tests.
 
 func float64Ptr(f float64) *float64 {

--- a/internal/webhook/server_test.go
+++ b/internal/webhook/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -378,6 +379,46 @@ func TestServerListenThenServe(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for event")
 	}
+}
+
+func TestServerGracefulShutdownReleasesPort(t *testing.T) {
+	ch := make(chan Event, 10)
+	srv := NewServer(0, "/webhook/github", ch)
+
+	if err := srv.Listen(); err != nil {
+		t.Fatalf("Listen failed: %v", err)
+	}
+	addr := srv.Addr()
+
+	go func() {
+		_ = srv.Serve()
+	}()
+
+	// Verify the server is accepting connections.
+	url := "http://" + addr + "/webhook/github"
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("server not reachable: %v", err)
+	}
+	resp.Body.Close()
+
+	// Shut down with a deadline.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		t.Fatalf("Shutdown failed: %v", err)
+	}
+
+	// The port should be released — we can bind a new server on the same address.
+	srv2 := NewServer(0, "/webhook/github", ch)
+	// Extract the port from the original address to reuse it.
+	_, port, _ := net.SplitHostPort(addr)
+	ln, err := net.Listen("tcp", "127.0.0.1:"+port)
+	if err != nil {
+		t.Fatalf("port not released after shutdown: %v", err)
+	}
+	ln.Close()
+	_ = srv2 // suppress unused warning
 }
 
 func TestEventIsInvalidationSignal(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add a shared cancellation context in the dashboard command that coordinates teardown of all subsystems (webhook server, file watcher, log file) on exit
- Gracefully shut down the webhook HTTP server with a 5-second timeout so the port is released promptly for immediate restart
- Cancel the shared context both when the user quits (q/ctrl+c) and when the BubbleTea program exits

## Test plan
- [x] `go test ./...` passes
- [x] New test verifies quit handler triggers the shutdown cancel function
- [x] New test verifies webhook server releases its port after graceful shutdown

Closes #204