### PR TITLE
Replace polling-based agent completion with event-driven detection

### DIFF
--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/patflynn/klaus/internal/config"
 	"github.com/patflynn/klaus/internal/git"
 	"github.com/patflynn/klaus/internal/nix"
@@ -20,8 +21,9 @@ import (
 )
 
 const (
-	klausSessionIDEnv = "KLAUS_SESSION_ID"
-	agentPollInterval = 3 * time.Second
+	klausSessionIDEnv  = "KLAUS_SESSION_ID"
+	agentWaitTimeout   = 30 * time.Minute
+	agentPollFallback  = 10 * time.Second
 )
 
 var sessionCmd = &cobra.Command{
@@ -361,10 +363,11 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 	return nil
 }
 
-// waitForAgents polls for active agent panes and waits for them to
-// finish before returning. Panes that have completed their work but
-// are still alive (e.g. stuck on a shell prompt) are killed so the
-// session can exit cleanly.
+// waitForAgents watches state files for changes and waits for active agent
+// panes to finish before returning. Uses fsnotify to react to state file
+// updates instead of polling, with a fallback poll for tmux pane exits that
+// don't trigger file changes. Times out after agentWaitTimeout to prevent
+// the session from hanging indefinitely.
 func waitForAgents(ctx context.Context, store run.StateStore, tc tmux.Client) {
 	states, err := store.List()
 	if err != nil {
@@ -372,7 +375,7 @@ func waitForAgents(ctx context.Context, store run.StateStore, tc tmux.Client) {
 	}
 
 	// Collect agent runs that still have live tmux panes, skipping stale ones.
-	var active []*run.State
+	active := make(map[string]*run.State)
 	for _, s := range states {
 		if s.Type == "session" {
 			continue
@@ -382,7 +385,7 @@ func waitForAgents(ctx context.Context, store run.StateStore, tc tmux.Client) {
 			continue
 		}
 		if s.TmuxPane != nil && tc.PaneExists(ctx, *s.TmuxPane) {
-			active = append(active, s)
+			active[s.ID] = s
 		}
 	}
 
@@ -392,28 +395,113 @@ func waitForAgents(ctx context.Context, store run.StateStore, tc tmux.Client) {
 
 	fmt.Printf("Waiting for %d agent(s) to finish...\n", len(active))
 
-	// Poll until all agent panes have exited or their work is done
+	// Set up fsnotify watcher on the state directory.
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		slog.Warn("failed to create file watcher, falling back to polling", "err", err)
+		waitForAgentsPoll(ctx, store, tc, active)
+		return
+	}
+	defer watcher.Close()
+
+	stateDir := store.StateDir()
+	if err := watcher.Add(stateDir); err != nil {
+		slog.Warn("failed to watch state dir, falling back to polling", "dir", stateDir, "err", err)
+		waitForAgentsPoll(ctx, store, tc, active)
+		return
+	}
+
+	timeout := time.After(agentWaitTimeout)
+	// Fallback ticker catches tmux pane exits that don't write state files.
+	fallbackTicker := time.NewTicker(agentPollFallback)
+	defer fallbackTicker.Stop()
+
 	for len(active) > 0 {
-		time.Sleep(agentPollInterval)
+		select {
+		case <-ctx.Done():
+			return
 
-		var stillActive []*run.State
-		for _, s := range active {
-			// Reload state to check for finalized cost/duration
-			if updated, err := store.Load(s.ID); err == nil {
-				s = updated
+		case <-timeout:
+			var names []string
+			for id := range active {
+				names = append(names, id)
 			}
+			fmt.Printf("Timed out after %s waiting for agents: %v\n", agentWaitTimeout, names)
+			fmt.Println("These agents may still be running in their tmux panes.")
+			return
 
-			if !s.IsAgentRunning() {
-				fmt.Printf("  agent %s finished, closing pane\n", s.ID)
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return
+			}
+			// Only react to state file writes.
+			if filepath.Ext(event.Name) != ".json" {
+				continue
+			}
+			reapFinishedAgents(ctx, store, tc, active)
+
+		case _, ok := <-watcher.Errors:
+			if !ok {
+				return
+			}
+			// Ignore transient watcher errors.
+
+		case <-fallbackTicker.C:
+			reapFinishedAgents(ctx, store, tc, active)
+		}
+	}
+
+	fmt.Println("All agents finished.")
+}
+
+// reapFinishedAgents checks each active agent and removes those that are
+// no longer running, killing their tmux panes.
+func reapFinishedAgents(ctx context.Context, store run.StateStore, tc tmux.Client, active map[string]*run.State) {
+	td := run.TmuxDeps{
+		PaneExists: func(id string) bool { return tc.PaneExists(ctx, id) },
+		PaneIsIdle: func(id string) bool { return tc.PaneIsIdle(ctx, id) },
+		PaneIsDead: func(id string) bool { return tc.PaneIsDead(ctx, id) },
+	}
+
+	for id, s := range active {
+		if updated, err := store.Load(id); err == nil {
+			s = updated
+		}
+
+		if !s.IsAgentRunningWith(td) {
+			fmt.Printf("  agent %s finished, closing pane\n", s.ID)
+			if s.TmuxPane != nil {
 				if err := tc.KillPane(ctx, *s.TmuxPane); err != nil {
 					slog.Warn("failed to kill agent pane", "id", s.ID, "pane", *s.TmuxPane, "err", err)
 				}
-				continue
 			}
-
-			stillActive = append(stillActive, s)
+			delete(active, id)
 		}
-		active = stillActive
+	}
+}
+
+// waitForAgentsPoll is the fallback polling loop used when fsnotify cannot
+// be set up.
+func waitForAgentsPoll(ctx context.Context, store run.StateStore, tc tmux.Client, active map[string]*run.State) {
+	timeout := time.After(agentWaitTimeout)
+	ticker := time.NewTicker(agentPollFallback)
+	defer ticker.Stop()
+
+	for len(active) > 0 {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timeout:
+			var names []string
+			for id := range active {
+				names = append(names, id)
+			}
+			fmt.Printf("Timed out after %s waiting for agents: %v\n", agentWaitTimeout, names)
+			fmt.Println("These agents may still be running in their tmux panes.")
+			return
+		case <-ticker.C:
+			reapFinishedAgents(ctx, store, tc, active)
+		}
 	}
 
 	fmt.Println("All agents finished.")

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -440,11 +440,11 @@ func waitForAgents(ctx context.Context, store run.StateStore, tc tmux.Client) {
 			}
 			reapFinishedAgents(ctx, store, tc, active)
 
-		case _, ok := <-watcher.Errors:
+		case err, ok := <-watcher.Errors:
 			if !ok {
 				return
 			}
-			// Ignore transient watcher errors.
+			slog.Debug("ignoring transient watcher error", "err", err)
 
 		case <-fallbackTicker.C:
 			reapFinishedAgents(ctx, store, tc, active)
@@ -469,11 +469,13 @@ func reapFinishedAgents(ctx context.Context, store run.StateStore, tc tmux.Clien
 		}
 
 		if !s.IsAgentRunningWith(td) {
-			fmt.Printf("  agent %s finished, closing pane\n", s.ID)
-			if s.TmuxPane != nil {
+			if s.TmuxPane != nil && tc.PaneExists(ctx, *s.TmuxPane) {
+				fmt.Printf("  agent %s finished, closing pane\n", s.ID)
 				if err := tc.KillPane(ctx, *s.TmuxPane); err != nil {
 					slog.Warn("failed to kill agent pane", "id", s.ID, "pane", *s.TmuxPane, "err", err)
 				}
+			} else {
+				fmt.Printf("  agent %s finished\n", s.ID)
 			}
 			delete(active, id)
 		}

--- a/internal/cmd/session_test.go
+++ b/internal/cmd/session_test.go
@@ -1,13 +1,16 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/patflynn/klaus/internal/run"
+	"github.com/patflynn/klaus/internal/tmux"
 )
 
 func TestDashboardPaneCommand(t *testing.T) {
@@ -212,6 +215,196 @@ func TestResumeClaudeArgs(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// stubTmuxClient is a minimal tmux.Client for testing waitForAgents.
+type stubTmuxClient struct {
+	tmux.ExecClient
+	existingPanes map[string]bool
+	killedPanes   []string
+}
+
+func (s *stubTmuxClient) PaneExists(_ context.Context, id string) bool {
+	return s.existingPanes[id]
+}
+
+func (s *stubTmuxClient) PaneIsDead(_ context.Context, _ string) bool {
+	return false
+}
+
+func (s *stubTmuxClient) PaneIsIdle(_ context.Context, _ string) bool {
+	return false
+}
+
+func (s *stubTmuxClient) KillPane(_ context.Context, id string) error {
+	s.killedPanes = append(s.killedPanes, id)
+	delete(s.existingPanes, id)
+	return nil
+}
+
+func TestWaitForAgents_ContextCancellation(t *testing.T) {
+	// Set up a store with an active agent.
+	tmpDir := t.TempDir()
+	store := run.NewHomeDirStoreFromPath(tmpDir)
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	pane := "%99"
+	state := &run.State{
+		ID:        "agent-test-cancel",
+		Type:      "agent",
+		TmuxPane:  &pane,
+		CreatedAt: time.Now().Format(time.RFC3339),
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+
+	tc := &stubTmuxClient{existingPanes: map[string]bool{"%99": true}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel immediately so waitForAgents returns quickly.
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		waitForAgents(ctx, store, tc)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Good -- returned promptly on context cancel.
+	case <-time.After(5 * time.Second):
+		t.Fatal("waitForAgents did not return after context cancellation")
+	}
+}
+
+func TestWaitForAgents_FsnotifyDetectsCompletion(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := run.NewHomeDirStoreFromPath(tmpDir)
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	pane := "%50"
+	state := &run.State{
+		ID:        "agent-fsnotify-test",
+		Type:      "agent",
+		TmuxPane:  &pane,
+		CreatedAt: time.Now().Format(time.RFC3339),
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+
+	tc := &stubTmuxClient{existingPanes: map[string]bool{"%50": true}}
+
+	ctx := context.Background()
+	done := make(chan struct{})
+	go func() {
+		waitForAgents(ctx, store, tc)
+		close(done)
+	}()
+
+	// Give fsnotify time to set up the watcher.
+	time.Sleep(100 * time.Millisecond)
+
+	// Simulate the agent finishing: remove the pane from the mock and
+	// write the state file to trigger fsnotify.
+	delete(tc.existingPanes, "%50")
+	state.CostUSD = new(float64)
+	*state.CostUSD = 0.05
+	if err := store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-done:
+		// Good -- detected completion via fsnotify.
+	case <-time.After(5 * time.Second):
+		t.Fatal("waitForAgents did not detect agent completion via fsnotify")
+	}
+}
+
+func TestWaitForAgents_NoActiveAgents(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := run.NewHomeDirStoreFromPath(tmpDir)
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Save a session (should be skipped) and no agents with live panes.
+	state := &run.State{
+		ID:        "session-skip",
+		Type:      "session",
+		CreatedAt: time.Now().Format(time.RFC3339),
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+
+	tc := &stubTmuxClient{existingPanes: map[string]bool{}}
+
+	done := make(chan struct{})
+	go func() {
+		waitForAgents(context.Background(), store, tc)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Returns immediately when no active agents.
+	case <-time.After(2 * time.Second):
+		t.Fatal("waitForAgents should return immediately with no active agents")
+	}
+}
+
+func TestReapFinishedAgents(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := run.NewHomeDirStoreFromPath(tmpDir)
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	pane1 := "%10"
+	pane2 := "%11"
+	// Agent 1: pane still exists (still running).
+	s1 := &run.State{
+		ID:        "agent-running",
+		Type:      "agent",
+		TmuxPane:  &pane1,
+		CreatedAt: time.Now().Format(time.RFC3339),
+	}
+	// Agent 2: pane gone (finished).
+	s2 := &run.State{
+		ID:        "agent-done",
+		Type:      "agent",
+		TmuxPane:  &pane2,
+		CreatedAt: time.Now().Format(time.RFC3339),
+	}
+	if err := store.Save(s1); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Save(s2); err != nil {
+		t.Fatal(err)
+	}
+
+	tc := &stubTmuxClient{existingPanes: map[string]bool{"%10": true}}
+	active := map[string]*run.State{
+		s1.ID: s1,
+		s2.ID: s2,
+	}
+
+	reapFinishedAgents(context.Background(), store, tc, active)
+
+	if _, ok := active["agent-done"]; ok {
+		t.Error("agent-done should have been reaped")
+	}
+	if _, ok := active["agent-running"]; !ok {
+		t.Error("agent-running should still be active")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replace 3-second polling loop in `waitForAgents()` with fsnotify-based file watching on the state directory
- Add 30-minute timeout to prevent indefinite hangs when agent state gets stuck
- Add fallback 10-second ticker to catch tmux pane exits that don't trigger state file writes
- Use `IsAgentRunningWith()` with TmuxDeps built from the passed tmux.Client for consistent behavior and testability

## Test plan
- [x] `TestWaitForAgents_ContextCancellation` -- verifies prompt return on context cancel
- [x] `TestWaitForAgents_FsnotifyDetectsCompletion` -- verifies real fsnotify detects state file writes
- [x] `TestWaitForAgents_NoActiveAgents` -- verifies immediate return with no active agents
- [x] `TestReapFinishedAgents` -- verifies correct reaping of finished vs still-running agents
- [x] `go test ./...` passes

Closes #206