### PR TITLE
feat: add timeouts to all subprocess execution

### DIFF
--- a/internal/git/exec_client.go
+++ b/internal/git/exec_client.go
@@ -10,56 +10,56 @@ func NewExecClient() *ExecClient {
 	return &ExecClient{}
 }
 
-func (c *ExecClient) CommonDir(_ context.Context) (string, error) {
-	return CommonDir()
+func (c *ExecClient) CommonDir(ctx context.Context) (string, error) {
+	return CommonDir(ctx)
 }
 
-func (c *ExecClient) FetchAll(_ context.Context, repoDir string) error {
-	return FetchAll(repoDir)
+func (c *ExecClient) FetchAll(ctx context.Context, repoDir string) error {
+	return FetchAll(ctx, repoDir)
 }
 
-func (c *ExecClient) FetchBranch(_ context.Context, repoDir, branch string) error {
-	return FetchBranch(repoDir, branch)
+func (c *ExecClient) FetchBranch(ctx context.Context, repoDir, branch string) error {
+	return FetchBranch(ctx, repoDir, branch)
 }
 
-func (c *ExecClient) WorktreeAdd(_ context.Context, repoDir, path, branch, startPoint string) error {
-	return WorktreeAdd(repoDir, path, branch, startPoint)
+func (c *ExecClient) WorktreeAdd(ctx context.Context, repoDir, path, branch, startPoint string) error {
+	return WorktreeAdd(ctx, repoDir, path, branch, startPoint)
 }
 
-func (c *ExecClient) WorktreeRemove(_ context.Context, repoDir, path string) error {
-	return WorktreeRemove(repoDir, path)
+func (c *ExecClient) WorktreeRemove(ctx context.Context, repoDir, path string) error {
+	return WorktreeRemove(ctx, repoDir, path)
 }
 
-func (c *ExecClient) WorktreeAddTrack(_ context.Context, repoDir, path, branch string) error {
-	return WorktreeAddTrack(repoDir, path, branch)
+func (c *ExecClient) WorktreeAddTrack(ctx context.Context, repoDir, path, branch string) error {
+	return WorktreeAddTrack(ctx, repoDir, path, branch)
 }
 
-func (c *ExecClient) WorktreePrune(_ context.Context, repoDir string) error {
-	return WorktreePrune(repoDir)
+func (c *ExecClient) WorktreePrune(ctx context.Context, repoDir string) error {
+	return WorktreePrune(ctx, repoDir)
 }
 
-func (c *ExecClient) BranchDelete(_ context.Context, repoDir, branch string) error {
-	return BranchDelete(repoDir, branch)
+func (c *ExecClient) BranchDelete(ctx context.Context, repoDir, branch string) error {
+	return BranchDelete(ctx, repoDir, branch)
 }
 
-func (c *ExecClient) EnsureDataRef(_ context.Context, repoDir, dataRef string) error {
-	return EnsureDataRef(repoDir, dataRef)
+func (c *ExecClient) EnsureDataRef(ctx context.Context, repoDir, dataRef string) error {
+	return EnsureDataRef(ctx, repoDir, dataRef)
 }
 
-func (c *ExecClient) SyncToDataRef(_ context.Context, repoDir, dataRef, commitMsg string, files map[string]string) error {
-	return SyncToDataRef(repoDir, dataRef, commitMsg, files)
+func (c *ExecClient) SyncToDataRef(ctx context.Context, repoDir, dataRef, commitMsg string, files map[string]string) error {
+	return SyncToDataRef(ctx, repoDir, dataRef, commitMsg, files)
 }
 
-func (c *ExecClient) EnsureClone(_ context.Context, cloneURL, destDir string) error {
-	return EnsureClone(cloneURL, destDir)
+func (c *ExecClient) EnsureClone(ctx context.Context, cloneURL, destDir string) error {
+	return EnsureClone(ctx, cloneURL, destDir)
 }
 
-func (c *ExecClient) PushDataRef(_ context.Context, repoDir, dataRef string) error {
-	return PushDataRef(repoDir, dataRef)
+func (c *ExecClient) PushDataRef(ctx context.Context, repoDir, dataRef string) error {
+	return PushDataRef(ctx, repoDir, dataRef)
 }
 
-func (c *ExecClient) InstallCommitMsgHook(_ context.Context, worktreeDir string) error {
-	return InstallCommitMsgHook(worktreeDir)
+func (c *ExecClient) InstallCommitMsgHook(ctx context.Context, worktreeDir string) error {
+	return InstallCommitMsgHook(ctx, worktreeDir)
 }
 
 // compile-time check

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -2,23 +2,33 @@ package git
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
+)
+
+// Timeout constants for git operations.
+const (
+	// networkTimeout is for git commands that talk to a remote (fetch, push, clone).
+	networkTimeout = 2 * time.Minute
+	// localTimeout is for git commands that operate on local data (worktree, branch, rev-parse).
+	localTimeout = 30 * time.Second
 )
 
 // RepoRoot returns the top-level directory of the git repository.
 func RepoRoot() (string, error) {
-	return runGit("", "rev-parse", "--show-toplevel")
+	return runGit(context.Background(), "", "rev-parse", "--show-toplevel")
 }
 
 // CommonDir returns the absolute path to the git common directory.
 // This works from worktrees too (returns the main repo's .git dir).
-func CommonDir() (string, error) {
-	d, err := runGit("", "rev-parse", "--git-common-dir")
+func CommonDir(ctx context.Context) (string, error) {
+	d, err := runGit(ctx, "", "rev-parse", "--git-common-dir")
 	if err != nil {
 		return "", err
 	}
@@ -31,62 +41,62 @@ func CommonDir() (string, error) {
 }
 
 // FetchAll fetches all branches and tags from origin, pruning deleted remote branches.
-func FetchAll(repoDir string) error {
-	_, err := runGit(repoDir, "fetch", "origin", "--prune", "--tags", "--quiet")
+func FetchAll(ctx context.Context, repoDir string) error {
+	_, err := runGitNetwork(ctx, repoDir, "fetch", "origin", "--prune", "--tags", "--quiet")
 	return err
 }
 
 // FetchBranch fetches a branch from origin.
-func FetchBranch(repoDir, branch string) error {
-	_, err := runGit(repoDir, "fetch", "origin", branch, "--quiet")
+func FetchBranch(ctx context.Context, repoDir, branch string) error {
+	_, err := runGitNetwork(ctx, repoDir, "fetch", "origin", branch, "--quiet")
 	return err
 }
 
 // WorktreeAdd creates a new worktree at path on a new branch based on startPoint.
 // If the branch is already checked out in a stale worktree, it prunes and retries once.
-func WorktreeAdd(repoDir, path, branch, startPoint string) error {
-	_, err := runGit(repoDir, "worktree", "add", path, "-b", branch, startPoint, "--quiet")
+func WorktreeAdd(ctx context.Context, repoDir, path, branch, startPoint string) error {
+	_, err := runGit(ctx, repoDir, "worktree", "add", path, "-b", branch, startPoint, "--quiet")
 	if err == nil {
 		return nil
 	}
-	return retryAfterPrune(repoDir, branch, err, func() error {
+	return retryAfterPrune(ctx, repoDir, branch, err, func() error {
 		// Use -B on retry: after pruning a stale worktree the branch ref remains,
 		// so -b (create new) would fail with "branch already exists".
-		_, e := runGit(repoDir, "worktree", "add", path, "-B", branch, startPoint, "--quiet")
+		_, e := runGit(ctx, repoDir, "worktree", "add", path, "-B", branch, startPoint, "--quiet")
 		return e
 	})
 }
 
 // WorktreeRemove removes a worktree. repoDir is the main repo directory.
-func WorktreeRemove(repoDir, path string) error {
-	_, err := runGit(repoDir, "worktree", "remove", "--force", path)
+func WorktreeRemove(ctx context.Context, repoDir, path string) error {
+	_, err := runGit(ctx, repoDir, "worktree", "remove", "--force", path)
 	return err
 }
 
 // WorktreeAddTrack creates a worktree tracking an existing remote branch.
 // It uses -B to force-create/reset the local branch to match origin/<branch>.
 // If the branch is already checked out in a stale worktree, it prunes and retries once.
-func WorktreeAddTrack(repoDir, path, branch string) error {
-	_, err := runGit(repoDir, "worktree", "add", "-B", branch, path, "origin/"+branch, "--quiet")
+func WorktreeAddTrack(ctx context.Context, repoDir, path, branch string) error {
+	_, err := runGit(ctx, repoDir, "worktree", "add", "-B", branch, path, "origin/"+branch, "--quiet")
 	if err == nil {
 		return nil
 	}
-	return retryAfterPrune(repoDir, branch, err, func() error {
-		_, e := runGit(repoDir, "worktree", "add", "-B", branch, path, "origin/"+branch, "--quiet")
+	return retryAfterPrune(ctx, repoDir, branch, err, func() error {
+		_, e := runGit(ctx, repoDir, "worktree", "add", "-B", branch, path, "origin/"+branch, "--quiet")
 		return e
 	})
 }
 
 // WorktreePrune removes stale worktree tracking information.
-func WorktreePrune(repoDir string) error {
-	_, err := runGit(repoDir, "worktree", "prune")
+func WorktreePrune(ctx context.Context, repoDir string) error {
+	_, err := runGit(ctx, repoDir, "worktree", "prune")
 	return err
 }
 
 // worktreePathForBranch returns the worktree path that has the given branch
 // checked out, or "" if not found.
-func worktreePathForBranch(repoDir, branch string) string {
-	out, err := runGit(repoDir, "worktree", "list", "--porcelain")
+func worktreePathForBranch(ctx context.Context, repoDir, branch string) string {
+	out, err := runGit(ctx, repoDir, "worktree", "list", "--porcelain")
 	if err != nil {
 		return ""
 	}
@@ -110,9 +120,9 @@ func worktreePathForBranch(repoDir, branch string) string {
 // retryAfterPrune handles "already used by worktree" errors. If the conflicting
 // worktree is stale (path no longer exists on disk), it prunes and retries.
 // If the worktree is still live, it returns a clear error.
-func retryAfterPrune(repoDir, branch string, origErr error, retry func() error) error {
+func retryAfterPrune(ctx context.Context, repoDir, branch string, origErr error, retry func() error) error {
 	// Check whether this branch is recorded in any worktree.
-	wtPath := worktreePathForBranch(repoDir, branch)
+	wtPath := worktreePathForBranch(ctx, repoDir, branch)
 	if wtPath == "" {
 		// Branch is not in any worktree — nothing to prune; return the original error.
 		return origErr
@@ -124,52 +134,52 @@ func retryAfterPrune(repoDir, branch string, origErr error, retry func() error) 
 	}
 
 	// Worktree directory is gone — prune stale entries and retry.
-	if err := WorktreePrune(repoDir); err != nil {
+	if err := WorktreePrune(ctx, repoDir); err != nil {
 		return fmt.Errorf("pruning stale worktrees: %w (original error: %v)", err, origErr)
 	}
 	return retry()
 }
 
 // BranchDelete deletes a local branch.
-func BranchDelete(repoDir, branch string) error {
-	_, err := runGit(repoDir, "branch", "-D", branch)
+func BranchDelete(ctx context.Context, repoDir, branch string) error {
+	_, err := runGit(ctx, repoDir, "branch", "-D", branch)
 	return err
 }
 
 // EnsureDataRef ensures the custom data ref exists. Creates it with an empty
 // initial commit if it doesn't. Uses git plumbing so nothing in the working
 // tree is touched.
-func EnsureDataRef(repoDir, dataRef string) error {
-	_, err := runGit(repoDir, "rev-parse", "--verify", dataRef)
+func EnsureDataRef(ctx context.Context, repoDir, dataRef string) error {
+	_, err := runGit(ctx, repoDir, "rev-parse", "--verify", dataRef)
 	if err == nil {
 		return nil // already exists
 	}
 
 	// Create empty tree
-	emptyTree, err := runGit(repoDir, "hash-object", "-t", "tree", "/dev/null")
+	emptyTree, err := runGit(ctx, repoDir, "hash-object", "-t", "tree", "/dev/null")
 	if err != nil {
 		return fmt.Errorf("creating empty tree: %w", err)
 	}
 
 	// Create initial commit
-	initCommit, err := runGitStdin(repoDir, "Initialize klaus run data", "commit-tree", emptyTree)
+	initCommit, err := runGitStdin(ctx, repoDir, "Initialize klaus run data", "commit-tree", emptyTree)
 	if err != nil {
 		return fmt.Errorf("creating initial commit: %w", err)
 	}
 
 	// Update ref
-	_, err = runGit(repoDir, "update-ref", dataRef, initCommit)
+	_, err = runGit(ctx, repoDir, "update-ref", dataRef, initCommit)
 	return err
 }
 
 // SyncToDataRef commits files to the data ref using a temporary index.
 // files is a map of path-in-tree -> local-file-path.
-func SyncToDataRef(repoDir, dataRef, commitMsg string, files map[string]string) error {
-	if err := EnsureDataRef(repoDir, dataRef); err != nil {
+func SyncToDataRef(ctx context.Context, repoDir, dataRef, commitMsg string, files map[string]string) error {
+	if err := EnsureDataRef(ctx, repoDir, dataRef); err != nil {
 		return err
 	}
 
-	parentCommit, err := runGit(repoDir, "rev-parse", dataRef)
+	parentCommit, err := runGit(ctx, repoDir, "rev-parse", dataRef)
 	if err != nil {
 		return fmt.Errorf("resolving data ref: %w", err)
 	}
@@ -183,36 +193,36 @@ func SyncToDataRef(repoDir, dataRef, commitMsg string, files map[string]string) 
 	defer os.Remove(tmpIndexPath)
 
 	// Read current tree into temp index
-	if err := runGitEnv(repoDir, map[string]string{"GIT_INDEX_FILE": tmpIndexPath}, "read-tree", dataRef); err != nil {
+	if err := runGitEnv(ctx, repoDir, map[string]string{"GIT_INDEX_FILE": tmpIndexPath}, "read-tree", dataRef); err != nil {
 		return fmt.Errorf("reading tree: %w", err)
 	}
 
 	// Add each file
 	for treePath, localPath := range files {
-		blob, err := runGit(repoDir, "hash-object", "-w", localPath)
+		blob, err := runGit(ctx, repoDir, "hash-object", "-w", localPath)
 		if err != nil {
 			return fmt.Errorf("hashing %s: %w", localPath, err)
 		}
 		cacheInfo := fmt.Sprintf("100644,%s,%s", blob, treePath)
-		if err := runGitEnv(repoDir, map[string]string{"GIT_INDEX_FILE": tmpIndexPath}, "update-index", "--add", "--cacheinfo", cacheInfo); err != nil {
+		if err := runGitEnv(ctx, repoDir, map[string]string{"GIT_INDEX_FILE": tmpIndexPath}, "update-index", "--add", "--cacheinfo", cacheInfo); err != nil {
 			return fmt.Errorf("updating index for %s: %w", treePath, err)
 		}
 	}
 
 	// Write tree
-	newTree, err := runGitOutput(repoDir, map[string]string{"GIT_INDEX_FILE": tmpIndexPath}, "write-tree")
+	newTree, err := runGitOutput(ctx, repoDir, map[string]string{"GIT_INDEX_FILE": tmpIndexPath}, "write-tree")
 	if err != nil {
 		return fmt.Errorf("writing tree: %w", err)
 	}
 
 	// Create commit
-	newCommit, err := runGitStdin(repoDir, commitMsg, "commit-tree", newTree, "-p", parentCommit)
+	newCommit, err := runGitStdin(ctx, repoDir, commitMsg, "commit-tree", newTree, "-p", parentCommit)
 	if err != nil {
 		return fmt.Errorf("creating commit: %w", err)
 	}
 
 	// Update ref
-	_, err = runGit(repoDir, "update-ref", dataRef, newCommit)
+	_, err = runGit(ctx, repoDir, "update-ref", dataRef, newCommit)
 	return err
 }
 
@@ -298,23 +308,23 @@ func ParseRepoRef(ref string) (owner, repo, cloneURL string, err error) {
 
 // EnsureClone clones a repo to destDir if it doesn't already exist.
 // If it already exists, fetches the latest from origin.
-func EnsureClone(cloneURL, destDir string) error {
+func EnsureClone(ctx context.Context, cloneURL, destDir string) error {
 	if _, err := os.Stat(filepath.Join(destDir, ".git")); err == nil {
-		_, fetchErr := runGit(destDir, "fetch", "origin", "--prune", "--tags", "--quiet")
+		_, fetchErr := runGitNetwork(ctx, destDir, "fetch", "origin", "--prune", "--tags", "--quiet")
 		return fetchErr
 	}
 
 	if err := os.MkdirAll(filepath.Dir(destDir), 0o755); err != nil {
 		return fmt.Errorf("creating parent dir: %w", err)
 	}
-	_, err := runGit("", "clone", cloneURL, destDir, "--quiet")
+	_, err := runGitNetwork(ctx, "", "clone", cloneURL, destDir, "--quiet")
 	return err
 }
 
 // PushDataRef pushes the data ref to origin.
-func PushDataRef(repoDir, dataRef string) error {
+func PushDataRef(ctx context.Context, repoDir, dataRef string) error {
 	refspec := fmt.Sprintf("%s:%s", dataRef, dataRef)
-	_, err := runGit(repoDir, "push", "origin", refspec, "--quiet")
+	_, err := runGitNetwork(ctx, repoDir, "push", "origin", refspec, "--quiet")
 	return err
 }
 
@@ -335,9 +345,9 @@ rm -f "$1.bak"
 
 // InstallCommitMsgHook installs a commit-msg hook in the given worktree that
 // strips Claude/Anthropic attribution from commit messages.
-func InstallCommitMsgHook(worktreeDir string) error {
+func InstallCommitMsgHook(ctx context.Context, worktreeDir string) error {
 	// Find the git dir for this worktree
-	gitDir, err := runGit(worktreeDir, "rev-parse", "--git-dir")
+	gitDir, err := runGit(ctx, worktreeDir, "rev-parse", "--git-dir")
 	if err != nil {
 		return fmt.Errorf("finding git dir: %w", err)
 	}
@@ -357,16 +367,28 @@ func InstallCommitMsgHook(worktreeDir string) error {
 
 	// Worktrees use the main repo's hooks by default. Point this worktree
 	// at its own hooks directory so our commit-msg hook actually runs.
-	if _, err := runGit(worktreeDir, "config", "core.hooksPath", hooksDir); err != nil {
+	if _, err := runGit(ctx, worktreeDir, "config", "core.hooksPath", hooksDir); err != nil {
 		return fmt.Errorf("setting core.hooksPath: %w", err)
 	}
 
 	return nil
 }
 
-// runGit executes a git command and returns trimmed stdout.
-func runGit(dir string, args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
+// ensureTimeout returns a context with the given default timeout applied if
+// the parent context has no deadline set.
+func ensureTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, timeout)
+}
+
+// runGit executes a local git command and returns trimmed stdout.
+func runGit(ctx context.Context, dir string, args ...string) (string, error) {
+	ctx, cancel := ensureTimeout(ctx, localTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", args...)
 	if dir != "" {
 		cmd.Dir = dir
 	}
@@ -374,14 +396,41 @@ func runGit(dir string, args ...string) (string, error) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("git %s timed out after %s", args[0], localTimeout)
+		}
+		return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, stderr.String())
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+// runGitNetwork executes a git command that talks to a remote and returns trimmed stdout.
+func runGitNetwork(ctx context.Context, dir string, args ...string) (string, error) {
+	ctx, cancel := ensureTimeout(ctx, networkTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("git %s timed out after %s", args[0], networkTimeout)
+		}
 		return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, stderr.String())
 	}
 	return strings.TrimSpace(stdout.String()), nil
 }
 
 // runGitStdin executes a git command with stdin and returns trimmed stdout.
-func runGitStdin(dir, stdin string, args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
+func runGitStdin(ctx context.Context, dir, stdin string, args ...string) (string, error) {
+	ctx, cancel := ensureTimeout(ctx, localTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", args...)
 	if dir != "" {
 		cmd.Dir = dir
 	}
@@ -390,14 +439,20 @@ func runGitStdin(dir, stdin string, args ...string) (string, error) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("git %s timed out after %s", args[0], localTimeout)
+		}
 		return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, stderr.String())
 	}
 	return strings.TrimSpace(stdout.String()), nil
 }
 
 // runGitEnv executes a git command with extra env vars (no stdout capture needed for some).
-func runGitEnv(dir string, env map[string]string, args ...string) error {
-	cmd := exec.Command("git", args...)
+func runGitEnv(ctx context.Context, dir string, env map[string]string, args ...string) error {
+	ctx, cancel := ensureTimeout(ctx, localTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", args...)
 	if dir != "" {
 		cmd.Dir = dir
 	}
@@ -408,14 +463,20 @@ func runGitEnv(dir string, env map[string]string, args ...string) error {
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("git %s timed out after %s", args[0], localTimeout)
+		}
 		return fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, stderr.String())
 	}
 	return nil
 }
 
 // runGitOutput executes a git command with extra env vars and returns stdout.
-func runGitOutput(dir string, env map[string]string, args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
+func runGitOutput(ctx context.Context, dir string, env map[string]string, args ...string) (string, error) {
+	ctx, cancel := ensureTimeout(ctx, localTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", args...)
 	if dir != "" {
 		cmd.Dir = dir
 	}
@@ -427,6 +488,9 @@ func runGitOutput(dir string, env map[string]string, args ...string) (string, er
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("git %s timed out after %s", args[0], localTimeout)
+		}
 		return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, stderr.String())
 	}
 	return strings.TrimSpace(stdout.String()), nil

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -44,10 +45,11 @@ func initTestRepo(t *testing.T) string {
 }
 
 func TestWorktreeAddRemove(t *testing.T) {
+	ctx := context.Background()
 	repo := initTestRepo(t)
 	wtPath := filepath.Join(t.TempDir(), "worktree1")
 
-	if err := WorktreeAdd(repo, wtPath, "test-branch", "main"); err != nil {
+	if err := WorktreeAdd(ctx, repo, wtPath, "test-branch", "main"); err != nil {
 		t.Fatalf("WorktreeAdd: %v", err)
 	}
 
@@ -56,7 +58,7 @@ func TestWorktreeAddRemove(t *testing.T) {
 		t.Errorf("worktree should contain README.md: %v", err)
 	}
 
-	if err := WorktreeRemove(repo, wtPath); err != nil {
+	if err := WorktreeRemove(ctx, repo, wtPath); err != nil {
 		t.Fatalf("WorktreeRemove: %v", err)
 	}
 
@@ -67,13 +69,14 @@ func TestWorktreeAddRemove(t *testing.T) {
 }
 
 func TestCommonDirFromWorktree(t *testing.T) {
+	ctx := context.Background()
 	repo := initTestRepo(t)
 	wtPath := filepath.Join(t.TempDir(), "wt")
 
-	if err := WorktreeAdd(repo, wtPath, "test-branch", "main"); err != nil {
+	if err := WorktreeAdd(ctx, repo, wtPath, "test-branch", "main"); err != nil {
 		t.Fatalf("WorktreeAdd: %v", err)
 	}
-	defer WorktreeRemove(repo, wtPath)
+	defer WorktreeRemove(ctx, repo, wtPath)
 
 	// Save original dir and chdir to worktree
 	origDir, err := os.Getwd()
@@ -93,7 +96,7 @@ func TestCommonDirFromWorktree(t *testing.T) {
 	}
 
 	// CommonDir from a worktree returns the main repo's .git dir
-	common, err := CommonDir()
+	common, err := CommonDir(ctx)
 	if err != nil {
 		t.Fatalf("CommonDir: %v", err)
 	}
@@ -103,7 +106,7 @@ func TestCommonDirFromWorktree(t *testing.T) {
 	}
 
 	// The main repo root survives worktree removal.
-	if err := WorktreeRemove(repo, wtPath); err != nil {
+	if err := WorktreeRemove(ctx, repo, wtPath); err != nil {
 		t.Fatalf("WorktreeRemove: %v", err)
 	}
 	if _, err := os.Stat(mainRoot); err != nil {
@@ -115,16 +118,17 @@ func TestCommonDirFromWorktree(t *testing.T) {
 }
 
 func TestEnsureDataRef(t *testing.T) {
+	ctx := context.Background()
 	repo := initTestRepo(t)
 	ref := "refs/klaus/data"
 
 	// First call creates the ref
-	if err := EnsureDataRef(repo, ref); err != nil {
+	if err := EnsureDataRef(ctx, repo, ref); err != nil {
 		t.Fatalf("EnsureDataRef (create): %v", err)
 	}
 
 	// Verify ref exists
-	out, err := runGit(repo, "rev-parse", "--verify", ref)
+	out, err := runGit(ctx, repo, "rev-parse", "--verify", ref)
 	if err != nil {
 		t.Fatalf("ref should exist: %v", err)
 	}
@@ -133,12 +137,13 @@ func TestEnsureDataRef(t *testing.T) {
 	}
 
 	// Second call is idempotent
-	if err := EnsureDataRef(repo, ref); err != nil {
+	if err := EnsureDataRef(ctx, repo, ref); err != nil {
 		t.Fatalf("EnsureDataRef (idempotent): %v", err)
 	}
 }
 
 func TestSyncToDataRef(t *testing.T) {
+	ctx := context.Background()
 	repo := initTestRepo(t)
 	ref := "refs/klaus/data"
 
@@ -152,12 +157,12 @@ func TestSyncToDataRef(t *testing.T) {
 		"runs/test-123.json": tmpFile,
 	}
 
-	if err := SyncToDataRef(repo, ref, "Run test-123", files); err != nil {
+	if err := SyncToDataRef(ctx, repo, ref, "Run test-123", files); err != nil {
 		t.Fatalf("SyncToDataRef: %v", err)
 	}
 
 	// Verify the file is in the data ref tree
-	out, err := runGit(repo, "ls-tree", "-r", "--name-only", ref)
+	out, err := runGit(ctx, repo, "ls-tree", "-r", "--name-only", ref)
 	if err != nil {
 		t.Fatalf("ls-tree: %v", err)
 	}
@@ -166,7 +171,7 @@ func TestSyncToDataRef(t *testing.T) {
 	}
 
 	// Verify content
-	content, err := runGit(repo, "show", ref+":runs/test-123.json")
+	content, err := runGit(ctx, repo, "show", ref+":runs/test-123.json")
 	if err != nil {
 		t.Fatalf("show: %v", err)
 	}
@@ -176,6 +181,7 @@ func TestSyncToDataRef(t *testing.T) {
 }
 
 func TestSyncToDataRefMultipleFiles(t *testing.T) {
+	ctx := context.Background()
 	repo := initTestRepo(t)
 	ref := "refs/klaus/data"
 
@@ -186,15 +192,15 @@ func TestSyncToDataRefMultipleFiles(t *testing.T) {
 	os.WriteFile(f2, []byte("log"), 0o644)
 
 	files := map[string]string{
-		"runs/a.json": f1,
+		"runs/a.json":  f1,
 		"logs/a.jsonl": f2,
 	}
 
-	if err := SyncToDataRef(repo, ref, "Run a", files); err != nil {
+	if err := SyncToDataRef(ctx, repo, ref, "Run a", files); err != nil {
 		t.Fatalf("SyncToDataRef: %v", err)
 	}
 
-	out, err := runGit(repo, "ls-tree", "-r", "--name-only", ref)
+	out, err := runGit(ctx, repo, "ls-tree", "-r", "--name-only", ref)
 	if err != nil {
 		t.Fatalf("ls-tree: %v", err)
 	}
@@ -368,15 +374,16 @@ func TestParseRepoRefSSH(t *testing.T) {
 }
 
 func TestInstallCommitMsgHook_StripsClaudeAttribution(t *testing.T) {
+	ctx := context.Background()
 	repo := initTestRepo(t)
 	wtPath := filepath.Join(t.TempDir(), "wt-hook")
 
-	if err := WorktreeAdd(repo, wtPath, "hook-test", "main"); err != nil {
+	if err := WorktreeAdd(ctx, repo, wtPath, "hook-test", "main"); err != nil {
 		t.Fatalf("WorktreeAdd: %v", err)
 	}
-	defer WorktreeRemove(repo, wtPath)
+	defer WorktreeRemove(ctx, repo, wtPath)
 
-	if err := InstallCommitMsgHook(wtPath); err != nil {
+	if err := InstallCommitMsgHook(ctx, wtPath); err != nil {
 		t.Fatalf("InstallCommitMsgHook: %v", err)
 	}
 
@@ -396,7 +403,7 @@ func TestInstallCommitMsgHook_StripsClaudeAttribution(t *testing.T) {
 	}
 
 	// Verify the Co-Authored-By line was stripped
-	msg, err := runGit(wtPath, "log", "-1", "--format=%B")
+	msg, err := runGit(ctx, wtPath, "log", "-1", "--format=%B")
 	if err != nil {
 		t.Fatalf("git log: %v", err)
 	}
@@ -409,15 +416,16 @@ func TestInstallCommitMsgHook_StripsClaudeAttribution(t *testing.T) {
 }
 
 func TestInstallCommitMsgHook_PreservesHumanCoAuthor(t *testing.T) {
+	ctx := context.Background()
 	repo := initTestRepo(t)
 	wtPath := filepath.Join(t.TempDir(), "wt-hook-human")
 
-	if err := WorktreeAdd(repo, wtPath, "hook-human-test", "main"); err != nil {
+	if err := WorktreeAdd(ctx, repo, wtPath, "hook-human-test", "main"); err != nil {
 		t.Fatalf("WorktreeAdd: %v", err)
 	}
-	defer WorktreeRemove(repo, wtPath)
+	defer WorktreeRemove(ctx, repo, wtPath)
 
-	if err := InstallCommitMsgHook(wtPath); err != nil {
+	if err := InstallCommitMsgHook(ctx, wtPath); err != nil {
 		t.Fatalf("InstallCommitMsgHook: %v", err)
 	}
 
@@ -435,7 +443,7 @@ func TestInstallCommitMsgHook_PreservesHumanCoAuthor(t *testing.T) {
 		}
 	}
 
-	msg, err := runGit(wtPath, "log", "-1", "--format=%B")
+	msg, err := runGit(ctx, wtPath, "log", "-1", "--format=%B")
 	if err != nil {
 		t.Fatalf("git log: %v", err)
 	}
@@ -445,15 +453,16 @@ func TestInstallCommitMsgHook_PreservesHumanCoAuthor(t *testing.T) {
 }
 
 func TestInstallCommitMsgHook_NoTrailerUnchanged(t *testing.T) {
+	ctx := context.Background()
 	repo := initTestRepo(t)
 	wtPath := filepath.Join(t.TempDir(), "wt-hook-clean")
 
-	if err := WorktreeAdd(repo, wtPath, "hook-clean-test", "main"); err != nil {
+	if err := WorktreeAdd(ctx, repo, wtPath, "hook-clean-test", "main"); err != nil {
 		t.Fatalf("WorktreeAdd: %v", err)
 	}
-	defer WorktreeRemove(repo, wtPath)
+	defer WorktreeRemove(ctx, repo, wtPath)
 
-	if err := InstallCommitMsgHook(wtPath); err != nil {
+	if err := InstallCommitMsgHook(ctx, wtPath); err != nil {
 		t.Fatalf("InstallCommitMsgHook: %v", err)
 	}
 
@@ -471,7 +480,7 @@ func TestInstallCommitMsgHook_NoTrailerUnchanged(t *testing.T) {
 		}
 	}
 
-	msg, err := runGit(wtPath, "log", "-1", "--format=%B")
+	msg, err := runGit(ctx, wtPath, "log", "-1", "--format=%B")
 	if err != nil {
 		t.Fatalf("git log: %v", err)
 	}
@@ -481,15 +490,16 @@ func TestInstallCommitMsgHook_NoTrailerUnchanged(t *testing.T) {
 }
 
 func TestInstallCommitMsgHook_StripsMultiplePatterns(t *testing.T) {
+	ctx := context.Background()
 	repo := initTestRepo(t)
 	wtPath := filepath.Join(t.TempDir(), "wt-hook-multi")
 
-	if err := WorktreeAdd(repo, wtPath, "hook-multi-test", "main"); err != nil {
+	if err := WorktreeAdd(ctx, repo, wtPath, "hook-multi-test", "main"); err != nil {
 		t.Fatalf("WorktreeAdd: %v", err)
 	}
-	defer WorktreeRemove(repo, wtPath)
+	defer WorktreeRemove(ctx, repo, wtPath)
 
-	if err := InstallCommitMsgHook(wtPath); err != nil {
+	if err := InstallCommitMsgHook(ctx, wtPath); err != nil {
 		t.Fatalf("InstallCommitMsgHook: %v", err)
 	}
 
@@ -509,7 +519,7 @@ func TestInstallCommitMsgHook_StripsMultiplePatterns(t *testing.T) {
 		}
 	}
 
-	msg, err := runGit(wtPath, "log", "-1", "--format=%B")
+	msg, err := runGit(ctx, wtPath, "log", "-1", "--format=%B")
 	if err != nil {
 		t.Fatalf("git log: %v", err)
 	}
@@ -525,11 +535,12 @@ func TestInstallCommitMsgHook_StripsMultiplePatterns(t *testing.T) {
 }
 
 func TestWorktreeAdd_PrunesStaleAndRetries(t *testing.T) {
+	ctx := context.Background()
 	repo := initTestRepo(t)
 
 	// Create a worktree, then delete its directory to make it stale
 	stalePath := filepath.Join(t.TempDir(), "stale-wt")
-	if err := WorktreeAdd(repo, stalePath, "stale-branch", "main"); err != nil {
+	if err := WorktreeAdd(ctx, repo, stalePath, "stale-branch", "main"); err != nil {
 		t.Fatalf("WorktreeAdd (setup): %v", err)
 	}
 	// Remove the worktree directory without telling git — makes it stale
@@ -539,10 +550,10 @@ func TestWorktreeAdd_PrunesStaleAndRetries(t *testing.T) {
 
 	// Now try to create a new worktree on the same branch — should auto-prune and succeed
 	newPath := filepath.Join(t.TempDir(), "new-wt")
-	if err := WorktreeAdd(repo, newPath, "stale-branch", "main"); err != nil {
+	if err := WorktreeAdd(ctx, repo, newPath, "stale-branch", "main"); err != nil {
 		t.Fatalf("WorktreeAdd should recover from stale worktree: %v", err)
 	}
-	defer WorktreeRemove(repo, newPath)
+	defer WorktreeRemove(ctx, repo, newPath)
 
 	// Verify the new worktree exists
 	if _, err := os.Stat(filepath.Join(newPath, "README.md")); err != nil {
@@ -551,6 +562,7 @@ func TestWorktreeAdd_PrunesStaleAndRetries(t *testing.T) {
 }
 
 func TestWorktreeAddTrack_PrunesStaleAndRetries(t *testing.T) {
+	ctx := context.Background()
 	repo := initTestRepo(t)
 
 	// Create a local bare repo as "origin" with a feature branch
@@ -559,21 +571,21 @@ func TestWorktreeAddTrack_PrunesStaleAndRetries(t *testing.T) {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("bare clone: %v\n%s", err, out)
 	}
-	if _, err := runGit(repo, "remote", "add", "origin", bareDir); err != nil {
-		runGit(repo, "remote", "set-url", "origin", bareDir)
+	if _, err := runGit(ctx, repo, "remote", "add", "origin", bareDir); err != nil {
+		runGit(ctx, repo, "remote", "set-url", "origin", bareDir)
 	}
 
 	// Create and push a feature branch
-	if _, err := runGit(repo, "branch", "feature-x"); err != nil {
+	if _, err := runGit(ctx, repo, "branch", "feature-x"); err != nil {
 		t.Fatalf("branch: %v", err)
 	}
-	if _, err := runGit(repo, "push", "origin", "feature-x"); err != nil {
+	if _, err := runGit(ctx, repo, "push", "origin", "feature-x"); err != nil {
 		t.Fatalf("push: %v", err)
 	}
 
 	// Create a worktree tracking origin/feature-x, then make it stale
 	stalePath := filepath.Join(t.TempDir(), "stale-track")
-	if err := WorktreeAddTrack(repo, stalePath, "feature-x"); err != nil {
+	if err := WorktreeAddTrack(ctx, repo, stalePath, "feature-x"); err != nil {
 		t.Fatalf("WorktreeAddTrack (setup): %v", err)
 	}
 	if err := os.RemoveAll(stalePath); err != nil {
@@ -582,10 +594,10 @@ func TestWorktreeAddTrack_PrunesStaleAndRetries(t *testing.T) {
 
 	// Retry should prune and succeed
 	newPath := filepath.Join(t.TempDir(), "new-track")
-	if err := WorktreeAddTrack(repo, newPath, "feature-x"); err != nil {
+	if err := WorktreeAddTrack(ctx, repo, newPath, "feature-x"); err != nil {
 		t.Fatalf("WorktreeAddTrack should recover from stale worktree: %v", err)
 	}
-	defer WorktreeRemove(repo, newPath)
+	defer WorktreeRemove(ctx, repo, newPath)
 
 	if _, err := os.Stat(filepath.Join(newPath, "README.md")); err != nil {
 		t.Errorf("new worktree should contain README.md: %v", err)
@@ -593,18 +605,19 @@ func TestWorktreeAddTrack_PrunesStaleAndRetries(t *testing.T) {
 }
 
 func TestWorktreeAdd_LiveWorktreeReturnsError(t *testing.T) {
+	ctx := context.Background()
 	repo := initTestRepo(t)
 
 	// Create a worktree that's still live (directory exists)
 	livePath := filepath.Join(t.TempDir(), "live-wt")
-	if err := WorktreeAdd(repo, livePath, "live-branch", "main"); err != nil {
+	if err := WorktreeAdd(ctx, repo, livePath, "live-branch", "main"); err != nil {
 		t.Fatalf("WorktreeAdd (setup): %v", err)
 	}
-	defer WorktreeRemove(repo, livePath)
+	defer WorktreeRemove(ctx, repo, livePath)
 
 	// Try to create another worktree on the same branch — should fail with a clear error
 	otherPath := filepath.Join(t.TempDir(), "other-wt")
-	err := WorktreeAdd(repo, otherPath, "live-branch", "main")
+	err := WorktreeAdd(ctx, repo, otherPath, "live-branch", "main")
 	if err == nil {
 		t.Fatal("WorktreeAdd should fail when branch is in a live worktree")
 	}
@@ -617,23 +630,24 @@ func TestWorktreeAdd_LiveWorktreeReturnsError(t *testing.T) {
 }
 
 func TestWorktreePrune(t *testing.T) {
+	ctx := context.Background()
 	repo := initTestRepo(t)
 
 	// Create a worktree, delete its directory, then prune
 	wtPath := filepath.Join(t.TempDir(), "prune-wt")
-	if err := WorktreeAdd(repo, wtPath, "prune-branch", "main"); err != nil {
+	if err := WorktreeAdd(ctx, repo, wtPath, "prune-branch", "main"); err != nil {
 		t.Fatalf("WorktreeAdd: %v", err)
 	}
 	os.RemoveAll(wtPath)
 
-	if err := WorktreePrune(repo); err != nil {
+	if err := WorktreePrune(ctx, repo); err != nil {
 		t.Fatalf("WorktreePrune: %v", err)
 	}
 
 	// After prune, creating a worktree on the same branch should work
 	// (using -B since the branch ref still exists after prune)
 	newPath := filepath.Join(t.TempDir(), "after-prune")
-	_, err := runGit(repo, "worktree", "add", newPath, "-B", "prune-branch", "main", "--quiet")
+	_, err := runGit(ctx, repo, "worktree", "add", newPath, "-B", "prune-branch", "main", "--quiet")
 	if err != nil {
 		t.Fatalf("worktree add after prune should succeed: %v", err)
 	}

--- a/internal/git/timeout_test.go
+++ b/internal/git/timeout_test.go
@@ -1,0 +1,73 @@
+package git
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunGitRespectsContextTimeout(t *testing.T) {
+	// Use an already-expired context to verify the command fails fast.
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	time.Sleep(5 * time.Millisecond)
+
+	_, err := runGit(ctx, "", "sleep", "60")
+	if err == nil {
+		t.Fatal("expected error from timed-out context")
+	}
+	if !strings.Contains(err.Error(), "timed out") && !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Errorf("expected timeout-related error, got: %v", err)
+	}
+}
+
+func TestRunGitNetworkRespectsContextTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	time.Sleep(5 * time.Millisecond)
+
+	_, err := runGitNetwork(ctx, "", "sleep", "60")
+	if err == nil {
+		t.Fatal("expected error from timed-out context")
+	}
+	if !strings.Contains(err.Error(), "timed out") && !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Errorf("expected timeout-related error, got: %v", err)
+	}
+}
+
+func TestEnsureTimeoutNoOverride(t *testing.T) {
+	// If the context already has a shorter deadline, ensureTimeout should not extend it.
+	shortTimeout := 10 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+	defer cancel()
+
+	newCtx, newCancel := ensureTimeout(ctx, 5*time.Minute)
+	defer newCancel()
+
+	deadline, ok := newCtx.Deadline()
+	if !ok {
+		t.Fatal("expected deadline to be set")
+	}
+	remaining := time.Until(deadline)
+	if remaining > 1*time.Second {
+		t.Errorf("deadline should be close to original short timeout, but remaining = %v", remaining)
+	}
+}
+
+func TestEnsureTimeoutAppliesDefault(t *testing.T) {
+	ctx := context.Background()
+	timeout := 42 * time.Second
+
+	newCtx, cancel := ensureTimeout(ctx, timeout)
+	defer cancel()
+
+	deadline, ok := newCtx.Deadline()
+	if !ok {
+		t.Fatal("expected deadline to be set")
+	}
+	remaining := time.Until(deadline)
+	if remaining < 40*time.Second || remaining > 43*time.Second {
+		t.Errorf("expected deadline ~42s from now, got %v", remaining)
+	}
+}

--- a/internal/github/gh_cli_client.go
+++ b/internal/github/gh_cli_client.go
@@ -7,10 +7,14 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 // Verify GHCLIClient implements Client at compile time.
 var _ Client = (*GHCLIClient)(nil)
+
+// defaultTimeout is the timeout for gh CLI calls (API operations).
+const defaultTimeout = 30 * time.Second
 
 // GHCLIClient implements Client by shelling out to the gh CLI.
 type GHCLIClient struct {
@@ -39,13 +43,37 @@ func (c *GHCLIClient) ghArgs(base []string, prRef string) []string {
 	return args
 }
 
+// ensureTimeout returns a context with defaultTimeout applied if the parent
+// context has no deadline set. If ctx is nil, a background context is used.
+func ensureTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, defaultTimeout)
+}
+
+// wrapTimeoutErr checks if an error is due to a context deadline and returns
+// a clearer message.
+func wrapTimeoutErr(ctx context.Context, cmdName string, err error) error {
+	if ctx.Err() == context.DeadlineExceeded {
+		return fmt.Errorf("%s timed out after %s", cmdName, defaultTimeout)
+	}
+	return err
+}
+
 // GetRepoOwnerAndName returns owner/repo by querying gh.
-func (c *GHCLIClient) GetRepoOwnerAndName(_ context.Context) (string, string, error) {
-	cmd := exec.Command("gh", "repo", "view", "--json", "owner,name", "-q", ".owner.login + \"/\" + .name")
+func (c *GHCLIClient) GetRepoOwnerAndName(ctx context.Context) (string, string, error) {
+	ctx, cancel := ensureTimeout(ctx)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "gh", "repo", "view", "--json", "owner,name", "-q", ".owner.login + \"/\" + .name")
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {
-		return "", "", err
+		return "", "", wrapTimeoutErr(ctx, "gh repo view", err)
 	}
 	parts := strings.SplitN(strings.TrimSpace(stdout.String()), "/", 2)
 	if len(parts) != 2 {
@@ -55,13 +83,16 @@ func (c *GHCLIClient) GetRepoOwnerAndName(_ context.Context) (string, string, er
 }
 
 // GetRepoOwnerAndNameFromDir returns owner/repo for the git repo at the given directory.
-func (c *GHCLIClient) GetRepoOwnerAndNameFromDir(_ context.Context, dir string) (string, string, error) {
-	cmd := exec.Command("gh", "repo", "view", "--json", "owner,name", "-q", ".owner.login + \"/\" + .name")
+func (c *GHCLIClient) GetRepoOwnerAndNameFromDir(ctx context.Context, dir string) (string, string, error) {
+	ctx, cancel := ensureTimeout(ctx)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "gh", "repo", "view", "--json", "owner,name", "-q", ".owner.login + \"/\" + .name")
 	cmd.Dir = dir
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {
-		return "", "", fmt.Errorf("resolving repo for %s: %w", dir, err)
+		return "", "", fmt.Errorf("resolving repo for %s: %w", dir, wrapTimeoutErr(ctx, "gh repo view", err))
 	}
 	parts := strings.SplitN(strings.TrimSpace(stdout.String()), "/", 2)
 	if len(parts) != 2 {
@@ -71,9 +102,12 @@ func (c *GHCLIClient) GetRepoOwnerAndNameFromDir(_ context.Context, dir string) 
 }
 
 // GetCI checks CI status by running "gh pr checks" and summarizing pass/fail/pending.
-func (c *GHCLIClient) GetCI(_ context.Context, prRef string) string {
+func (c *GHCLIClient) GetCI(ctx context.Context, prRef string) string {
+	ctx, cancel := ensureTimeout(ctx)
+	defer cancel()
+
 	args := c.ghArgs([]string{"pr", "checks"}, prRef)
-	cmd := exec.Command("gh", args...)
+	cmd := exec.CommandContext(ctx, "gh", args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -91,9 +125,12 @@ func (c *GHCLIClient) GetCI(_ context.Context, prRef string) string {
 }
 
 // GetConflicts checks if a PR has merge conflicts.
-func (c *GHCLIClient) GetConflicts(_ context.Context, prRef string) string {
+func (c *GHCLIClient) GetConflicts(ctx context.Context, prRef string) string {
+	ctx, cancel := ensureTimeout(ctx)
+	defer cancel()
+
 	args := c.ghArgs([]string{"pr", "view", "--json", "mergeable", "-q", ".mergeable"}, prRef)
-	cmd := exec.Command("gh", args...)
+	cmd := exec.CommandContext(ctx, "gh", args...)
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {
@@ -110,9 +147,12 @@ func (c *GHCLIClient) GetConflicts(_ context.Context, prRef string) string {
 }
 
 // GetReviewDecision fetches the review decision for a PR.
-func (c *GHCLIClient) GetReviewDecision(_ context.Context, prRef string) string {
+func (c *GHCLIClient) GetReviewDecision(ctx context.Context, prRef string) string {
+	ctx, cancel := ensureTimeout(ctx)
+	defer cancel()
+
 	args := c.ghArgs([]string{"pr", "view", "--json", "reviewDecision", "-q", ".reviewDecision"}, prRef)
-	cmd := exec.Command("gh", args...)
+	cmd := exec.CommandContext(ctx, "gh", args...)
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {
@@ -122,9 +162,12 @@ func (c *GHCLIClient) GetReviewDecision(_ context.Context, prRef string) string 
 }
 
 // GetState returns the PR state (e.g. "OPEN", "MERGED", "CLOSED").
-func (c *GHCLIClient) GetState(_ context.Context, prRef string) string {
+func (c *GHCLIClient) GetState(ctx context.Context, prRef string) string {
+	ctx, cancel := ensureTimeout(ctx)
+	defer cancel()
+
 	args := c.ghArgs([]string{"pr", "view", "--json", "state", "-q", ".state"}, prRef)
-	cmd := exec.Command("gh", args...)
+	cmd := exec.CommandContext(ctx, "gh", args...)
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {
@@ -138,14 +181,17 @@ func (c *GHCLIClient) GetState(_ context.Context, prRef string) string {
 }
 
 // GetBranch returns the head branch name for a PR.
-func (c *GHCLIClient) GetBranch(_ context.Context, prRef string) (string, error) {
+func (c *GHCLIClient) GetBranch(ctx context.Context, prRef string) (string, error) {
+	ctx, cancel := ensureTimeout(ctx)
+	defer cancel()
+
 	args := c.ghArgs([]string{"pr", "view", "--json", "headRefName", "-q", ".headRefName"}, prRef)
-	cmd := exec.Command("gh", args...)
+	cmd := exec.CommandContext(ctx, "gh", args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("gh pr view: %w: %s", err, strings.TrimSpace(stderr.String()))
+		return "", fmt.Errorf("gh pr view: %w", wrapTimeoutErr(ctx, "gh pr view", err))
 	}
 	branch := strings.TrimSpace(stdout.String())
 	if branch == "" {
@@ -155,22 +201,28 @@ func (c *GHCLIClient) GetBranch(_ context.Context, prRef string) (string, error)
 }
 
 // GetURL returns the HTML URL for a PR.
-func (c *GHCLIClient) GetURL(_ context.Context, prRef string) (string, error) {
+func (c *GHCLIClient) GetURL(ctx context.Context, prRef string) (string, error) {
+	ctx, cancel := ensureTimeout(ctx)
+	defer cancel()
+
 	args := c.ghArgs([]string{"pr", "view", "--json", "url", "-q", ".url"}, prRef)
-	cmd := exec.Command("gh", args...)
+	cmd := exec.CommandContext(ctx, "gh", args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("gh pr view: %w: %s", err, strings.TrimSpace(stderr.String()))
+		return "", fmt.Errorf("gh pr view: %w", wrapTimeoutErr(ctx, "gh pr view", err))
 	}
 	return strings.TrimSpace(stdout.String()), nil
 }
 
 // GetTitle fetches the title of a PR.
-func (c *GHCLIClient) GetTitle(_ context.Context, prRef string) string {
+func (c *GHCLIClient) GetTitle(ctx context.Context, prRef string) string {
+	ctx, cancel := ensureTimeout(ctx)
+	defer cancel()
+
 	args := c.ghArgs([]string{"pr", "view", "--json", "title", "-q", ".title"}, prRef)
-	cmd := exec.Command("gh", args...)
+	cmd := exec.CommandContext(ctx, "gh", args...)
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {
@@ -184,13 +236,16 @@ func (c *GHCLIClient) GetTitle(_ context.Context, prRef string) string {
 }
 
 // Merge merges a PR with the given method.
-func (c *GHCLIClient) Merge(_ context.Context, prNumber, mergeMethod string, deleteBranch bool) error {
+func (c *GHCLIClient) Merge(ctx context.Context, prNumber, mergeMethod string, deleteBranch bool) error {
+	ctx, cancel := ensureTimeout(ctx)
+	defer cancel()
+
 	args := MergeArgs(prNumber, mergeMethod, deleteBranch, c.repo)
-	cmd := exec.Command("gh", args...)
+	cmd := exec.CommandContext(ctx, "gh", args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("gh pr merge: %w: %s", err, strings.TrimSpace(stderr.String()))
+		return fmt.Errorf("gh pr merge: %w", wrapTimeoutErr(ctx, "gh pr merge", err))
 	}
 	return nil
 }
@@ -216,24 +271,31 @@ func (c *GHCLIClient) ReplyToReviewComment(ctx context.Context, owner, repo, prN
 }
 
 // FetchReviewThreads fetches review threads for a PR using the GraphQL API.
-func (c *GHCLIClient) FetchReviewThreads(_ context.Context, owner, repo string, prNumber int) ([]ReviewThread, error) {
+func (c *GHCLIClient) FetchReviewThreads(ctx context.Context, owner, repo string, prNumber int) ([]ReviewThread, error) {
 	query := fmt.Sprintf(`{ repository(owner:%q, name:%q) { pullRequest(number: %d) { reviewThreads(first: 100) { nodes { id isResolved } } } } }`, owner, repo, prNumber)
-	return fetchReviewThreadsImpl(query, c.runGraphQL)
+	return fetchReviewThreadsImpl(query, func(q string) ([]byte, error) {
+		return c.runGraphQL(ctx, q)
+	})
 }
 
 // ResolveReviewThread resolves a review thread by its GraphQL node ID.
-func (c *GHCLIClient) ResolveReviewThread(_ context.Context, threadID string) error {
-	return resolveReviewThreadImpl(threadID, c.runGraphQL)
+func (c *GHCLIClient) ResolveReviewThread(ctx context.Context, threadID string) error {
+	return resolveReviewThreadImpl(threadID, func(q string) ([]byte, error) {
+		return c.runGraphQL(ctx, q)
+	})
 }
 
 // runGraphQL executes a GraphQL query via gh api.
-func (c *GHCLIClient) runGraphQL(query string) ([]byte, error) {
-	cmd := exec.Command("gh", "api", "graphql", "-f", "query="+query)
+func (c *GHCLIClient) runGraphQL(ctx context.Context, query string) ([]byte, error) {
+	ctx, cancel := ensureTimeout(ctx)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "gh", "api", "graphql", "-f", "query="+query)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("gh api graphql: %w: %s", err, strings.TrimSpace(stderr.String()))
+		return nil, fmt.Errorf("gh api graphql: %w", wrapTimeoutErr(ctx, "gh api graphql", err))
 	}
 	return stdout.Bytes(), nil
 }
@@ -290,13 +352,16 @@ func resolveReviewThreadImpl(threadID string, runner graphQLRunner) error {
 }
 
 // FetchCollaborators returns the list of collaborator logins for a repo.
-func (c *GHCLIClient) FetchCollaborators(_ context.Context, owner, repo string) ([]string, error) {
-	cmd := exec.Command("gh", "api", fmt.Sprintf("repos/%s/%s/collaborators", owner, repo), "--jq", ".[].login")
+func (c *GHCLIClient) FetchCollaborators(ctx context.Context, owner, repo string) ([]string, error) {
+	ctx, cancel := ensureTimeout(ctx)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "gh", "api", fmt.Sprintf("repos/%s/%s/collaborators", owner, repo), "--jq", ".[].login")
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("fetching collaborators: %w: %s", err, strings.TrimSpace(stderr.String()))
+		return nil, fmt.Errorf("fetching collaborators: %w", wrapTimeoutErr(ctx, "gh api collaborators", err))
 	}
 	var logins []string
 	for _, line := range strings.Split(strings.TrimSpace(stdout.String()), "\n") {
@@ -308,63 +373,75 @@ func (c *GHCLIClient) FetchCollaborators(_ context.Context, owner, repo string) 
 }
 
 // APIGet runs gh api with the given path and returns raw bytes.
-func (c *GHCLIClient) APIGet(_ context.Context, path string) ([]byte, error) {
-	cmd := exec.Command("gh", "api", path)
+func (c *GHCLIClient) APIGet(ctx context.Context, path string) ([]byte, error) {
+	ctx, cancel := ensureTimeout(ctx)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "gh", "api", path)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("gh api %s: %w: %s", path, err, strings.TrimSpace(stderr.String()))
+		return nil, fmt.Errorf("gh api %s: %w", path, wrapTimeoutErr(ctx, "gh api "+path, err))
 	}
 	return stdout.Bytes(), nil
 }
 
 // APIPost runs gh api with POST method and field arguments.
-func (c *GHCLIClient) APIPost(_ context.Context, path string, fields map[string]string) error {
+func (c *GHCLIClient) APIPost(ctx context.Context, path string, fields map[string]string) error {
+	ctx, cancel := ensureTimeout(ctx)
+	defer cancel()
+
 	args := []string{"api", path, "-X", "POST"}
 	for k, v := range fields {
 		args = append(args, "-f", k+"="+v)
 	}
-	cmd := exec.Command("gh", args...)
+	cmd := exec.CommandContext(ctx, "gh", args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("gh api POST %s: %w: %s", path, err, strings.TrimSpace(stderr.String()))
+		return fmt.Errorf("gh api POST %s: %w", path, wrapTimeoutErr(ctx, "gh api POST "+path, err))
 	}
 	return nil
 }
 
 // APIPostJSON runs gh api with POST method and a raw JSON body via --input.
-func (c *GHCLIClient) APIPostJSON(_ context.Context, path string, body interface{}) ([]byte, error) {
+func (c *GHCLIClient) APIPostJSON(ctx context.Context, path string, body interface{}) ([]byte, error) {
+	ctx, cancel := ensureTimeout(ctx)
+	defer cancel()
+
 	payload, err := json.Marshal(body)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling request body: %w", err)
 	}
-	cmd := exec.Command("gh", "api", path, "-X", "POST", "--input", "-")
+	cmd := exec.CommandContext(ctx, "gh", "api", path, "-X", "POST", "--input", "-")
 	cmd.Stdin = bytes.NewReader(payload)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("gh api POST %s: %w: %s", path, err, strings.TrimSpace(stderr.String()))
+		return nil, fmt.Errorf("gh api POST %s: %w", path, wrapTimeoutErr(ctx, "gh api POST "+path, err))
 	}
 	return stdout.Bytes(), nil
 }
 
 // FetchPRMetadata fetches PR URL, title, head branch, and state from GitHub via gh CLI.
-func (c *GHCLIClient) FetchPRMetadata(_ context.Context, prNumber, repo string) (prURL, title, headBranch, state string, err error) {
+func (c *GHCLIClient) FetchPRMetadata(ctx context.Context, prNumber, repo string) (prURL, title, headBranch, state string, err error) {
+	ctx, cancel := ensureTimeout(ctx)
+	defer cancel()
+
 	args := []string{
 		"pr", "view", prNumber,
 		"--repo", repo,
 		"--json", "url,title,headRefName,state",
 		"-q", `(.url) + "\t" + (.title) + "\t" + (.headRefName) + "\t" + (.state)`,
 	}
-	cmd := exec.Command("gh", args...)
+	cmd := exec.CommandContext(ctx, "gh", args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return "", "", "", "", fmt.Errorf("gh pr view: %s", strings.TrimSpace(stderr.String()))
+		return "", "", "", "", wrapTimeoutErr(ctx, "gh pr view", fmt.Errorf("gh pr view: %s", strings.TrimSpace(stderr.String())))
 	}
 
 	parts := strings.SplitN(strings.TrimSpace(stdout.String()), "\t", 4)
@@ -375,12 +452,15 @@ func (c *GHCLIClient) FetchPRMetadata(_ context.Context, prNumber, repo string) 
 }
 
 // GetAuthenticatedUser returns the login of the currently authenticated GitHub user.
-func (c *GHCLIClient) GetAuthenticatedUser(_ context.Context) (string, error) {
-	cmd := exec.Command("gh", "api", "user", "-q", ".login")
+func (c *GHCLIClient) GetAuthenticatedUser(ctx context.Context) (string, error) {
+	ctx, cancel := ensureTimeout(ctx)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "gh", "api", "user", "-q", ".login")
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("gh api user: %w", err)
+		return "", fmt.Errorf("gh api user: %w", wrapTimeoutErr(ctx, "gh api user", err))
 	}
 	login := strings.TrimSpace(stdout.String())
 	if login == "" {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -69,7 +69,7 @@ func FetchReviewThreads(owner, repo string, prNumber int) ([]ReviewThread, error
 type graphQLRunner func(query string) ([]byte, error)
 
 func defaultGraphQLRunner(query string) ([]byte, error) {
-	return NewGHCLIClient("").runGraphQL(query)
+	return NewGHCLIClient("").runGraphQL(context.TODO(), query)
 }
 
 func fetchReviewThreadsWithRunner(query string, runner graphQLRunner) ([]ReviewThread, error) {

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
@@ -46,11 +47,12 @@ type TmuxDeps struct {
 }
 
 // DefaultTmuxDeps returns TmuxDeps wired to the real tmux package.
+// Uses a background context for the underlying tmux calls.
 func DefaultTmuxDeps() TmuxDeps {
 	return TmuxDeps{
-		PaneExists: tmux.PaneExists,
-		PaneIsIdle: tmux.PaneIsIdle,
-		PaneIsDead: tmux.PaneIsDead,
+		PaneExists: func(paneID string) bool { return tmux.PaneExists(context.Background(), paneID) },
+		PaneIsIdle: func(paneID string) bool { return tmux.PaneIsIdle(context.Background(), paneID) },
+		PaneIsDead: func(paneID string) bool { return tmux.PaneIsDead(context.Background(), paneID) },
 	}
 }
 

--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -64,57 +64,57 @@ func NewExecClient() *ExecClient { return &ExecClient{} }
 func (c *ExecClient) InSession() bool { return InSession() }
 
 func (c *ExecClient) SplitWindow(ctx context.Context, targetPane, dir, command string) (string, error) {
-	return SplitWindow(targetPane, dir, command)
+	return SplitWindow(ctx, targetPane, dir, command)
 }
 
 func (c *ExecClient) SplitWindowSized(ctx context.Context, targetPane, dir, command, orientation, size string) (string, error) {
-	return SplitWindowSized(targetPane, dir, command, orientation, size)
+	return SplitWindowSized(ctx, targetPane, dir, command, orientation, size)
 }
 
 func (c *ExecClient) SetPaneTitle(ctx context.Context, paneID, title string) error {
-	return SetPaneTitle(paneID, title)
+	return SetPaneTitle(ctx, paneID, title)
 }
 
 func (c *ExecClient) LockPaneTitle(ctx context.Context, paneID string) error {
-	return LockPaneTitle(paneID)
+	return LockPaneTitle(ctx, paneID)
 }
 
 func (c *ExecClient) RebalanceLayout(ctx context.Context, targetPane string) error {
-	return RebalanceLayout(targetPane)
+	return RebalanceLayout(ctx, targetPane)
 }
 
 func (c *ExecClient) SwapPane(ctx context.Context, src, dst string) error {
-	return SwapPane(src, dst)
+	return SwapPane(ctx, src, dst)
 }
 
 func (c *ExecClient) ListWindowPanes(ctx context.Context, targetPane string) ([]string, error) {
-	return ListWindowPanes(targetPane)
+	return ListWindowPanes(ctx, targetPane)
 }
 
 func (c *ExecClient) PaneExists(ctx context.Context, paneID string) bool {
-	return PaneExists(paneID)
+	return PaneExists(ctx, paneID)
 }
 
 func (c *ExecClient) PaneIsDead(ctx context.Context, paneID string) bool {
-	return PaneIsDead(paneID)
+	return PaneIsDead(ctx, paneID)
 }
 
 func (c *ExecClient) PaneIsIdle(ctx context.Context, paneID string) bool {
-	return PaneIsIdle(paneID)
+	return PaneIsIdle(ctx, paneID)
 }
 
 func (c *ExecClient) CapturePane(ctx context.Context, paneID string, history int) (string, error) {
-	return CapturePane(paneID, history)
+	return CapturePane(ctx, paneID, history)
 }
 
 func (c *ExecClient) KillPane(ctx context.Context, paneID string) error {
-	return KillPane(paneID)
+	return KillPane(ctx, paneID)
 }
 
 func (c *ExecClient) SetWindowOption(ctx context.Context, target, option, value string) error {
-	return SetWindowOption(target, option, value)
+	return SetWindowOption(ctx, target, option, value)
 }
 
 func (c *ExecClient) RenameWindow(ctx context.Context, target, name string) error {
-	return RenameWindow(target, name)
+	return RenameWindow(ctx, target, name)
 }

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2,11 +2,17 @@ package tmux
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 )
+
+// defaultTimeout is the timeout for tmux commands. These are local IPC calls
+// to the tmux server and should complete almost instantly.
+const defaultTimeout = 5 * time.Second
 
 // InSession returns true if we're currently inside a tmux session.
 func InSession() bool {
@@ -16,7 +22,7 @@ func InSession() bool {
 // SplitWindow creates a new tmux pane by splitting vertically.
 // Returns the new pane ID. The command runs in the specified dir.
 // targetPane specifies which pane to split (e.g. from $TMUX_PANE).
-func SplitWindow(targetPane, dir, command string) (string, error) {
+func SplitWindow(ctx context.Context, targetPane, dir, command string) (string, error) {
 	args := []string{
 		"split-window",
 		"-t", targetPane,
@@ -25,7 +31,7 @@ func SplitWindow(targetPane, dir, command string) (string, error) {
 		"-c", dir,
 		command,
 	}
-	out, err := runTmux(args...)
+	out, err := runTmux(ctx, args...)
 	if err != nil {
 		return "", fmt.Errorf("split-window: %w", err)
 	}
@@ -35,7 +41,7 @@ func SplitWindow(targetPane, dir, command string) (string, error) {
 // SplitWindowSized creates a new tmux pane with a specified size.
 // orientation is "-v" for top/bottom or "-h" for left/right.
 // size is passed to tmux's -l flag (e.g. "30%" or "15").
-func SplitWindowSized(targetPane, dir, command, orientation, size string) (string, error) {
+func SplitWindowSized(ctx context.Context, targetPane, dir, command, orientation, size string) (string, error) {
 	args := []string{
 		"split-window",
 		"-t", targetPane,
@@ -45,7 +51,7 @@ func SplitWindowSized(targetPane, dir, command, orientation, size string) (strin
 		"-c", dir,
 		command,
 	}
-	out, err := runTmux(args...)
+	out, err := runTmux(ctx, args...)
 	if err != nil {
 		return "", fmt.Errorf("split-window: %w", err)
 	}
@@ -55,35 +61,35 @@ func SplitWindowSized(targetPane, dir, command, orientation, size string) (strin
 // SetPaneTitle sets the title of a tmux pane.
 // Uses select-pane -T which correctly handles titles with spaces,
 // unlike set-option -p pane-title which breaks in tmux 3.6+.
-func SetPaneTitle(paneID, title string) error {
-	_, err := runTmux("select-pane", "-t", paneID, "-T", title)
+func SetPaneTitle(ctx context.Context, paneID, title string) error {
+	_, err := runTmux(ctx, "select-pane", "-t", paneID, "-T", title)
 	return err
 }
 
 // LockPaneTitle prevents applications in the pane from overriding the title.
-func LockPaneTitle(paneID string) error {
-	_, err := runTmux("set-option", "-p", "-t", paneID, "allow-rename", "off")
+func LockPaneTitle(ctx context.Context, paneID string) error {
+	_, err := runTmux(ctx, "set-option", "-p", "-t", paneID, "allow-rename", "off")
 	return err
 }
 
 // RebalanceLayout rebalances the pane layout for the window containing targetPane.
-func RebalanceLayout(targetPane string) error {
+func RebalanceLayout(ctx context.Context, targetPane string) error {
 	if targetPane == "" {
 		return fmt.Errorf("targetPane cannot be empty")
 	}
-	_, err := runTmux("select-layout", "-t", targetPane, "even-vertical")
+	_, err := runTmux(ctx, "select-layout", "-t", targetPane, "even-vertical")
 	return err
 }
 
 // SwapPane swaps two tmux panes.
-func SwapPane(src, dst string) error {
-	_, err := runTmux("swap-pane", "-s", src, "-t", dst)
+func SwapPane(ctx context.Context, src, dst string) error {
+	_, err := runTmux(ctx, "swap-pane", "-s", src, "-t", dst)
 	return err
 }
 
 // ListWindowPanes returns the pane IDs for the window containing targetPane, in layout order (top to bottom).
-func ListWindowPanes(targetPane string) ([]string, error) {
-	out, err := runTmux("list-panes", "-t", targetPane, "-F", "#{pane_id}")
+func ListWindowPanes(ctx context.Context, targetPane string) ([]string, error) {
+	out, err := runTmux(ctx, "list-panes", "-t", targetPane, "-F", "#{pane_id}")
 	if err != nil {
 		return nil, fmt.Errorf("list-panes: %w", err)
 	}
@@ -98,8 +104,8 @@ func ListWindowPanes(targetPane string) ([]string, error) {
 }
 
 // PaneExists checks if a tmux pane is still alive.
-func PaneExists(paneID string) bool {
-	out, err := runTmux("list-panes", "-a", "-F", "#{pane_id}")
+func PaneExists(ctx context.Context, paneID string) bool {
+	out, err := runTmux(ctx, "list-panes", "-a", "-F", "#{pane_id}")
 	if err != nil {
 		return false
 	}
@@ -113,33 +119,33 @@ func PaneExists(paneID string) bool {
 
 // CapturePane captures the visible content of a pane.
 // history controls how many lines of scrollback to include.
-func CapturePane(paneID string, history int) (string, error) {
+func CapturePane(ctx context.Context, paneID string, history int) (string, error) {
 	histStr := fmt.Sprintf("-%d", history)
-	return runTmux("capture-pane", "-t", paneID, "-p", "-S", histStr)
+	return runTmux(ctx, "capture-pane", "-t", paneID, "-p", "-S", histStr)
 }
 
 // KillPane kills a tmux pane.
-func KillPane(paneID string) error {
-	_, err := runTmux("kill-pane", "-t", paneID)
+func KillPane(ctx context.Context, paneID string) error {
+	_, err := runTmux(ctx, "kill-pane", "-t", paneID)
 	return err
 }
 
 // SetWindowOption sets a tmux window option for the window containing target pane.
-func SetWindowOption(target, option, value string) error {
-	_, err := runTmux("set-option", "-w", "-t", target, option, value)
+func SetWindowOption(ctx context.Context, target, option, value string) error {
+	_, err := runTmux(ctx, "set-option", "-w", "-t", target, option, value)
 	return err
 }
 
 // RenameWindow renames the tmux window containing the target pane.
-func RenameWindow(target, name string) error {
-	_, err := runTmux("rename-window", "-t", target, name)
+func RenameWindow(ctx context.Context, target, name string) error {
+	_, err := runTmux(ctx, "rename-window", "-t", target, name)
 	return err
 }
 
 // PaneIsDead checks if a tmux pane's command has exited.
 // Only returns true when remain-on-exit is set and the process is gone.
-func PaneIsDead(paneID string) bool {
-	out, err := runTmux("display-message", "-t", paneID, "-p", "#{pane_dead}")
+func PaneIsDead(ctx context.Context, paneID string) bool {
+	out, err := runTmux(ctx, "display-message", "-t", paneID, "-p", "#{pane_dead}")
 	return err == nil && strings.TrimSpace(out) == "1"
 }
 
@@ -148,15 +154,15 @@ func PaneIsDead(paneID string) bool {
 // running foreground process is a shell — which indicates the
 // command pipeline has likely completed. Note that this may return
 // true for active agents that are currently executing shell scripts.
-func PaneIsIdle(paneID string) bool {
-	if PaneIsDead(paneID) {
+func PaneIsIdle(ctx context.Context, paneID string) bool {
+	if PaneIsDead(ctx, paneID) {
 		return true
 	}
 
 	// Check the current foreground command in the pane. While the agent's
 	// command pipeline is active, pane_current_command will be "claude",
 	// "tee", "klaus", etc. Once finished, only the shell remains.
-	out, err := runTmux("display-message", "-t", paneID, "-p", "#{pane_current_command}")
+	out, err := runTmux(ctx, "display-message", "-t", paneID, "-p", "#{pane_current_command}")
 	if err != nil {
 		return false
 	}
@@ -175,12 +181,28 @@ func BuildArgs(op string, args ...string) []string {
 	return append([]string{op}, args...)
 }
 
-func runTmux(args ...string) (string, error) {
-	cmd := exec.Command("tmux", args...)
+// ensureTimeout returns a context with defaultTimeout applied if the parent
+// context has no deadline set. If the parent already has a shorter deadline,
+// it is returned unchanged.
+func ensureTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, defaultTimeout)
+}
+
+func runTmux(ctx context.Context, args ...string) (string, error) {
+	ctx, cancel := ensureTimeout(ctx)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "tmux", args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("tmux %s timed out after %s", args[0], defaultTimeout)
+		}
 		return "", fmt.Errorf("tmux %s: %w: %s", strings.Join(args, " "), err, stderr.String())
 	}
 	return strings.TrimSpace(stdout.String()), nil

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -1,6 +1,7 @@
 package tmux
 
 import (
+	"context"
 	"reflect"
 	"testing"
 )
@@ -48,7 +49,7 @@ func TestBuildArgsCapturePane(t *testing.T) {
 }
 
 func TestRebalanceLayoutEmptyPane(t *testing.T) {
-	err := RebalanceLayout("")
+	err := RebalanceLayout(context.Background(), "")
 	if err == nil {
 		t.Fatal("expected error for empty targetPane, got nil")
 	}


### PR DESCRIPTION
## Summary
- Add default timeouts to all `ExecClient` subprocess calls to prevent hung processes from blocking indefinitely
- tmux commands: 5s, git network ops: 2m, git local ops: 30s, gh CLI: 30s
- Timeouts applied in low-level exec functions via `context.WithTimeout`, respecting any shorter caller-provided deadlines
- Clear timeout error messages indicate which command timed out and the duration

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] New `timeout_test.go` verifies expired contexts cause immediate failures with timeout errors
- [x] Tests verify `ensureTimeout` respects existing shorter deadlines and applies defaults when none set

Closes #203