### PR TITLE
refactor: canonicalize state store — one store per session

### DIFF
--- a/internal/cmd/approve.go
+++ b/internal/cmd/approve.go
@@ -25,7 +25,11 @@ Use --all to approve all merge-ready PRs.`,
 			return fmt.Errorf("specify PR numbers, --run <id>, or --all")
 		}
 
-		states, store, err := listStatesFromEnvOrAll()
+		store, err := sessionStore()
+		if err != nil {
+			return err
+		}
+		states, err := store.List()
 		if err != nil {
 			return err
 		}
@@ -35,7 +39,7 @@ Use --all to approve all merge-ready PRs.`,
 		}
 
 		if runID != "" {
-			return approveByRunID(runID)
+			return approveByRunID(runID, store)
 		}
 
 		return approveByPRNumbers(args, states, store)
@@ -65,8 +69,8 @@ func approveAll(states []*run.State, store run.StateStore) error {
 	return nil
 }
 
-func approveByRunID(id string) error {
-	state, store, err := loadStateFromEnvOrAll(id)
+func approveByRunID(id string, store run.StateStore) error {
+	state, err := store.Load(id)
 	if err != nil {
 		return fmt.Errorf("run %s not found: %w", id, err)
 	}
@@ -108,21 +112,12 @@ func markApproved(s *run.State, store run.StateStore) error {
 	return nil
 }
 
-// findRunByPR finds a run state matching a PR number. If store is non-nil,
-// saves are directed there; otherwise scans all sessions.
+// findRunByPR finds a run state matching a PR number in the given store.
 func findRunByPR(prNumber string, states []*run.State, store run.StateStore) (*run.State, run.StateStore, error) {
 	prNumber = strings.TrimPrefix(prNumber, "#")
 	for _, s := range states {
 		if extractPRNumber(s) == prNumber {
-			if store != nil {
-				return s, store, nil
-			}
-			// Need to find the store for this state when scanning all sessions
-			_, foundStore, err := loadStateFromEnvOrAll(s.ID)
-			if err != nil {
-				return nil, nil, fmt.Errorf("found run %s but could not load its state store: %w", s.ID, err)
-			}
-			return s, foundStore, nil
+			return s, store, nil
 		}
 	}
 	return nil, nil, fmt.Errorf("no run with PR #%s", prNumber)

--- a/internal/cmd/cleanup.go
+++ b/internal/cmd/cleanup.go
@@ -31,27 +31,19 @@ by default; pass --force to remove them anyway.`,
 
 		deps := DefaultCleanupDeps(tmuxClient)
 
+		store, err := sessionStore()
+		if err != nil {
+			return err
+		}
+
 		if all {
-			store, err := sessionStoreOrAll()
-			if err != nil {
-				return err
-			}
-			if store != nil {
-				return cleanupAll(ctx, root, store, gitClient, force, deps, tmuxClient)
-			}
-			// No session env — could scan all, but require explicit session
-			return fmt.Errorf("KLAUS_SESSION_ID not set; specify a run ID or run inside a session")
+			return cleanupAll(ctx, root, store, gitClient, force, deps, tmuxClient)
 		}
 
 		if len(args) != 1 {
 			return fmt.Errorf("usage: klaus cleanup <run-id> or klaus cleanup --all")
 		}
 
-		state, store, err := loadStateFromEnvOrAll(args[0])
-		if err != nil {
-			return err
-		}
-		_ = state // cleanupOne will re-load
 		return cleanupOne(ctx, root, store, gitClient, args[0], force, deps, tmuxClient)
 	},
 }

--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -50,11 +50,8 @@ Keyboard shortcuts:
   q  quit
   r  force refresh`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		store, err := sessionStoreOrAll()
+		store, err := sessionStore()
 		if err != nil {
-			return err
-		}
-		if store == nil {
 			return fmt.Errorf("KLAUS_SESSION_ID not set; run inside a klaus session")
 		}
 

--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -30,9 +30,13 @@ Modes:
 		ctx := cmd.Context()
 		tmuxClient := tmux.NewExecClient()
 
-		state, _, err := loadStateFromEnvOrAll(id)
+		store, err := sessionStore()
 		if err != nil {
 			return err
+		}
+		state, err := store.Load(id)
+		if err != nil {
+			return fmt.Errorf("no run found with id: %s", id)
 		}
 
 		if raw {

--- a/internal/cmd/merge.go
+++ b/internal/cmd/merge.go
@@ -79,9 +79,7 @@ func buildRepoResolver(store run.StateStore, repoFlag string) func(string) strin
 
 	var sessionTarget string
 	if store != nil {
-		if hds, ok := store.(*run.HomeDirStore); ok {
-			sessionTarget, _ = run.LoadTarget(hds.BaseDir())
-		}
+		sessionTarget, _ = run.LoadTarget(filepath.Dir(store.StateDir()))
 	}
 
 	return func(prNumber string) string {

--- a/internal/cmd/merge.go
+++ b/internal/cmd/merge.go
@@ -71,20 +71,16 @@ func newMergeRunner(out io.Writer, in io.Reader, store run.StateStore, repoFlag 
 // buildRepoResolver returns a function that resolves the target repo for a given PR number.
 // Priority: run state pr_url match > --repo flag > session target > "" (existing behavior).
 func buildRepoResolver(store run.StateStore, repoFlag string) func(string) string {
-	// Pre-load states and session target once.
+	// Pre-load states and session target once from the provided store.
 	var states []*run.State
 	if store != nil {
 		states, _ = store.List()
-	} else {
-		states, _, _ = listStatesFromEnvOrAll()
 	}
 
 	var sessionTarget string
-	if store == nil {
-		if s, err := sessionStore(); err == nil {
-			if hds, ok := s.(*run.HomeDirStore); ok {
-				sessionTarget, _ = run.LoadTarget(hds.BaseDir())
-			}
+	if store != nil {
+		if hds, ok := store.(*run.HomeDirStore); ok {
+			sessionTarget, _ = run.LoadTarget(hds.BaseDir())
 		}
 	}
 
@@ -116,9 +112,7 @@ func buildApprovalChecker(store run.StateStore) func(string) bool {
 	return func(prNumber string) bool {
 		// Check internal approval state first.
 		var states []*run.State
-		if store == nil {
-			states, _, _ = listStatesFromEnvOrAll()
-		} else {
+		if store != nil {
 			states, _ = store.List()
 		}
 

--- a/internal/cmd/notifications.go
+++ b/internal/cmd/notifications.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/patflynn/klaus/internal/event"
-	"github.com/patflynn/klaus/internal/run"
 	"github.com/spf13/cobra"
 )
 
@@ -31,11 +30,7 @@ Use --all to show all events, or --json for machine-readable output.`,
 			return err
 		}
 
-		hds, ok := store.(*run.HomeDirStore)
-		if !ok {
-			return fmt.Errorf("unexpected store type")
-		}
-		baseDir := hds.BaseDir()
+		baseDir := filepath.Dir(store.StateDir())
 		log := event.NewLog(baseDir)
 
 		var events []event.Event

--- a/internal/cmd/notifications.go
+++ b/internal/cmd/notifications.go
@@ -26,42 +26,31 @@ Use --all to show all events, or --json for machine-readable output.`,
 		showAll, _ := cmd.Flags().GetBool("all")
 		jsonOut, _ := cmd.Flags().GetBool("json")
 
-		store, err := sessionStoreOrAll()
+		store, err := sessionStore()
 		if err != nil {
 			return err
 		}
 
-		// Collect events from session or all sessions
+		hds, ok := store.(*run.HomeDirStore)
+		if !ok {
+			return fmt.Errorf("unexpected store type")
+		}
+		baseDir := hds.BaseDir()
+		log := event.NewLog(baseDir)
+
 		var events []event.Event
-		var baseDir string
-
-		if store != nil {
-			hds, ok := store.(*run.HomeDirStore)
-			if !ok {
-				return fmt.Errorf("unexpected store type")
-			}
-			baseDir = hds.BaseDir()
-			log := event.NewLog(baseDir)
-
-			if showAll {
-				events, err = log.Read()
-			} else {
-				marker := loadMarker(baseDir)
-				var newMarker string
-				events, newMarker, err = log.ReadSince(marker)
-				if err == nil {
-					saveMarker(baseDir, newMarker)
-				}
-			}
-			if err != nil {
-				return fmt.Errorf("reading events: %w", err)
-			}
+		if showAll {
+			events, err = log.Read()
 		} else {
-			// No active session — scan all sessions
-			events, err = readAllSessionEvents()
-			if err != nil {
-				return fmt.Errorf("reading events: %w", err)
+			marker := loadMarker(baseDir)
+			var newMarker string
+			events, newMarker, err = log.ReadSince(marker)
+			if err == nil {
+				saveMarker(baseDir, newMarker)
 			}
+		}
+		if err != nil {
+			return fmt.Errorf("reading events: %w", err)
 		}
 
 		if jsonOut {
@@ -199,37 +188,6 @@ func saveMarker(baseDir, marker string) {
 	if err := os.WriteFile(filepath.Join(baseDir, markerFile), []byte(marker+"\n"), 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: could not save notification marker: %v\n", err)
 	}
-}
-
-// readAllSessionEvents reads events from all session directories.
-func readAllSessionEvents() ([]event.Event, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
-	}
-	sessionsDir := filepath.Join(home, ".klaus", "sessions")
-	entries, err := os.ReadDir(sessionsDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	var all []event.Event
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		baseDir := filepath.Join(sessionsDir, e.Name())
-		log := event.NewLog(baseDir)
-		events, readErr := log.Read()
-		if readErr != nil {
-			continue
-		}
-		all = append(all, events...)
-	}
-	return all, nil
 }
 
 func init() {

--- a/internal/cmd/pushlog.go
+++ b/internal/cmd/pushlog.go
@@ -28,9 +28,13 @@ warnings. Use after reviewing the log and confirming it's safe.`,
 			return err
 		}
 
-		state, store, err := loadStateFromEnvOrAll(id)
+		store, err := sessionStore()
 		if err != nil {
 			return err
+		}
+		state, err := store.Load(id)
+		if err != nil {
+			return fmt.Errorf("no run found with id: %s", id)
 		}
 
 		if state.LogFile == nil {

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -19,7 +19,11 @@ var statusCmd = &cobra.Command{
 		ctx := cmd.Context()
 		tmuxClient := tmux.NewExecClient()
 
-		states, _, err := listStatesFromEnvOrAll()
+		store, err := sessionStore()
+		if err != nil {
+			return err
+		}
+		states, err := store.List()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/store_helper.go
+++ b/internal/cmd/store_helper.go
@@ -22,6 +22,7 @@ func tmuxSessionEnvPrefix() string {
 }
 
 // sessionStore returns a HomeDirStore for the current session (from KLAUS_SESSION_ID env var).
+// This is the canonical way to get the store for the active session.
 func sessionStore() (run.StateStore, error) {
 	sessionID := os.Getenv(sessionIDEnv)
 	if sessionID == "" {
@@ -32,56 +33,4 @@ func sessionStore() (run.StateStore, error) {
 		return nil, err
 	}
 	return store, nil
-}
-
-// sessionStoreOrAll returns a store for the current session if KLAUS_SESSION_ID is set,
-// otherwise returns nil (callers should use ListAllSessions to scan all sessions).
-func sessionStoreOrAll() (run.StateStore, error) {
-	sessionID := os.Getenv(sessionIDEnv)
-	if sessionID == "" {
-		return nil, nil
-	}
-	store, err := run.NewHomeDirStore(sessionID)
-	if err != nil {
-		return nil, err
-	}
-	return store, nil
-}
-
-// listStatesFromEnvOrAll lists states from the current session if KLAUS_SESSION_ID
-// is set, otherwise lists states from all sessions under ~/.klaus/sessions/.
-func listStatesFromEnvOrAll() ([]*run.State, run.StateStore, error) {
-	store, err := sessionStoreOrAll()
-	if err != nil {
-		return nil, nil, err
-	}
-	if store != nil {
-		states, err := store.List()
-		return states, store, err
-	}
-	// No session env set — scan all sessions
-	states, err := run.ListAllSessions()
-	return states, nil, err
-}
-
-// loadStateFromEnvOrAll loads a specific run state. If KLAUS_SESSION_ID is set,
-// looks only in that session. Otherwise scans all sessions.
-func loadStateFromEnvOrAll(id string) (*run.State, run.StateStore, error) {
-	store, err := sessionStoreOrAll()
-	if err != nil {
-		return nil, nil, err
-	}
-	if store != nil {
-		state, err := store.Load(id)
-		if err != nil {
-			return nil, nil, fmt.Errorf("no run found with id: %s", id)
-		}
-		return state, store, nil
-	}
-	// Scan all sessions
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil, nil, fmt.Errorf("resolving home dir: %w", err)
-	}
-	return run.FindStateInSessions(home, id)
 }

--- a/internal/cmd/store_helper.go
+++ b/internal/cmd/store_helper.go
@@ -26,7 +26,16 @@ func tmuxSessionEnvPrefix() string {
 func sessionStore() (run.StateStore, error) {
 	sessionID := os.Getenv(sessionIDEnv)
 	if sessionID == "" {
-		return nil, fmt.Errorf("KLAUS_SESSION_ID is not set (are you inside a klaus session?)")
+		// Fall back to most recent session
+		sessionsDir, err := run.SessionsDir()
+		if err != nil {
+			return nil, fmt.Errorf("KLAUS_SESSION_ID is not set and could not find sessions directory: %w", err)
+		}
+		found, err := run.FindMostRecentSession(sessionsDir)
+		if err != nil {
+			return nil, fmt.Errorf("KLAUS_SESSION_ID is not set and no sessions found (are you inside a klaus session?)")
+		}
+		sessionID = found
 	}
 	store, err := run.NewHomeDirStore(sessionID)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Remove `sessionStoreOrAll()`, `listStatesFromEnvOrAll()`, and `loadStateFromEnvOrAll()` — all commands now use `sessionStore()` as the single canonical entry point
- Eliminate store re-derivation from environment variables on every command invocation; each session uses exactly one `HomeDirStore`
- Fix `buildRepoResolver()` and `buildApprovalChecker()` in merge.go to use the provided store instead of falling back to re-scanning all sessions

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 15 packages)
- [ ] Manual: run `klaus session`, launch agents, verify dashboard updates correctly
- [ ] Manual: run `klaus status`, `klaus cleanup`, `klaus approve` inside a session

Closes #201