### PR TITLE
fix: nil context panic when running bare 'klaus' command

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -23,7 +23,7 @@ If no session exists, a new one is created. Use 'klaus new' to explicitly start
 a fresh session.`,
 	Version: version,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return sessionCmd.RunE(sessionCmd, args)
+		return runSession(cmd, false)
 	},
 }
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -377,6 +377,9 @@ func InstallCommitMsgHook(ctx context.Context, worktreeDir string) error {
 // ensureTimeout returns a context with the given default timeout applied if
 // the parent context has no deadline set.
 func ensureTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if _, ok := ctx.Deadline(); ok {
 		return ctx, func() {}
 	}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -185,6 +185,9 @@ func BuildArgs(op string, args ...string) []string {
 // context has no deadline set. If the parent already has a shorter deadline,
 // it is returned unchanged.
 func ensureTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if _, ok := ctx.Deadline(); ok {
 		return ctx, func() {}
 	}


### PR DESCRIPTION
## Summary

- Fix panic when running `klaus` with no subcommand: the root command bypassed cobra's context initialization by calling `sessionCmd.RunE(sessionCmd, args)`, causing `cmd.Context()` to return nil
- Add nil-context guards in git and tmux `ensureTimeout` functions as defense in depth

Root cause: PR #227 (subprocess timeouts) added `ensureTimeout` which calls `ctx.Deadline()` — a nil context panics. The root command's direct delegation to `sessionCmd` bypassed cobra's context setup.

## Test plan

- [x] `go build ./...` and `go test ./...` pass
- [x] `klaus` (no args) no longer panics
- [x] `klaus status` still works