### PR TITLE
fix: clean-resume sessions and pin coordinator pane to top

### DIFF
--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -639,6 +639,20 @@ func pinDashboardToBottom(ctx context.Context, currentPane string, store run.Sta
 	if err := tc.SwapPane(ctx, dashPane, lastPane); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: could not pin dashboard to bottom: %v\n", err)
 	}
+
+	// Pin the coordinator pane to the top. After even-vertical rebalancing,
+	// agents may end up above the coordinator.
+	if s.TmuxPane != nil {
+		panes, err = tc.ListWindowPanes(ctx, currentPane)
+		if err == nil && len(panes) > 1 && panes[0] != *s.TmuxPane {
+			for _, p := range panes {
+				if p == *s.TmuxPane {
+					_ = tc.SwapPane(ctx, p, panes[0])
+					break
+				}
+			}
+		}
+	}
 }
 
 func init() {

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -135,13 +135,15 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 	var state *run.State
 
 	if resuming {
-		// Load existing state for the session being resumed
-		state, err = store.Load(id)
+		// Load existing state — only carry forward Claude session ID,
+		// worktree path, and repo root. All ephemeral state (pane IDs,
+		// etc.) starts clean to avoid stale references after tmux restarts.
+		prevState, err := store.Load(id)
 		if err != nil {
 			return fmt.Errorf("loading session state: %w", err)
 		}
-		branch = state.Branch
-		worktree = state.Worktree
+		worktree = prevState.Worktree
+		branch = prevState.Branch
 		if branch != "" {
 			repoName = filepath.Base(filepath.Dir(worktree))
 		} else if inRepo {
@@ -151,15 +153,13 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 		// Verify worktree still exists; recreate if cleaned up
 		if _, statErr := os.Stat(worktree); os.IsNotExist(statErr) {
 			if branch == "" {
-				// Non-repo session: recreate scratch workspace
 				if err := os.MkdirAll(worktree, 0o755); err != nil {
 					return fmt.Errorf("recreating scratch workspace: %w", err)
 				}
 			} else {
-				// Repo session: recreate worktree using the original repo root
 				baseRepo := root
-				if state.RepoRoot != nil && *state.RepoRoot != "" {
-					baseRepo = *state.RepoRoot
+				if prevState.RepoRoot != nil && *prevState.RepoRoot != "" {
+					baseRepo = *prevState.RepoRoot
 				}
 				if baseRepo == "" {
 					return fmt.Errorf("session worktree no longer exists and no repo root available: %s", worktree)
@@ -176,20 +176,19 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 			fmt.Printf("Recreated worktree at %s\n", worktree)
 		}
 
-		// Clear stale tmux pane references and persist immediately
-		modified := false
-		if state.TmuxPane != nil && !tmuxClient.PaneExists(ctx, *state.TmuxPane) {
-			state.TmuxPane = nil
-			modified = true
+		// Build clean state, carrying forward only what matters
+		state = &run.State{
+			ID:              id,
+			Type:            "session",
+			Prompt:          "(interactive session)",
+			Branch:          branch,
+			Worktree:        worktree,
+			CreatedAt:       prevState.CreatedAt,
+			RepoRoot:        prevState.RepoRoot,
+			ClaudeSessionID: prevState.ClaudeSessionID,
 		}
-		if state.DashboardPane != nil && !tmuxClient.PaneExists(ctx, *state.DashboardPane) {
-			state.DashboardPane = nil
-			modified = true
-		}
-		if modified {
-			if err := store.Save(state); err != nil {
-				slog.Warn("failed to save state after clearing stale panes", "id", state.ID, "err", err)
-			}
+		if err := store.Save(state); err != nil {
+			return fmt.Errorf("saving refreshed session state: %w", err)
 		}
 
 		fmt.Printf("Resuming coordinator session %s...\n", id)
@@ -294,22 +293,17 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 	fmt.Println()
 
 	// Launch dashboard in a bottom pane before starting Claude.
-	// If a dashboard pane already exists from a prior run, reuse it.
 	var dashPane string
 	if currentPane != "" {
-		if state.DashboardPane != nil && tmuxClient.PaneExists(ctx, *state.DashboardPane) {
-			dashPane = *state.DashboardPane
+		dashCmd := fmt.Sprintf("KLAUS_SESSION_ID=%s klaus dashboard", id)
+		paneID, err := tmuxClient.SplitWindowSized(ctx, currentPane, worktree, dashCmd, "-v", "30%")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not open dashboard pane: %v\n", err)
 		} else {
-			dashCmd := fmt.Sprintf("KLAUS_SESSION_ID=%s klaus dashboard", id)
-			paneID, err := tmuxClient.SplitWindowSized(ctx, currentPane, worktree, dashCmd, "-v", "30%")
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "warning: could not open dashboard pane: %v\n", err)
-			} else {
-				dashPane = paneID
-				state.DashboardPane = &dashPane
-				if err := store.Save(state); err != nil {
-					fmt.Fprintf(os.Stderr, "warning: could not persist dashboard pane: %v\n", err)
-				}
+			dashPane = paneID
+			state.DashboardPane = &dashPane
+			if err := store.Save(state); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: could not persist dashboard pane: %v\n", err)
 			}
 		}
 	}

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -368,7 +368,18 @@ func waitForAgents(ctx context.Context, store run.StateStore, tc tmux.Client) {
 		return
 	}
 
-	// Collect agent runs that still have live tmux panes, skipping stale ones.
+	// Collect agent runs that still have live tmux panes in our window,
+	// skipping stale ones and panes from recycled tmux IDs.
+	currentPane := os.Getenv("TMUX_PANE")
+	var windowPanes []string
+	if currentPane != "" {
+		windowPanes, _ = tc.ListWindowPanes(ctx, currentPane)
+	}
+	windowPaneSet := make(map[string]bool, len(windowPanes))
+	for _, p := range windowPanes {
+		windowPaneSet[p] = true
+	}
+
 	active := make(map[string]*run.State)
 	for _, s := range states {
 		if s.Type == "session" {
@@ -378,7 +389,7 @@ func waitForAgents(ctx context.Context, store run.StateStore, tc tmux.Client) {
 			fmt.Printf("  agent %s is stale (orphaned), skipping\n", s.ID)
 			continue
 		}
-		if s.TmuxPane != nil && tc.PaneExists(ctx, *s.TmuxPane) {
+		if s.TmuxPane != nil && windowPaneSet[*s.TmuxPane] {
 			active[s.ID] = s
 		}
 	}

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -176,6 +176,19 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 			fmt.Printf("Recreated worktree at %s\n", worktree)
 		}
 
+		// Clear stale tmux pane references from all agent runs in this session.
+		// After a tmux restart, pane IDs recycle and point to unrelated panes.
+		agentStates, _ := store.List()
+		for _, as := range agentStates {
+			if as.Type == "session" || as.TmuxPane == nil {
+				continue
+			}
+			as.TmuxPane = nil
+			if err := store.Save(as); err != nil {
+				slog.Warn("failed to clear stale pane from agent", "id", as.ID, "err", err)
+			}
+		}
+
 		// Build clean state, carrying forward only what matters
 		state = &run.State{
 			ID:              id,
@@ -368,18 +381,7 @@ func waitForAgents(ctx context.Context, store run.StateStore, tc tmux.Client) {
 		return
 	}
 
-	// Collect agent runs that still have live tmux panes in our window,
-	// skipping stale ones and panes from recycled tmux IDs.
-	currentPane := os.Getenv("TMUX_PANE")
-	var windowPanes []string
-	if currentPane != "" {
-		windowPanes, _ = tc.ListWindowPanes(ctx, currentPane)
-	}
-	windowPaneSet := make(map[string]bool, len(windowPanes))
-	for _, p := range windowPanes {
-		windowPaneSet[p] = true
-	}
-
+	// Collect agent runs that still have live tmux panes, skipping stale ones.
 	active := make(map[string]*run.State)
 	for _, s := range states {
 		if s.Type == "session" {
@@ -389,7 +391,7 @@ func waitForAgents(ctx context.Context, store run.StateStore, tc tmux.Client) {
 			fmt.Printf("  agent %s is stale (orphaned), skipping\n", s.ID)
 			continue
 		}
-		if s.TmuxPane != nil && windowPaneSet[*s.TmuxPane] {
+		if s.TmuxPane != nil && tc.PaneExists(ctx, *s.TmuxPane) {
 			active[s.ID] = s
 		}
 	}


### PR DESCRIPTION
## Summary

- **Clean resume**: Session resume now only carries forward `ClaudeSessionID`, worktree path, and repo root. All ephemeral state (pane IDs, dashboard references) starts fresh, eliminating stale reference bugs after tmux server restarts.
- **Pane ordering**: After rebalancing, the coordinator pane is pinned to the top position so agent panes don't appear above it.
- **Dashboard launch simplified**: Removed stale-pane-reuse logic since state always starts clean on resume.

## Test plan

- [x] `go build ./...` and `go test ./...` pass
- [x] Verified tmux split-window still works in current session