### PR TITLE
fix: prevent pipeline dispatch loops and stale worktree accumulation

### DIFF
--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -213,6 +213,19 @@ are synced back after completion. Use --local to force local execution, or
 				return fmt.Errorf("creating worktree: %w", err)
 			}
 		}
+
+		// Clean up the worktree if the launch fails after this point.
+		// This prevents stale worktrees from blocking future dispatch retries.
+		var launchSucceeded bool
+		defer func() {
+			if !launchSucceeded {
+				fmt.Fprintf(os.Stderr, "cleaning up worktree after failed launch: %s\n", worktree)
+				if rmErr := gitClient.WorktreeRemove(ctx, repoRoot, worktree); rmErr != nil {
+					fmt.Fprintf(os.Stderr, "warning: failed to remove worktree %s: %v\n", worktree, rmErr)
+				}
+			}
+		}()
+
 		fmt.Printf("  worktree: %s\n", worktree)
 		fmt.Printf("  branch:   %s\n", branch)
 
@@ -403,6 +416,7 @@ are synced back after completion. Use --local to force local execution, or
 		fmt.Printf("  log:      %s\n", logFile)
 		fmt.Println()
 		fmt.Printf("Agent %s is running. Use 'klaus status' to check progress.\n", id)
+		launchSucceeded = true
 		return nil
 	},
 }

--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -220,7 +220,7 @@ are synced back after completion. Use --local to force local execution, or
 		defer func() {
 			if !launchSucceeded {
 				fmt.Fprintf(os.Stderr, "cleaning up worktree after failed launch: %s\n", worktree)
-				if rmErr := gitClient.WorktreeRemove(ctx, repoRoot, worktree); rmErr != nil {
+				if rmErr := gitClient.WorktreeRemove(context.Background(), repoRoot, worktree); rmErr != nil {
 					fmt.Fprintf(os.Stderr, "warning: failed to remove worktree %s: %v\n", worktree, rmErr)
 				}
 			}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -205,7 +205,7 @@ func (c *Controller) HandleGHStatus(ctx context.Context, statuses map[string]*PR
 			continue
 		}
 
-		ps := c.getOrCreateState(prNum)
+		ps := c.getOrCreateState(prNum, status)
 
 		// Update agent running status.
 		wasRunning := ps.AgentRunning
@@ -344,17 +344,36 @@ func (c *Controller) PipelineStates() map[string]*PRPipelineState {
 	return out
 }
 
-func (c *Controller) getOrCreateState(prNum string) *PRPipelineState {
+func (c *Controller) getOrCreateState(prNum string, status *PRStatus) *PRPipelineState {
 	ps, ok := c.prStates[prNum]
 	if !ok {
+		// Seed initial stage from current GitHub status so that session
+		// resume doesn't force already-progressed PRs back to ci_pending.
+		stage := seedStageFromStatus(status)
 		ps = &PRPipelineState{
 			PRNumber:       prNum,
-			Stage:          StageCIPending,
+			Stage:          stage,
 			SeenCommentIDs: make(map[int64]bool),
 		}
 		c.prStates[prNum] = ps
 	}
 	return ps
+}
+
+// seedStageFromStatus returns an appropriate initial pipeline stage based on
+// the PR's current GitHub status. This prevents merged/closed PRs from
+// re-entering the pipeline as ci_pending on session resume.
+func seedStageFromStatus(status *PRStatus) Stage {
+	switch {
+	case status.State == "MERGED":
+		return StageMerged
+	case status.CI == "passing":
+		return StageCIPassed
+	case status.CI == "failing":
+		return StageCIFailed
+	default:
+		return StageCIPending
+	}
 }
 
 // maxLaunchRetries is the maximum number of agent launch retries before going to StageStalled.

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -361,12 +361,10 @@ func (c *Controller) getOrCreateState(prNum string, status *PRStatus) *PRPipelin
 }
 
 // seedStageFromStatus returns an appropriate initial pipeline stage based on
-// the PR's current GitHub status. This prevents merged/closed PRs from
-// re-entering the pipeline as ci_pending on session resume.
+// the PR's current GitHub status. Merged/closed PRs are filtered out before
+// this function is called, so only open-PR statuses are handled here.
 func seedStageFromStatus(status *PRStatus) Stage {
 	switch {
-	case status.State == "MERGED":
-		return StageMerged
 	case status.CI == "passing":
 		return StageCIPassed
 	case status.CI == "failing":

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -1672,6 +1672,147 @@ func TestIsRunning_DeadPane(t *testing.T) {
 	}
 }
 
+func TestCooldownRespectsLastFailedAt(t *testing.T) {
+	c, _ := newTestController(t)
+
+	launchCount := 0
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
+		launchCount++
+		return "", fmt.Errorf("worktree conflict")
+	})
+
+	statuses := map[string]*PRStatus{
+		"42": {PRNumber: "42", State: "OPEN", CI: "failing", TargetRepo: "owner/repo"},
+	}
+
+	// First call: dispatches and fails.
+	c.HandleGHStatus(context.Background(), statuses, nil)
+	if launchCount != 1 {
+		t.Fatalf("expected 1 launch attempt, got %d", launchCount)
+	}
+
+	// Second call immediately after: cooldown should prevent re-dispatch
+	// because LastFailedAt was just set.
+	c.HandleGHStatus(context.Background(), statuses, nil)
+	if launchCount != 1 {
+		t.Errorf("expected cooldown to block immediate retry, got %d launches", launchCount)
+	}
+
+	// After cooldown expires, retry should be allowed.
+	c.mu.Lock()
+	c.prStates["42"].LastFailedAt = time.Now().Add(-2 * time.Minute)
+	c.mu.Unlock()
+
+	c.HandleGHStatus(context.Background(), statuses, nil)
+	if launchCount != 2 {
+		t.Errorf("expected retry after cooldown expired, got %d launches", launchCount)
+	}
+}
+
+func TestMergedStageIsTerminal(t *testing.T) {
+	c, _ := newTestController(t)
+	c.SetAutoMergeOnApproval(true)
+
+	launchCount := 0
+	mergeCount := 0
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
+		launchCount++
+		return "agent-001", nil
+	})
+	c.SetMergePRs(func(ctx context.Context, repo string, prNumbers []string) error {
+		mergeCount++
+		return nil
+	})
+
+	// Seed a PR directly in StageMerged (simulates post-merge state).
+	c.mu.Lock()
+	c.prStates["38"] = &PRPipelineState{
+		PRNumber:       "38",
+		Stage:          StageMerged,
+		SeenCommentIDs: make(map[int64]bool),
+	}
+	c.mu.Unlock()
+
+	// Even with CI passing and approved status, merged should not transition.
+	statuses := map[string]*PRStatus{
+		"38": {
+			PRNumber: "38", State: "OPEN", CI: "passing",
+			ReviewDecision: "APPROVED", Conflicts: "none", TargetRepo: "owner/repo",
+		},
+	}
+
+	c.HandleGHStatus(context.Background(), statuses, nil)
+
+	state := c.PipelineStates()["38"]
+	if state.Stage != StageMerged {
+		t.Errorf("expected merged to remain terminal, got stage %s", state.Stage)
+	}
+	if launchCount != 0 {
+		t.Errorf("expected no agent launch for merged PR, got %d", launchCount)
+	}
+	if mergeCount != 0 {
+		t.Errorf("expected no merge attempt for merged PR, got %d", mergeCount)
+	}
+}
+
+func TestSessionResumeSeedsFromGitHubStatus(t *testing.T) {
+	c, _ := newTestController(t)
+
+	launchCount := 0
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
+		launchCount++
+		return "agent-001", nil
+	})
+
+	// Simulate session resume: prStates is empty, but PR is already passing CI.
+	statuses := map[string]*PRStatus{
+		"50": {PRNumber: "50", State: "OPEN", CI: "passing", TargetRepo: "owner/repo"},
+	}
+
+	c.HandleGHStatus(context.Background(), statuses, nil)
+
+	state := c.PipelineStates()["50"]
+	if state == nil {
+		t.Fatal("expected PR 50 to be tracked")
+	}
+	// A passing PR on session resume should seed as ci_passed, not ci_pending.
+	if state.Stage != StageCIPassed {
+		t.Errorf("expected ci_passed on resume with passing CI, got %s", state.Stage)
+	}
+	// Should not have dispatched any agent (CI is passing, no review issues).
+	if launchCount != 0 {
+		t.Errorf("expected no agent launch for passing PR on resume, got %d", launchCount)
+	}
+}
+
+func TestSessionResumeFailingCISeedsCorrectly(t *testing.T) {
+	c, _ := newTestController(t)
+
+	launchCount := 0
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
+		launchCount++
+		return "agent-fix", nil
+	})
+
+	// Session resume with a failing CI PR.
+	statuses := map[string]*PRStatus{
+		"51": {PRNumber: "51", State: "OPEN", CI: "failing", TargetRepo: "owner/repo"},
+	}
+
+	c.HandleGHStatus(context.Background(), statuses, nil)
+
+	state := c.PipelineStates()["51"]
+	if state == nil {
+		t.Fatal("expected PR 51 to be tracked")
+	}
+	if state.Stage != StageCIFailed {
+		t.Errorf("expected ci_failed after handling failing CI, got %s", state.Stage)
+	}
+	if launchCount != 1 {
+		t.Errorf("expected 1 agent launch for failing CI, got %d", launchCount)
+	}
+}
+
 func strPtr(s string) *string {
 	return &s
 }

--- a/internal/pipeline/transitions.go
+++ b/internal/pipeline/transitions.go
@@ -20,6 +20,15 @@ type transition struct {
 
 // transitions is the ordered list of pipeline rules. First match wins.
 var transitions = []transition{
+	// ── Terminal: merged PRs must not be re-processed ───────────────────
+	{
+		Name:  "terminal/merged",
+		Guard: inStage(StageMerged),
+		Apply: func(_ *Controller, _ *PRPipelineState, _ *PRStatus, _ []*run.State) ([]Action, []ActionDescriptor) {
+			return nil, nil
+		},
+	},
+
 	// ── CI failing ──────────────────────────────────────────────────────
 
 	{
@@ -427,6 +436,12 @@ func agentNotRunning(_ *Controller, ps *PRPipelineState, _ *PRStatus, _ []*run.S
 }
 
 func cooldownExpired(_ *Controller, ps *PRPipelineState, _ *PRStatus, _ []*run.State) bool {
+	// Check both LastDispatchAt (set on success) and LastFailedAt (set on failure).
+	// Without checking LastFailedAt, a failed dispatch allows immediate re-evaluation
+	// because LastDispatchAt is never updated on failure.
+	if !ps.LastFailedAt.IsZero() && time.Since(ps.LastFailedAt) <= dispatchCooldown {
+		return false
+	}
 	return time.Since(ps.LastDispatchAt) > dispatchCooldown
 }
 


### PR DESCRIPTION
## Summary

- **Dispatch backoff**: `cooldownExpired` guard now checks `LastFailedAt` in addition to `LastDispatchAt`, preventing rapid-fire retry loops after dispatch failures
- **Terminal merged state**: `StageMerged` is now a terminal state via a top-of-table transition guard, breaking the `merged → merging` loop
- **Session resume seeding**: `getOrCreateState` seeds initial pipeline stage from current GitHub status, so resumed sessions don't force already-progressed PRs back to `ci_pending`
- **Worktree cleanup on failed launch**: Launch command defers worktree removal if the launch fails after worktree creation, preventing stale worktrees from blocking future retries

## Test plan

- [x] `TestCooldownRespectsLastFailedAt` — verifies cooldown blocks immediate retry after failure, allows retry after expiry
- [x] `TestMergedStageIsTerminal` — verifies merged PRs cannot transition to merging even with passing CI + approval
- [x] `TestSessionResumeSeedsFromGitHubStatus` — verifies new PRs with passing CI seed as `ci_passed` not `ci_pending`
- [x] `TestSessionResumeFailingCISeedsCorrectly` — verifies new PRs with failing CI seed as `ci_failed`
- [x] All existing tests pass (`go test ./...`)

Run: 20260414-0836-778d
Fixes #231