### PR TITLE
docs: add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # klaus
 
-[![CI](https://github.com/patflynn/klaus/actions/workflows/ci.yml/badge.svg)](https://github.com/patflynn/klaus/actions/workflows/ci.yml)
+[![Build Status](https://github.com/patflynn/klaus/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/patflynn/klaus/actions/workflows/ci.yml)
 
 Multi-agent orchestrator for [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Start a normal Claude Code session that can fan out work to parallel autonomous agents, each in its own git worktree and tmux pane.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # klaus
 
+[![CI](https://github.com/patflynn/klaus/actions/workflows/ci.yml/badge.svg)](https://github.com/patflynn/klaus/actions/workflows/ci.yml)
+
 Multi-agent orchestrator for [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Start a normal Claude Code session that can fan out work to parallel autonomous agents, each in its own git worktree and tmux pane.
 
 ## Quick start


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI status badge to the top of README.md, right after the title heading

## Test plan
- [x] Verify badge markdown renders correctly
- [x] Badge links to CI workflow runs page
- [x] No other README changes

Run: 20260414-1037-5ba4
Fixes #58