### PR TITLE
fix: auto-recover stale worktrees blocking PR branch relaunch

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -59,7 +59,7 @@ func WorktreeAdd(ctx context.Context, repoDir, path, branch, startPoint string) 
 	if err == nil {
 		return nil
 	}
-	return retryAfterPrune(ctx, repoDir, branch, err, func() error {
+	return retryAfterPrune(ctx, repoDir, branch, err, false, func() error {
 		// Use -B on retry: after pruning a stale worktree the branch ref remains,
 		// so -b (create new) would fail with "branch already exists".
 		_, e := runGit(ctx, repoDir, "worktree", "add", path, "-B", branch, startPoint, "--quiet")
@@ -81,7 +81,7 @@ func WorktreeAddTrack(ctx context.Context, repoDir, path, branch string) error {
 	if err == nil {
 		return nil
 	}
-	return retryAfterPrune(ctx, repoDir, branch, err, func() error {
+	return retryAfterPrune(ctx, repoDir, branch, err, true, func() error {
 		_, e := runGit(ctx, repoDir, "worktree", "add", "-B", branch, path, "origin/"+branch, "--quiet")
 		return e
 	})
@@ -119,8 +119,9 @@ func worktreePathForBranch(ctx context.Context, repoDir, branch string) string {
 
 // retryAfterPrune handles "already used by worktree" errors. If the conflicting
 // worktree is stale (path no longer exists on disk), it prunes and retries.
-// If the worktree is still live, it returns a clear error.
-func retryAfterPrune(ctx context.Context, repoDir, branch string, origErr error, retry func() error) error {
+// If forceRemoveLive is true and the worktree directory still exists, it
+// force-removes the old worktree before retrying. Otherwise it returns a clear error.
+func retryAfterPrune(ctx context.Context, repoDir, branch string, origErr error, forceRemoveLive bool, retry func() error) error {
 	// Check whether this branch is recorded in any worktree.
 	wtPath := worktreePathForBranch(ctx, repoDir, branch)
 	if wtPath == "" {
@@ -128,9 +129,16 @@ func retryAfterPrune(ctx context.Context, repoDir, branch string, origErr error,
 		return origErr
 	}
 
-	// If the worktree directory still exists, the worktree is live — don't touch it.
 	if _, err := os.Stat(wtPath); err == nil {
-		return fmt.Errorf("branch %q is already checked out in active worktree %q; remove it first with: git worktree remove %s", branch, wtPath, wtPath)
+		// Worktree directory still exists on disk.
+		if !forceRemoveLive {
+			return fmt.Errorf("branch %q is already checked out in active worktree %q; remove it first with: git worktree remove %s", branch, wtPath, wtPath)
+		}
+		// Force-remove the old worktree so we can reuse the branch.
+		if err := WorktreeRemove(ctx, repoDir, wtPath); err != nil {
+			return fmt.Errorf("removing existing worktree %q: %w (original error: %v)", wtPath, err, origErr)
+		}
+		return retry()
 	}
 
 	// Worktree directory is gone — prune stale entries and retry.

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -604,6 +604,57 @@ func TestWorktreeAddTrack_PrunesStaleAndRetries(t *testing.T) {
 	}
 }
 
+func TestWorktreeAddTrack_ForceRemovesLiveWorktree(t *testing.T) {
+	ctx := context.Background()
+	repo := initTestRepo(t)
+
+	// Create a local bare repo as "origin" with a feature branch
+	bareDir := filepath.Join(t.TempDir(), "bare.git")
+	cmd := exec.Command("git", "clone", "--bare", repo, bareDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("bare clone: %v\n%s", err, out)
+	}
+	if _, err := runGit(ctx, repo, "remote", "add", "origin", bareDir); err != nil {
+		runGit(ctx, repo, "remote", "set-url", "origin", bareDir)
+	}
+
+	// Create and push a feature branch
+	if _, err := runGit(ctx, repo, "branch", "feature-y"); err != nil {
+		t.Fatalf("branch: %v", err)
+	}
+	if _, err := runGit(ctx, repo, "push", "origin", "feature-y"); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+
+	// Create a worktree tracking origin/feature-y (simulates a previous agent run)
+	oldPath := filepath.Join(t.TempDir(), "old-worktree")
+	if err := WorktreeAddTrack(ctx, repo, oldPath, "feature-y"); err != nil {
+		t.Fatalf("WorktreeAddTrack (setup): %v", err)
+	}
+
+	// Directory still exists — simulates incomplete cleanup
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Fatalf("old worktree should exist: %v", err)
+	}
+
+	// Creating a new worktree for the same branch should auto-recover
+	newPath := filepath.Join(t.TempDir(), "new-worktree")
+	if err := WorktreeAddTrack(ctx, repo, newPath, "feature-y"); err != nil {
+		t.Fatalf("WorktreeAddTrack should auto-remove live worktree and succeed: %v", err)
+	}
+	defer WorktreeRemove(ctx, repo, newPath)
+
+	// Old worktree should be gone
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Error("old worktree directory should have been removed")
+	}
+
+	// New worktree should be functional
+	if _, err := os.Stat(filepath.Join(newPath, "README.md")); err != nil {
+		t.Errorf("new worktree should contain README.md: %v", err)
+	}
+}
+
 func TestWorktreeAdd_LiveWorktreeReturnsError(t *testing.T) {
 	ctx := context.Background()
 	repo := initTestRepo(t)


### PR DESCRIPTION
## Summary
- When a previous agent's worktree isn't fully cleaned up (crash, kill, etc.), `WorktreeAddTrack` now force-removes the old worktree and retries instead of erroring out
- Added `forceRemoveLive` parameter to `retryAfterPrune` — enabled for `WorktreeAddTrack` (which uses `-B` to reset the branch anyway), disabled for `WorktreeAdd` to preserve its existing safety behavior
- Added integration test verifying the auto-recovery: creates a worktree, then calls `WorktreeAddTrack` again on the same branch and confirms the old worktree is removed and the new one is functional

## Test plan
- [x] `TestWorktreeAddTrack_ForceRemovesLiveWorktree` — new test covering the fix
- [x] `TestWorktreeAddTrack_PrunesStaleAndRetries` — existing stale worktree test still passes
- [x] `TestWorktreeAdd_LiveWorktreeReturnsError` — existing test confirming `WorktreeAdd` still errors on live worktrees
- [x] Full `go test ./...` passes

Run: 20260414-2048-705a
Fixes #231