### PR TITLE
fix: kill agent tmux panes on finalize

### DIFF
--- a/internal/cmd/hidden.go
+++ b/internal/cmd/hidden.go
@@ -15,6 +15,7 @@ import (
 	"github.com/patflynn/klaus/internal/run"
 	"github.com/patflynn/klaus/internal/scan"
 	"github.com/patflynn/klaus/internal/stream"
+	"github.com/patflynn/klaus/internal/tmux"
 	"github.com/spf13/cobra"
 )
 
@@ -99,6 +100,10 @@ var finalizeCmd = &cobra.Command{
 
 		cleanupWorktree(ctx, store, gitClient, state)
 
+		// Kill the tmux pane — _finalize is the last command in the pipeline,
+		// so this is safe. The pane would otherwise stay open indefinitely.
+		killAgentPane(ctx, store, tmux.NewExecClient(), state)
+
 		return nil
 	},
 }
@@ -130,6 +135,22 @@ func cleanupWorktree(ctx context.Context, store run.StateStore, gitClient git.Cl
 	state.Worktree = ""
 	if err := store.Save(state); err != nil {
 		slog.Warn("failed to save state after worktree cleanup", "id", state.ID, "err", err)
+	}
+}
+
+// killAgentPane kills the tmux pane associated with the agent. This must
+// be called after all state writes and worktree cleanup are complete,
+// since _finalize runs inside the pane itself.
+func killAgentPane(ctx context.Context, store run.StateStore, tc tmux.Client, state *run.State) {
+	if state.TmuxPane == nil {
+		return
+	}
+	if err := tc.KillPane(ctx, *state.TmuxPane); err != nil {
+		slog.Warn("failed to kill agent pane", "id", state.ID, "pane", *state.TmuxPane, "err", err)
+	}
+	state.TmuxPane = nil
+	if err := store.Save(state); err != nil {
+		slog.Warn("failed to save state after pane cleanup", "id", state.ID, "err", err)
 	}
 }
 

--- a/internal/cmd/hidden.go
+++ b/internal/cmd/hidden.go
@@ -138,19 +138,21 @@ func cleanupWorktree(ctx context.Context, store run.StateStore, gitClient git.Cl
 	}
 }
 
-// killAgentPane kills the tmux pane associated with the agent. This must
-// be called after all state writes and worktree cleanup are complete,
-// since _finalize runs inside the pane itself.
+// killAgentPane kills the tmux pane associated with the agent. State is
+// saved before the pane is killed because _finalize runs inside the pane
+// itself — killing the pane first would terminate the process before the
+// state save executes.
 func killAgentPane(ctx context.Context, store run.StateStore, tc tmux.Client, state *run.State) {
 	if state.TmuxPane == nil {
 		return
 	}
-	if err := tc.KillPane(ctx, *state.TmuxPane); err != nil {
-		slog.Warn("failed to kill agent pane", "id", state.ID, "pane", *state.TmuxPane, "err", err)
-	}
+	paneID := *state.TmuxPane
 	state.TmuxPane = nil
 	if err := store.Save(state); err != nil {
-		slog.Warn("failed to save state after pane cleanup", "id", state.ID, "err", err)
+		slog.Warn("failed to save state before pane cleanup", "id", state.ID, "err", err)
+	}
+	if err := tc.KillPane(ctx, paneID); err != nil {
+		slog.Warn("failed to kill agent pane", "id", state.ID, "pane", paneID, "err", err)
 	}
 }
 

--- a/internal/cmd/hidden_test.go
+++ b/internal/cmd/hidden_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/patflynn/klaus/internal/git"
 	"github.com/patflynn/klaus/internal/run"
+	"github.com/patflynn/klaus/internal/tmux"
 )
 
 func TestFinalizeWorktreeCleanup(t *testing.T) {
@@ -111,6 +112,48 @@ func runGitCmd(t *testing.T, dir string, args ...string) {
 	if err != nil {
 		t.Fatalf("git %v failed: %v\n%s", args, err, out)
 	}
+}
+
+func TestKillAgentPane(t *testing.T) {
+	paneID := "%42"
+
+	t.Run("kills pane and clears state", func(t *testing.T) {
+		state := &run.State{ID: "test-run", TmuxPane: &paneID}
+		store := &testStateStore{state: state}
+		tc := &fakeTmux{killedPanes: []string{}}
+
+		killAgentPane(context.Background(), store, tc, state)
+
+		if len(tc.killedPanes) != 1 || tc.killedPanes[0] != paneID {
+			t.Errorf("expected KillPane(%q), got %v", paneID, tc.killedPanes)
+		}
+		if state.TmuxPane != nil {
+			t.Errorf("expected TmuxPane to be nil, got %v", *state.TmuxPane)
+		}
+	})
+
+	t.Run("no-op when TmuxPane is nil", func(t *testing.T) {
+		state := &run.State{ID: "test-run", TmuxPane: nil}
+		store := &testStateStore{state: state}
+		tc := &fakeTmux{}
+
+		killAgentPane(context.Background(), store, tc, state)
+
+		if len(tc.killedPanes) != 0 {
+			t.Errorf("expected no KillPane calls, got %v", tc.killedPanes)
+		}
+	})
+}
+
+// fakeTmux is a minimal tmux.Client for testing killAgentPane.
+type fakeTmux struct {
+	tmux.ExecClient
+	killedPanes []string
+}
+
+func (f *fakeTmux) KillPane(_ context.Context, id string) error {
+	f.killedPanes = append(f.killedPanes, id)
+	return nil
 }
 
 func TestExtractPRNumberFromURL(t *testing.T) {


### PR DESCRIPTION
## Summary
- Agent tmux panes were never killed after `_finalize` completed, causing pane accumulation in the dashboard
- Added `killAgentPane` at the end of finalize (after all state writes and worktree cleanup) to kill the pane and clear the state reference
- Existing pane-killing in `cleanup.go` and `session.go` is preserved as fallback

## Test plan
- [x] `TestKillAgentPane` verifies KillPane is called with correct pane ID and TmuxPane is set to nil
- [x] `TestKillAgentPane` verifies no-op when TmuxPane is nil
- [x] All existing tests pass (`go test ./...`)

Run: 20260414-2106-e2ab
Fixes #231