### PR TITLE
fix: don't block on agent completion when user exits Claude

### DIFF
--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -7,10 +7,11 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 	"time"
 
-	"github.com/fsnotify/fsnotify"
 	"github.com/patflynn/klaus/internal/config"
 	"github.com/patflynn/klaus/internal/git"
 	"github.com/patflynn/klaus/internal/nix"
@@ -21,9 +22,7 @@ import (
 )
 
 const (
-	klausSessionIDEnv  = "KLAUS_SESSION_ID"
-	agentWaitTimeout   = 30 * time.Minute
-	agentPollFallback  = 10 * time.Second
+	klausSessionIDEnv = "KLAUS_SESSION_ID"
 )
 
 var sessionCmd = &cobra.Command{
@@ -354,12 +353,20 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 	fmt.Println()
 	fmt.Printf("Session %s ended.\n", id)
 
-	// Wait for any running agents to finish, then clean up their panes
-	waitForAgents(ctx, store, tmuxClient)
+	// Install signal handler so Ctrl+C during post-exit work exits promptly.
+	sigCtx, sigStop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer sigStop()
+
+	// Check for running agents and print a summary instead of blocking.
+	running := checkRunningAgents(sigCtx, store, tmuxClient)
 
 	if dashPane != "" {
-		if err := tmuxClient.KillPane(ctx, dashPane); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: could not kill dashboard pane %s: %v\n", dashPane, err)
+		if len(running) > 0 {
+			fmt.Println("Dashboard pane left open to monitor running agents.")
+		} else {
+			if err := tmuxClient.KillPane(sigCtx, dashPane); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: could not kill dashboard pane %s: %v\n", dashPane, err)
+			}
 		}
 	}
 
@@ -370,150 +377,41 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 	return nil
 }
 
-// waitForAgents watches state files for changes and waits for active agent
-// panes to finish before returning. Uses fsnotify to react to state file
-// updates instead of polling, with a fallback poll for tmux pane exits that
-// don't trigger file changes. Times out after agentWaitTimeout to prevent
-// the session from hanging indefinitely.
-func waitForAgents(ctx context.Context, store run.StateStore, tc tmux.Client) {
+// checkRunningAgents inspects agent states and returns those still running
+// in tmux panes. It prints a summary so the user knows what's still active.
+// It does not block — agents continue in their tmux panes independently.
+func checkRunningAgents(ctx context.Context, store run.StateStore, tc tmux.Client) []*run.State {
 	states, err := store.List()
 	if err != nil {
-		return
+		return nil
 	}
 
-	// Collect agent runs that still have live tmux panes, skipping stale ones.
-	active := make(map[string]*run.State)
-	for _, s := range states {
-		if s.Type == "session" {
-			continue
-		}
-		if s.IsStale() {
-			fmt.Printf("  agent %s is stale (orphaned), skipping\n", s.ID)
-			continue
-		}
-		if s.TmuxPane != nil && tc.PaneExists(ctx, *s.TmuxPane) {
-			active[s.ID] = s
-		}
-	}
-
-	if len(active) == 0 {
-		return
-	}
-
-	fmt.Printf("Waiting for %d agent(s) to finish...\n", len(active))
-
-	// Set up fsnotify watcher on the state directory.
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		slog.Warn("failed to create file watcher, falling back to polling", "err", err)
-		waitForAgentsPoll(ctx, store, tc, active)
-		return
-	}
-	defer watcher.Close()
-
-	stateDir := store.StateDir()
-	if err := watcher.Add(stateDir); err != nil {
-		slog.Warn("failed to watch state dir, falling back to polling", "dir", stateDir, "err", err)
-		waitForAgentsPoll(ctx, store, tc, active)
-		return
-	}
-
-	timeout := time.After(agentWaitTimeout)
-	// Fallback ticker catches tmux pane exits that don't write state files.
-	fallbackTicker := time.NewTicker(agentPollFallback)
-	defer fallbackTicker.Stop()
-
-	for len(active) > 0 {
-		select {
-		case <-ctx.Done():
-			return
-
-		case <-timeout:
-			var names []string
-			for id := range active {
-				names = append(names, id)
-			}
-			fmt.Printf("Timed out after %s waiting for agents: %v\n", agentWaitTimeout, names)
-			fmt.Println("These agents may still be running in their tmux panes.")
-			return
-
-		case event, ok := <-watcher.Events:
-			if !ok {
-				return
-			}
-			// Only react to state file writes.
-			if filepath.Ext(event.Name) != ".json" {
-				continue
-			}
-			reapFinishedAgents(ctx, store, tc, active)
-
-		case err, ok := <-watcher.Errors:
-			if !ok {
-				return
-			}
-			slog.Debug("ignoring transient watcher error", "err", err)
-
-		case <-fallbackTicker.C:
-			reapFinishedAgents(ctx, store, tc, active)
-		}
-	}
-
-	fmt.Println("All agents finished.")
-}
-
-// reapFinishedAgents checks each active agent and removes those that are
-// no longer running, killing their tmux panes.
-func reapFinishedAgents(ctx context.Context, store run.StateStore, tc tmux.Client, active map[string]*run.State) {
 	td := run.TmuxDeps{
 		PaneExists: func(id string) bool { return tc.PaneExists(ctx, id) },
 		PaneIsIdle: func(id string) bool { return tc.PaneIsIdle(ctx, id) },
 		PaneIsDead: func(id string) bool { return tc.PaneIsDead(ctx, id) },
 	}
 
-	for id, s := range active {
-		if updated, err := store.Load(id); err == nil {
-			s = updated
+	var running []*run.State
+	for _, s := range states {
+		if s.Type == "session" {
+			continue
 		}
-
-		if !s.IsAgentRunningWith(td) {
-			if s.TmuxPane != nil && tc.PaneExists(ctx, *s.TmuxPane) {
-				fmt.Printf("  agent %s finished, closing pane\n", s.ID)
-				if err := tc.KillPane(ctx, *s.TmuxPane); err != nil {
-					slog.Warn("failed to kill agent pane", "id", s.ID, "pane", *s.TmuxPane, "err", err)
-				}
-			} else {
-				fmt.Printf("  agent %s finished\n", s.ID)
-			}
-			delete(active, id)
-		}
-	}
-}
-
-// waitForAgentsPoll is the fallback polling loop used when fsnotify cannot
-// be set up.
-func waitForAgentsPoll(ctx context.Context, store run.StateStore, tc tmux.Client, active map[string]*run.State) {
-	timeout := time.After(agentWaitTimeout)
-	ticker := time.NewTicker(agentPollFallback)
-	defer ticker.Stop()
-
-	for len(active) > 0 {
-		select {
-		case <-ctx.Done():
-			return
-		case <-timeout:
-			var names []string
-			for id := range active {
-				names = append(names, id)
-			}
-			fmt.Printf("Timed out after %s waiting for agents: %v\n", agentWaitTimeout, names)
-			fmt.Println("These agents may still be running in their tmux panes.")
-			return
-		case <-ticker.C:
-			reapFinishedAgents(ctx, store, tc, active)
+		if s.TmuxPane != nil && tc.PaneExists(ctx, *s.TmuxPane) && s.IsAgentRunningWith(td) {
+			running = append(running, s)
 		}
 	}
 
-	fmt.Println("All agents finished.")
+	if len(running) == 0 {
+		fmt.Println("No agents running.")
+		return nil
+	}
+
+	fmt.Printf("%d agent(s) still running:\n", len(running))
+	for _, s := range running {
+		fmt.Printf("  - %s (pane %s)\n", s.ID, *s.TmuxPane)
+	}
+	return running
 }
 
 // genUUIDv4 returns a random UUID v4 string, or "" on error.

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -383,6 +383,7 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 func checkRunningAgents(ctx context.Context, store run.StateStore, tc tmux.Client) []*run.State {
 	states, err := store.List()
 	if err != nil {
+		slog.Warn("failed to list agent states", "err", err)
 		return nil
 	}
 
@@ -394,10 +395,13 @@ func checkRunningAgents(ctx context.Context, store run.StateStore, tc tmux.Clien
 
 	var running []*run.State
 	for _, s := range states {
+		if ctx.Err() != nil {
+			break
+		}
 		if s.Type == "session" {
 			continue
 		}
-		if s.TmuxPane != nil && tc.PaneExists(ctx, *s.TmuxPane) && s.IsAgentRunningWith(td) {
+		if s.IsAgentRunningWith(td) {
 			running = append(running, s)
 		}
 	}

--- a/internal/cmd/session_test.go
+++ b/internal/cmd/session_test.go
@@ -243,126 +243,7 @@ func (s *stubTmuxClient) KillPane(_ context.Context, id string) error {
 	return nil
 }
 
-func TestWaitForAgents_ContextCancellation(t *testing.T) {
-	// Set up a store with an active agent.
-	tmpDir := t.TempDir()
-	store := run.NewHomeDirStoreFromPath(tmpDir)
-	if err := store.EnsureDirs(); err != nil {
-		t.Fatal(err)
-	}
-
-	pane := "%99"
-	state := &run.State{
-		ID:        "agent-test-cancel",
-		Type:      "agent",
-		TmuxPane:  &pane,
-		CreatedAt: time.Now().Format(time.RFC3339),
-	}
-	if err := store.Save(state); err != nil {
-		t.Fatal(err)
-	}
-
-	tc := &stubTmuxClient{existingPanes: map[string]bool{"%99": true}}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	// Cancel immediately so waitForAgents returns quickly.
-	cancel()
-
-	done := make(chan struct{})
-	go func() {
-		waitForAgents(ctx, store, tc)
-		close(done)
-	}()
-
-	select {
-	case <-done:
-		// Good -- returned promptly on context cancel.
-	case <-time.After(5 * time.Second):
-		t.Fatal("waitForAgents did not return after context cancellation")
-	}
-}
-
-func TestWaitForAgents_FsnotifyDetectsCompletion(t *testing.T) {
-	tmpDir := t.TempDir()
-	store := run.NewHomeDirStoreFromPath(tmpDir)
-	if err := store.EnsureDirs(); err != nil {
-		t.Fatal(err)
-	}
-
-	pane := "%50"
-	state := &run.State{
-		ID:        "agent-fsnotify-test",
-		Type:      "agent",
-		TmuxPane:  &pane,
-		CreatedAt: time.Now().Format(time.RFC3339),
-	}
-	if err := store.Save(state); err != nil {
-		t.Fatal(err)
-	}
-
-	tc := &stubTmuxClient{existingPanes: map[string]bool{"%50": true}}
-
-	ctx := context.Background()
-	done := make(chan struct{})
-	go func() {
-		waitForAgents(ctx, store, tc)
-		close(done)
-	}()
-
-	// Give fsnotify time to set up the watcher.
-	time.Sleep(100 * time.Millisecond)
-
-	// Simulate the agent finishing: remove the pane from the mock and
-	// write the state file to trigger fsnotify.
-	delete(tc.existingPanes, "%50")
-	state.CostUSD = new(float64)
-	*state.CostUSD = 0.05
-	if err := store.Save(state); err != nil {
-		t.Fatal(err)
-	}
-
-	select {
-	case <-done:
-		// Good -- detected completion via fsnotify.
-	case <-time.After(5 * time.Second):
-		t.Fatal("waitForAgents did not detect agent completion via fsnotify")
-	}
-}
-
-func TestWaitForAgents_NoActiveAgents(t *testing.T) {
-	tmpDir := t.TempDir()
-	store := run.NewHomeDirStoreFromPath(tmpDir)
-	if err := store.EnsureDirs(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Save a session (should be skipped) and no agents with live panes.
-	state := &run.State{
-		ID:        "session-skip",
-		Type:      "session",
-		CreatedAt: time.Now().Format(time.RFC3339),
-	}
-	if err := store.Save(state); err != nil {
-		t.Fatal(err)
-	}
-
-	tc := &stubTmuxClient{existingPanes: map[string]bool{}}
-
-	done := make(chan struct{})
-	go func() {
-		waitForAgents(context.Background(), store, tc)
-		close(done)
-	}()
-
-	select {
-	case <-done:
-		// Returns immediately when no active agents.
-	case <-time.After(2 * time.Second):
-		t.Fatal("waitForAgents should return immediately with no active agents")
-	}
-}
-
-func TestReapFinishedAgents(t *testing.T) {
+func TestCheckRunningAgents_ReturnsRunning(t *testing.T) {
 	tmpDir := t.TempDir()
 	store := run.NewHomeDirStoreFromPath(tmpDir)
 	if err := store.EnsureDirs(); err != nil {
@@ -371,14 +252,14 @@ func TestReapFinishedAgents(t *testing.T) {
 
 	pane1 := "%10"
 	pane2 := "%11"
-	// Agent 1: pane still exists (still running).
+	// Agent 1: pane exists → running.
 	s1 := &run.State{
 		ID:        "agent-running",
 		Type:      "agent",
 		TmuxPane:  &pane1,
 		CreatedAt: time.Now().Format(time.RFC3339),
 	}
-	// Agent 2: pane gone (finished).
+	// Agent 2: pane gone → not running.
 	s2 := &run.State{
 		ID:        "agent-done",
 		Type:      "agent",
@@ -393,18 +274,100 @@ func TestReapFinishedAgents(t *testing.T) {
 	}
 
 	tc := &stubTmuxClient{existingPanes: map[string]bool{"%10": true}}
-	active := map[string]*run.State{
-		s1.ID: s1,
-		s2.ID: s2,
+	running := checkRunningAgents(context.Background(), store, tc)
+
+	if len(running) != 1 {
+		t.Fatalf("expected 1 running agent, got %d", len(running))
+	}
+	if running[0].ID != "agent-running" {
+		t.Errorf("expected agent-running, got %s", running[0].ID)
+	}
+}
+
+func TestCheckRunningAgents_NoAgents(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := run.NewHomeDirStoreFromPath(tmpDir)
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatal(err)
 	}
 
-	reapFinishedAgents(context.Background(), store, tc, active)
-
-	if _, ok := active["agent-done"]; ok {
-		t.Error("agent-done should have been reaped")
+	// Save a session (should be skipped).
+	state := &run.State{
+		ID:        "session-skip",
+		Type:      "session",
+		CreatedAt: time.Now().Format(time.RFC3339),
 	}
-	if _, ok := active["agent-running"]; !ok {
-		t.Error("agent-running should still be active")
+	if err := store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+
+	tc := &stubTmuxClient{existingPanes: map[string]bool{}}
+	running := checkRunningAgents(context.Background(), store, tc)
+
+	if len(running) != 0 {
+		t.Errorf("expected no running agents, got %d", len(running))
+	}
+}
+
+func TestCheckRunningAgents_SkipsSessions(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := run.NewHomeDirStoreFromPath(tmpDir)
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	pane := "%20"
+	// A session with a live pane should not be counted as a running agent.
+	state := &run.State{
+		ID:        "session-live",
+		Type:      "session",
+		TmuxPane:  &pane,
+		CreatedAt: time.Now().Format(time.RFC3339),
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+
+	tc := &stubTmuxClient{existingPanes: map[string]bool{"%20": true}}
+	running := checkRunningAgents(context.Background(), store, tc)
+
+	if len(running) != 0 {
+		t.Errorf("expected no running agents (session should be skipped), got %d", len(running))
+	}
+}
+
+func TestCheckRunningAgents_NonBlocking(t *testing.T) {
+	// Verify checkRunningAgents returns immediately even with active agents.
+	tmpDir := t.TempDir()
+	store := run.NewHomeDirStoreFromPath(tmpDir)
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	pane := "%99"
+	state := &run.State{
+		ID:        "agent-active",
+		Type:      "agent",
+		TmuxPane:  &pane,
+		CreatedAt: time.Now().Format(time.RFC3339),
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatal(err)
+	}
+
+	tc := &stubTmuxClient{existingPanes: map[string]bool{"%99": true}}
+
+	done := make(chan struct{})
+	go func() {
+		checkRunningAgents(context.Background(), store, tc)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Good — returned immediately without blocking.
+	case <-time.After(2 * time.Second):
+		t.Fatal("checkRunningAgents blocked instead of returning immediately")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replace the blocking `waitForAgents` loop (30min timeout) with a non-blocking `checkRunningAgents` that prints a summary of active agents and exits immediately
- Agents continue running in their tmux panes; dashboard pane stays open if agents are still active, gets cleaned up if not
- Install a signal handler (SIGINT/SIGTERM) on the post-exit path so Ctrl+C always works
- Remove `waitForAgentsPoll` and `reapFinishedAgents` (no longer needed)

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all tests pass
- [x] `klaus _pre-review` passes (no critical/high findings)
- [x] New tests: `TestCheckRunningAgents_ReturnsRunning`, `TestCheckRunningAgents_NoAgents`, `TestCheckRunningAgents_SkipsSessions`, `TestCheckRunningAgents_NonBlocking`

Run: 20260418-2148-8883
Fixes #238