### PR TITLE
Background sync registered projects on session/launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The coordinator session uses these — you generally don't run them directly:
 | `klaus project list` | Show registered projects |
 | `klaus project remove <name>` | Unregister a project |
 | `klaus project set-dir <path>` | Set the default projects directory |
+| `klaus sync` | Fetch and fast-forward every registered project |
 | `klaus new <project-name>` | Scaffold a new project using principles-based generation |
 | `klaus webhook check` | Check registered projects for GitHub webhook configuration |
 | `klaus webhook setup [project]` | Create missing webhooks for registered projects |

--- a/internal/cmd/dashboard_test.go
+++ b/internal/cmd/dashboard_test.go
@@ -864,24 +864,11 @@ func TestWebhookMsgTriggersRefetchForMatchedPR(t *testing.T) {
 		t.Fatal("expected tea.BatchMsg from webhook handler")
 	}
 
-	// Run each sub-command with a timeout to avoid blocking on channel reads.
-	foundFetch := false
-	for _, sub := range bm {
-		if sub == nil {
-			continue
-		}
-		done := make(chan tea.Msg, 1)
-		go func(c tea.Cmd) { done <- c() }(sub)
-		select {
-		case r := <-done:
-			if _, ok := r.(ghStatusMsg); ok {
-				foundFetch = true
-			}
-		case <-time.After(2 * time.Second):
-			// This is the blocking waitForWebhookCmd — skip it.
-		}
-	}
-	if !foundFetch {
+	// Run all sub-commands concurrently; one is waitForWebhookCmd which
+	// blocks forever (the channel is empty), so we wait on a shared result
+	// channel with a generous timeout rather than per-iteration. A tight
+	// timeout per sub-command races the real gh CLI on slow CI runners.
+	if !awaitGHStatusMsg(bm, 15*time.Second) {
 		t.Error("expected ghStatusMsg from webhook-triggered fetch")
 	}
 }
@@ -948,24 +935,32 @@ func TestWebhookPushTriggersFullRefetch(t *testing.T) {
 		t.Fatal("expected tea.BatchMsg from push webhook handler")
 	}
 
-	foundFetch := false
+	if !awaitGHStatusMsg(bm, 15*time.Second) {
+		t.Error("expected ghStatusMsg from push-triggered fetch")
+	}
+}
+
+// awaitGHStatusMsg runs all sub-commands in bm concurrently and reports
+// whether any produced a ghStatusMsg within the given timeout. Sub-commands
+// that block (e.g. waitForWebhookCmd with an empty channel) are ignored.
+func awaitGHStatusMsg(bm tea.BatchMsg, timeout time.Duration) bool {
+	results := make(chan tea.Msg, len(bm))
 	for _, sub := range bm {
 		if sub == nil {
 			continue
 		}
-		done := make(chan tea.Msg, 1)
-		go func(c tea.Cmd) { done <- c() }(sub)
-		select {
-		case r := <-done:
-			if _, ok := r.(ghStatusMsg); ok {
-				foundFetch = true
-			}
-		case <-time.After(2 * time.Second):
-			// This is the blocking waitForWebhookCmd — skip it.
-		}
+		go func(c tea.Cmd) { results <- c() }(sub)
 	}
-	if !foundFetch {
-		t.Error("expected ghStatusMsg from push-triggered fetch")
+	deadline := time.After(timeout)
+	for {
+		select {
+		case r := <-results:
+			if _, ok := r.(ghStatusMsg); ok {
+				return true
+			}
+		case <-deadline:
+			return false
+		}
 	}
 }
 

--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -160,6 +160,11 @@ are synced back after completion. Use --local to force local execution, or
 
 		worktree := filepath.Join(hostCfg.WorktreeBase, repoName, id)
 
+		// Background-sync registered project clones so the agent's worktree
+		// branches from fresh main. Non-blocking; results go to ~/.klaus/sync.log.
+		// Exclude repoRoot to avoid racing with the foreground fetch below.
+		kickoffBackgroundSync("launch", repoRoot)
+
 		// Fetch all refs so the worktree starts from the latest state.
 		// Skip when EnsureClone was already called — it fetches with the
 		// same flags (--prune --tags), so a second fetch is redundant.

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -16,6 +16,7 @@ import (
 	"github.com/patflynn/klaus/internal/git"
 	"github.com/patflynn/klaus/internal/nix"
 	"github.com/patflynn/klaus/internal/project"
+	"github.com/patflynn/klaus/internal/projectsync"
 	"github.com/patflynn/klaus/internal/run"
 	"github.com/patflynn/klaus/internal/tmux"
 	"github.com/spf13/cobra"
@@ -129,6 +130,12 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 	if err := store.EnsureDirs(); err != nil {
 		return err
 	}
+
+	// Keep registered project clones up-to-date with their upstreams in the
+	// background so the coordinator sees current code. Never blocks startup;
+	// results are appended to ~/.klaus/sync.log. The current repo is excluded
+	// to avoid racing with the foreground git operations below.
+	kickoffBackgroundSync("session", root)
 
 	var branch, repoName, worktree string
 	var state *run.State
@@ -375,6 +382,25 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 	}
 	fmt.Printf("  To clean up: klaus cleanup %s\n", id)
 	return nil
+}
+
+// kickoffBackgroundSync fires projectsync.Sync in a goroutine and writes its
+// results to ~/.klaus/sync.log. The foreground caller is not blocked. The
+// goroutine uses a detached context so it survives past the foreground
+// command's lifetime (bounded by projectsync.PerRepoTimeout per repo).
+//
+// excludePath is the absolute path of any repo the foreground caller is about
+// to operate on; it's skipped to avoid racing with concurrent git operations
+// (e.g., FETCH_HEAD.lock contention).
+func kickoffBackgroundSync(source, excludePath string) {
+	reg, err := project.Load()
+	if err != nil || reg == nil || len(reg.Projects) == 0 {
+		return
+	}
+	go func() {
+		results := projectsync.Sync(context.Background(), reg, git.NewExecClient(), excludePath)
+		projectsync.WriteLog(source, results)
+	}()
 }
 
 // checkRunningAgents inspects agent states and returns those still running

--- a/internal/cmd/sync.go
+++ b/internal/cmd/sync.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/patflynn/klaus/internal/git"
+	"github.com/patflynn/klaus/internal/project"
+	"github.com/patflynn/klaus/internal/projectsync"
+	"github.com/spf13/cobra"
+)
+
+var syncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Fetch and fast-forward every registered project",
+	Long: `Synchronously fetches every project in ~/.klaus/projects.json and fast-forwards
+its current branch to the upstream when the working tree is clean.
+
+Projects with a dirty tree, diverged branch, detached HEAD, or missing upstream
+are reported as skipped and left untouched. klaus never resets or force-updates
+a working clone.
+
+Exit code is 0 if every project succeeded (up-to-date / pulled / fetched-only)
+or was intentionally skipped. A non-zero exit code means at least one project
+hit an error (typically a fetch failure).`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		reg, err := project.Load()
+		if err != nil {
+			return fmt.Errorf("loading project registry: %w", err)
+		}
+		if reg == nil || len(reg.Projects) == 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "No projects registered. Use 'klaus project add' to register one.")
+			return nil
+		}
+
+		results := projectsync.Sync(cmd.Context(), reg, git.NewExecClient())
+		// Also append to the log file so CLI invocations appear there.
+		projectsync.WriteLog("cli", results)
+
+		writeSyncTable(cmd.OutOrStdout(), results)
+
+		for _, r := range results {
+			if r.Status == projectsync.StatusError {
+				return fmt.Errorf("one or more projects failed to sync")
+			}
+		}
+		return nil
+	},
+}
+
+func writeSyncTable(w io.Writer, results []projectsync.SyncResult) {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "PROJECT\tSTATUS\tBRANCH\tDETAIL")
+	for _, r := range results {
+		status := string(r.Status)
+		// Include the skip reason in the STATUS column for parity with the
+		// documented output format (e.g. "skipped: dirty tree").
+		if r.Status == projectsync.StatusSkipped && r.Detail != "" {
+			status = string(r.Status) + ": " + r.Detail
+		} else if r.Status == projectsync.StatusError && r.Detail != "" {
+			status = string(r.Status) + ": " + r.Detail
+		}
+		detail := r.Detail
+		if r.Status == projectsync.StatusSkipped || r.Status == projectsync.StatusError {
+			detail = "" // already rolled into status
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", r.Name, status, r.Branch, detail)
+	}
+	tw.Flush()
+}
+
+func init() {
+	rootCmd.AddCommand(syncCmd)
+}

--- a/internal/cmd/sync_test.go
+++ b/internal/cmd/sync_test.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/patflynn/klaus/internal/project"
+)
+
+func runGitT(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// setupProjectWithUpstream creates a bare origin and a clone, and returns the
+// clone path. Advances origin by one commit if advance=true.
+func setupProjectWithUpstream(t *testing.T, advance bool) string {
+	t.Helper()
+	seed := t.TempDir()
+	runGitT(t, ".", "init", "--initial-branch=main", seed)
+	runGitT(t, seed, "config", "user.email", "t@t.com")
+	runGitT(t, seed, "config", "user.name", "T")
+	os.WriteFile(filepath.Join(seed, "README.md"), []byte("# seed\n"), 0o644)
+	runGitT(t, seed, "add", "README.md")
+	runGitT(t, seed, "commit", "-m", "init")
+
+	bare := filepath.Join(t.TempDir(), "origin.git")
+	if out, err := exec.Command("git", "clone", "--bare", seed, bare).CombinedOutput(); err != nil {
+		t.Fatalf("bare clone: %v\n%s", err, out)
+	}
+
+	clone := filepath.Join(t.TempDir(), "clone")
+	if out, err := exec.Command("git", "clone", bare, clone).CombinedOutput(); err != nil {
+		t.Fatalf("clone: %v\n%s", err, out)
+	}
+	runGitT(t, clone, "config", "user.email", "t@t.com")
+	runGitT(t, clone, "config", "user.name", "T")
+
+	if advance {
+		staging := filepath.Join(t.TempDir(), "staging")
+		if out, err := exec.Command("git", "clone", bare, staging).CombinedOutput(); err != nil {
+			t.Fatalf("staging clone: %v\n%s", err, out)
+		}
+		runGitT(t, staging, "config", "user.email", "t@t.com")
+		runGitT(t, staging, "config", "user.name", "T")
+		os.WriteFile(filepath.Join(staging, "extra.txt"), []byte("x"), 0o644)
+		runGitT(t, staging, "add", "extra.txt")
+		runGitT(t, staging, "commit", "-m", "advance")
+		runGitT(t, staging, "push", "origin", "main")
+	}
+
+	return clone
+}
+
+// withTempHome sets HOME to a temp dir for the duration of the test and
+// registers cleanup.
+func withTempHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	return home
+}
+
+// writeRegistry writes a projects.json inside HOME/.klaus pointing at the
+// given projects.
+func writeRegistry(t *testing.T, home string, projects map[string]string) {
+	t.Helper()
+	reg := &project.Registry{
+		ProjectsDir: filepath.Join(home, "src"),
+		Projects:    projects,
+	}
+	regDir := filepath.Join(home, ".klaus")
+	if err := os.MkdirAll(regDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.SaveTo(filepath.Join(regDir, "projects.json")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSyncCmd_TableOutputAndExit(t *testing.T) {
+	home := withTempHome(t)
+	cleanClone := setupProjectWithUpstream(t, true) // behind upstream, clean
+
+	writeRegistry(t, home, map[string]string{
+		"demo": cleanClone,
+	})
+
+	buf := &bytes.Buffer{}
+	cmd := syncCmd
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetContext(context.Background())
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		t.Fatalf("syncCmd: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "demo") {
+		t.Errorf("output should include project name, got:\n%s", out)
+	}
+	if !strings.Contains(out, "pulled") {
+		t.Errorf("output should include 'pulled' status, got:\n%s", out)
+	}
+	if !strings.Contains(out, "main") {
+		t.Errorf("output should include branch name, got:\n%s", out)
+	}
+}
+
+func TestSyncCmd_DirtyIsSkippedNoError(t *testing.T) {
+	home := withTempHome(t)
+	clone := setupProjectWithUpstream(t, true)
+
+	// Dirty the clone
+	os.WriteFile(filepath.Join(clone, "wip.txt"), []byte("wip"), 0o644)
+
+	writeRegistry(t, home, map[string]string{"demo": clone})
+
+	buf := &bytes.Buffer{}
+	cmd := syncCmd
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetContext(context.Background())
+	err := cmd.RunE(cmd, []string{})
+	if err != nil {
+		t.Errorf("dirty clone should NOT cause a non-zero exit, got err: %v", err)
+	}
+	if !strings.Contains(buf.String(), "skipped") {
+		t.Errorf("output should include 'skipped', got:\n%s", buf.String())
+	}
+}
+
+func TestSyncCmd_FetchErrorReturnsError(t *testing.T) {
+	home := withTempHome(t)
+	clone := setupProjectWithUpstream(t, false)
+
+	// Break the remote so fetch fails
+	runGitT(t, clone, "remote", "set-url", "origin", filepath.Join(t.TempDir(), "nope.git"))
+
+	writeRegistry(t, home, map[string]string{"demo": clone})
+
+	buf := &bytes.Buffer{}
+	cmd := syncCmd
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetContext(context.Background())
+	err := cmd.RunE(cmd, []string{})
+	if err == nil {
+		t.Error("expected error exit when a project fetch fails")
+	}
+	if !strings.Contains(buf.String(), "error") {
+		t.Errorf("output should include 'error', got:\n%s", buf.String())
+	}
+}
+
+func TestSyncCmd_EmptyRegistry(t *testing.T) {
+	home := withTempHome(t)
+	writeRegistry(t, home, map[string]string{})
+
+	buf := &bytes.Buffer{}
+	cmd := syncCmd
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetContext(context.Background())
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		t.Fatalf("empty registry: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No projects") {
+		t.Errorf("expected 'No projects' message, got:\n%s", buf.String())
+	}
+}

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -32,6 +32,23 @@ type Client interface {
 	// BranchDelete deletes a local branch.
 	BranchDelete(ctx context.Context, repoDir, branch string) error
 
+	// IsClean reports whether the working tree at repoDir has no uncommitted changes.
+	IsClean(ctx context.Context, repoDir string) (bool, error)
+
+	// CurrentBranch returns the short name of the currently checked-out branch,
+	// or "" when HEAD is detached.
+	CurrentBranch(ctx context.Context, repoDir string) (string, error)
+
+	// HasUpstream reports whether the current branch has a tracking upstream.
+	HasUpstream(ctx context.Context, repoDir string) (bool, error)
+
+	// MergeFastForward runs `git merge --ff-only @{u}` in repoDir.
+	MergeFastForward(ctx context.Context, repoDir string) error
+
+	// CommitsBehindUpstream returns how many commits the current branch is
+	// behind its upstream. Returns 0 if already up-to-date.
+	CommitsBehindUpstream(ctx context.Context, repoDir string) (int, error)
+
 	// EnsureDataRef ensures the custom data ref exists. Creates it with an empty
 	// initial commit if it doesn't.
 	EnsureDataRef(ctx context.Context, repoDir, dataRef string) error

--- a/internal/git/exec_client.go
+++ b/internal/git/exec_client.go
@@ -42,6 +42,26 @@ func (c *ExecClient) BranchDelete(ctx context.Context, repoDir, branch string) e
 	return BranchDelete(ctx, repoDir, branch)
 }
 
+func (c *ExecClient) IsClean(ctx context.Context, repoDir string) (bool, error) {
+	return IsClean(ctx, repoDir)
+}
+
+func (c *ExecClient) CurrentBranch(ctx context.Context, repoDir string) (string, error) {
+	return CurrentBranch(ctx, repoDir)
+}
+
+func (c *ExecClient) HasUpstream(ctx context.Context, repoDir string) (bool, error) {
+	return HasUpstream(ctx, repoDir)
+}
+
+func (c *ExecClient) MergeFastForward(ctx context.Context, repoDir string) error {
+	return MergeFastForward(ctx, repoDir)
+}
+
+func (c *ExecClient) CommitsBehindUpstream(ctx context.Context, repoDir string) (int, error) {
+	return CommitsBehindUpstream(ctx, repoDir)
+}
+
 func (c *ExecClient) EnsureDataRef(ctx context.Context, repoDir, dataRef string) error {
 	return EnsureDataRef(ctx, repoDir, dataRef)
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -152,6 +153,106 @@ func retryAfterPrune(ctx context.Context, repoDir, branch string, origErr error,
 func BranchDelete(ctx context.Context, repoDir, branch string) error {
 	_, err := runGit(ctx, repoDir, "branch", "-D", branch)
 	return err
+}
+
+// IsClean reports whether the working tree at repoDir has no uncommitted changes.
+// Returns true only when git status --porcelain produces empty output.
+func IsClean(ctx context.Context, repoDir string) (bool, error) {
+	out, err := runGit(ctx, repoDir, "status", "--porcelain")
+	if err != nil {
+		return false, err
+	}
+	return out == "", nil
+}
+
+// CurrentBranch returns the short name of the currently checked-out branch,
+// or "" if the repo is in a detached HEAD state. Any other failure (not a git
+// repo, missing HEAD, etc.) is returned as an error rather than silently
+// treated as "no branch".
+func CurrentBranch(ctx context.Context, repoDir string) (string, error) {
+	ctx, cancel := ensureTimeout(ctx, localTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "symbolic-ref", "--quiet", "--short", "HEAD")
+	cmd.Dir = repoDir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		return strings.TrimSpace(stdout.String()), nil
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("git symbolic-ref timed out after %s", localTimeout)
+	}
+	// With --quiet, symbolic-ref exits with code 1 ONLY when HEAD is not a
+	// symbolic ref (i.e., detached HEAD). Other failures (e.g., not a git
+	// repo → "fatal:" exit 128) still need to bubble up.
+	if ee, ok := err.(*exec.ExitError); ok && ee.ExitCode() == 1 && stderr.Len() == 0 {
+		return "", nil
+	}
+	return "", fmt.Errorf("git symbolic-ref: %w: %s", err, stderr.String())
+}
+
+// HasUpstream reports whether the current branch at repoDir has a tracking
+// upstream. Missing upstream (a normal state) is reported as (false, nil);
+// other failures — not a git repo, bad path, I/O errors — return an error.
+func HasUpstream(ctx context.Context, repoDir string) (bool, error) {
+	ctx, cancel := ensureTimeout(ctx, localTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
+	cmd.Dir = repoDir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		return strings.TrimSpace(stdout.String()) != "", nil
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		return false, fmt.Errorf("git rev-parse timed out after %s", localTimeout)
+	}
+	// Git reports missing upstream with specific stderr text and exit 128.
+	// Distinguish that from fatal errors like "not a git repository".
+	se := stderr.String()
+	if isNoUpstreamErr(se) {
+		return false, nil
+	}
+	return false, fmt.Errorf("git rev-parse: %w: %s", err, se)
+}
+
+// isNoUpstreamErr returns true if stderr matches the messages git emits when
+// a branch has no configured upstream. Covers both `@{u}` phrasings seen in
+// modern git.
+func isNoUpstreamErr(stderr string) bool {
+	s := strings.ToLower(stderr)
+	return strings.Contains(s, "no upstream configured") ||
+		strings.Contains(s, "does not point to a branch") ||
+		strings.Contains(s, "head does not point")
+}
+
+// MergeFastForward runs `git merge --ff-only @{u}` in repoDir. Fails if the
+// current branch has diverged from upstream, has no upstream, or the working
+// tree isn't clean. Does NOT touch the tree on failure.
+func MergeFastForward(ctx context.Context, repoDir string) error {
+	_, err := runGit(ctx, repoDir, "merge", "--ff-only", "--quiet", "@{u}")
+	return err
+}
+
+// CommitsBehindUpstream returns how many commits the current branch is behind
+// its upstream. Returns 0 if already up-to-date. Assumes an upstream exists;
+// callers should check HasUpstream first.
+func CommitsBehindUpstream(ctx context.Context, repoDir string) (int, error) {
+	out, err := runGit(ctx, repoDir, "rev-list", "--count", "HEAD..@{u}")
+	if err != nil {
+		return 0, err
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return 0, fmt.Errorf("parsing rev-list --count output %q: %w", out, err)
+	}
+	return n, nil
 }
 
 // EnsureDataRef ensures the custom data ref exists. Creates it with an empty

--- a/internal/git/sync_helpers_test.go
+++ b/internal/git/sync_helpers_test.go
@@ -1,0 +1,171 @@
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// runInRepo is a tiny helper used by these tests to run raw git commands.
+func runInRepo(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return string(out)
+}
+
+// setupRepoWithRemote creates two bare-ish repos: `origin` (bare) and `repo`
+// (a working clone of origin). It returns the clone path.
+func setupRepoWithRemote(t *testing.T) string {
+	t.Helper()
+
+	upstream := initTestRepo(t)
+	bareDir := filepath.Join(t.TempDir(), "origin.git")
+	if out, err := exec.Command("git", "clone", "--bare", upstream, bareDir).CombinedOutput(); err != nil {
+		t.Fatalf("bare clone: %v\n%s", err, out)
+	}
+
+	cloneDir := filepath.Join(t.TempDir(), "clone")
+	if out, err := exec.Command("git", "clone", bareDir, cloneDir).CombinedOutput(); err != nil {
+		t.Fatalf("clone: %v\n%s", err, out)
+	}
+	runInRepo(t, cloneDir, "config", "user.email", "test@test.com")
+	runInRepo(t, cloneDir, "config", "user.name", "Test")
+
+	return cloneDir
+}
+
+func TestIsClean(t *testing.T) {
+	ctx := context.Background()
+	repo := initTestRepo(t)
+
+	clean, err := IsClean(ctx, repo)
+	if err != nil {
+		t.Fatalf("IsClean on fresh repo: %v", err)
+	}
+	if !clean {
+		t.Errorf("fresh repo should be clean")
+	}
+
+	// Add an untracked file — still counts as dirty
+	if err := os.WriteFile(filepath.Join(repo, "new.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	clean, err = IsClean(ctx, repo)
+	if err != nil {
+		t.Fatalf("IsClean with untracked file: %v", err)
+	}
+	if clean {
+		t.Errorf("repo with untracked file should not be clean")
+	}
+}
+
+func TestCurrentBranch(t *testing.T) {
+	ctx := context.Background()
+	repo := initTestRepo(t)
+
+	branch, err := CurrentBranch(ctx, repo)
+	if err != nil {
+		t.Fatalf("CurrentBranch: %v", err)
+	}
+	if branch != "main" {
+		t.Errorf("CurrentBranch = %q, want main", branch)
+	}
+
+	// Detached HEAD returns empty string without error
+	runInRepo(t, repo, "checkout", "--detach")
+	branch, err = CurrentBranch(ctx, repo)
+	if err != nil {
+		t.Fatalf("CurrentBranch detached: %v", err)
+	}
+	if branch != "" {
+		t.Errorf("detached HEAD should return empty branch, got %q", branch)
+	}
+}
+
+func TestHasUpstream(t *testing.T) {
+	ctx := context.Background()
+
+	// Plain repo, no remote — no upstream
+	repo := initTestRepo(t)
+	up, err := HasUpstream(ctx, repo)
+	if err != nil {
+		t.Fatalf("HasUpstream no-remote: %v", err)
+	}
+	if up {
+		t.Errorf("repo without remote should have no upstream")
+	}
+
+	// Repo cloned from origin — main tracks origin/main
+	clone := setupRepoWithRemote(t)
+	up, err = HasUpstream(ctx, clone)
+	if err != nil {
+		t.Fatalf("HasUpstream with upstream: %v", err)
+	}
+	if !up {
+		t.Errorf("cloned repo's main should have an upstream")
+	}
+}
+
+func TestMergeFastForward(t *testing.T) {
+	ctx := context.Background()
+	clone := setupRepoWithRemote(t)
+
+	// Advance origin by committing to another clone, then pushing.
+	// Easiest path: make a commit in clone, push, then hard-reset clone back
+	// one commit to simulate being behind origin.
+	if err := os.WriteFile(filepath.Join(clone, "extra.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runInRepo(t, clone, "add", "extra.txt")
+	runInRepo(t, clone, "commit", "-m", "advance")
+	runInRepo(t, clone, "push", "origin", "main")
+	runInRepo(t, clone, "reset", "--hard", "HEAD~1")
+
+	// Before merge: HEAD is behind origin/main by one commit
+	if err := FetchAll(ctx, clone); err != nil {
+		t.Fatalf("FetchAll: %v", err)
+	}
+
+	if err := MergeFastForward(ctx, clone); err != nil {
+		t.Fatalf("MergeFastForward: %v", err)
+	}
+
+	// After fast-forward, extra.txt should be present again
+	if _, err := os.Stat(filepath.Join(clone, "extra.txt")); err != nil {
+		t.Errorf("fast-forward should bring extra.txt back: %v", err)
+	}
+}
+
+func TestMergeFastForward_DivergedFails(t *testing.T) {
+	ctx := context.Background()
+	clone := setupRepoWithRemote(t)
+
+	// Make and push one commit, then reset locally and make a different commit.
+	// After re-fetch, local and origin/main have diverged.
+	if err := os.WriteFile(filepath.Join(clone, "a.txt"), []byte("a"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runInRepo(t, clone, "add", "a.txt")
+	runInRepo(t, clone, "commit", "-m", "a")
+	runInRepo(t, clone, "push", "origin", "main")
+	runInRepo(t, clone, "reset", "--hard", "HEAD~1")
+	if err := os.WriteFile(filepath.Join(clone, "b.txt"), []byte("b"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runInRepo(t, clone, "add", "b.txt")
+	runInRepo(t, clone, "commit", "-m", "b")
+
+	if err := FetchAll(ctx, clone); err != nil {
+		t.Fatalf("FetchAll: %v", err)
+	}
+
+	if err := MergeFastForward(ctx, clone); err == nil {
+		t.Errorf("MergeFastForward should fail when diverged")
+	}
+}

--- a/internal/projectsync/log.go
+++ b/internal/projectsync/log.go
@@ -1,0 +1,50 @@
+package projectsync
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// LogPath returns the absolute path to the klaus sync log (~/.klaus/sync.log).
+func LogPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home dir: %w", err)
+	}
+	return filepath.Join(home, ".klaus", "sync.log"), nil
+}
+
+// WriteLog appends a single block of timestamped sync results to the klaus
+// sync log. The source argument tags where the sync was triggered from (e.g.
+// "session", "launch", "cli") so a tail of the log explains who started it.
+// Failures to write are swallowed — a background sync that can't log should
+// not affect the foreground caller.
+func WriteLog(source string, results []SyncResult) {
+	path, err := LogPath()
+	if err != nil {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	writeLog(f, source, time.Now(), results)
+}
+
+func writeLog(w io.Writer, source string, now time.Time, results []SyncResult) {
+	fmt.Fprintf(w, "[%s] sync source=%s projects=%d\n", now.UTC().Format(time.RFC3339), source, len(results))
+	for _, r := range results {
+		line := fmt.Sprintf("    %-20s %-14s %s", r.Name, r.Status, r.Branch)
+		if r.Detail != "" {
+			line += "  " + r.Detail
+		}
+		fmt.Fprintln(w, line)
+	}
+}

--- a/internal/projectsync/projectsync.go
+++ b/internal/projectsync/projectsync.go
@@ -1,0 +1,201 @@
+// Package projectsync keeps registered project clones current with their
+// upstreams. It is deliberately conservative: it fetches every project, and
+// only performs a fast-forward merge when the working tree is clean and the
+// current branch has a tracking upstream. It never resets, force-updates, or
+// switches branches. Any surprising state (dirty tree, detached HEAD, diverged
+// branch, no upstream) is reported as a "skipped" result and left untouched.
+package projectsync
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/patflynn/klaus/internal/git"
+	"github.com/patflynn/klaus/internal/project"
+)
+
+// PerRepoTimeout bounds the total time spent syncing a single repo.
+const PerRepoTimeout = 15 * time.Second
+
+// MaxConcurrency caps how many project syncs run at once. Each sync spawns
+// several `git` subprocesses, so unbounded fan-out on a registry with many
+// projects can exhaust file descriptors or thrash the disk.
+const MaxConcurrency = 8
+
+// Status is the outcome of syncing a single project.
+type Status string
+
+const (
+	// StatusUpToDate means fetch ran and the branch was already current.
+	StatusUpToDate Status = "up-to-date"
+	// StatusPulled means a fast-forward merge advanced the working branch.
+	StatusPulled Status = "pulled"
+	// StatusFetched means fetch ran but no ff was attempted.
+	StatusFetched Status = "fetched-only"
+	// StatusSkipped means the repo was left untouched (dirty, diverged,
+	// detached, or no upstream). Detail explains why.
+	StatusSkipped Status = "skipped"
+	// StatusError means fetch or a git query failed. Detail contains the error.
+	StatusError Status = "error"
+)
+
+// SyncResult describes the outcome of syncing one project.
+type SyncResult struct {
+	Name   string
+	Path   string
+	Branch string
+	Status Status
+	// Detail is a short human-readable explanation. For skipped results this
+	// is the reason (e.g. "dirty tree"); for errors it's the error message;
+	// for pulled results it notes how many commits were applied.
+	Detail string
+}
+
+// Sync fetches and fast-forwards every project in reg concurrently. Returns
+// results sorted by project name. Per-project failures are reported in the
+// results, never as a returned error.
+//
+// excludePaths lists absolute paths the caller is already operating on in the
+// foreground; matching projects are skipped to avoid racing with concurrent
+// git operations (e.g., FETCH_HEAD.lock contention).
+func Sync(ctx context.Context, reg *project.Registry, gc git.Client, excludePaths ...string) []SyncResult {
+	if reg == nil {
+		return nil
+	}
+	projects := reg.List()
+	if len(projects) == 0 {
+		return nil
+	}
+
+	excluded := make(map[string]struct{}, len(excludePaths))
+	for _, p := range excludePaths {
+		if p == "" {
+			continue
+		}
+		if abs, err := filepath.Abs(p); err == nil {
+			excluded[abs] = struct{}{}
+		} else {
+			excluded[p] = struct{}{}
+		}
+	}
+
+	resCh := make(chan SyncResult, len(projects))
+	sem := make(chan struct{}, MaxConcurrency)
+	var wg sync.WaitGroup
+	for name, path := range projects {
+		if isExcluded(path, excluded) {
+			continue
+		}
+		wg.Add(1)
+		go func(name, path string) {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
+			defer func() { <-sem }()
+			resCh <- syncOne(ctx, gc, name, path)
+		}(name, path)
+	}
+	wg.Wait()
+	close(resCh)
+
+	results := make([]SyncResult, 0, len(projects))
+	for r := range resCh {
+		results = append(results, r)
+	}
+	sort.Slice(results, func(i, j int) bool { return results[i].Name < results[j].Name })
+	return results
+}
+
+// isExcluded reports whether path resolves to the same absolute path as any
+// entry in excluded.
+func isExcluded(path string, excluded map[string]struct{}) bool {
+	if len(excluded) == 0 {
+		return false
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		abs = path
+	}
+	_, ok := excluded[abs]
+	return ok
+}
+
+func syncOne(ctx context.Context, gc git.Client, name, path string) SyncResult {
+	r := SyncResult{Name: name, Path: path}
+
+	ctx, cancel := context.WithTimeout(ctx, PerRepoTimeout)
+	defer cancel()
+
+	// Capture the branch for reporting even if later steps fail/skip.
+	branch, _ := gc.CurrentBranch(ctx, path)
+	r.Branch = branch
+
+	if err := gc.FetchAll(ctx, path); err != nil {
+		r.Status = StatusError
+		r.Detail = fmt.Sprintf("fetch failed: %v", err)
+		return r
+	}
+
+	if branch == "" {
+		r.Status = StatusSkipped
+		r.Detail = "detached HEAD"
+		return r
+	}
+
+	clean, err := gc.IsClean(ctx, path)
+	if err != nil {
+		r.Status = StatusError
+		r.Detail = fmt.Sprintf("status check failed: %v", err)
+		return r
+	}
+	if !clean {
+		r.Status = StatusSkipped
+		r.Detail = "dirty tree"
+		return r
+	}
+
+	hasUp, err := gc.HasUpstream(ctx, path)
+	if err != nil {
+		r.Status = StatusError
+		r.Detail = fmt.Sprintf("upstream check failed: %v", err)
+		return r
+	}
+	if !hasUp {
+		r.Status = StatusSkipped
+		r.Detail = "no upstream"
+		return r
+	}
+
+	behind, err := gc.CommitsBehindUpstream(ctx, path)
+	if err != nil {
+		r.Status = StatusError
+		r.Detail = fmt.Sprintf("rev-list failed: %v", err)
+		return r
+	}
+	if behind == 0 {
+		r.Status = StatusUpToDate
+		return r
+	}
+
+	if err := gc.MergeFastForward(ctx, path); err != nil {
+		// ff failed — most likely diverged. Leave the tree alone.
+		r.Status = StatusSkipped
+		r.Detail = fmt.Sprintf("cannot fast-forward: %v", err)
+		return r
+	}
+
+	r.Status = StatusPulled
+	if behind == 1 {
+		r.Detail = "1 commit"
+	} else {
+		r.Detail = fmt.Sprintf("%d commits", behind)
+	}
+	return r
+}

--- a/internal/projectsync/projectsync_test.go
+++ b/internal/projectsync/projectsync_test.go
@@ -1,0 +1,299 @@
+package projectsync
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/patflynn/klaus/internal/git"
+	"github.com/patflynn/klaus/internal/project"
+)
+
+// runGit runs a git command from dir and fails the test on error.
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// makeUpstream creates a bare origin repo with one initial commit and returns
+// its path.
+func makeUpstream(t *testing.T) string {
+	t.Helper()
+	seed := t.TempDir()
+	runGit(t, ".", "init", "--initial-branch=main", seed)
+	runGit(t, seed, "config", "user.email", "test@test.com")
+	runGit(t, seed, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(seed, "README.md"), []byte("# seed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, seed, "add", "README.md")
+	runGit(t, seed, "commit", "-m", "initial")
+
+	bare := filepath.Join(t.TempDir(), "origin.git")
+	if out, err := exec.Command("git", "clone", "--bare", seed, bare).CombinedOutput(); err != nil {
+		t.Fatalf("bare clone: %v\n%s", err, out)
+	}
+	return bare
+}
+
+// cloneFrom clones bare into a fresh directory and configures git user, returning the path.
+func cloneFrom(t *testing.T, bare string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "clone")
+	if out, err := exec.Command("git", "clone", bare, dir).CombinedOutput(); err != nil {
+		t.Fatalf("clone: %v\n%s", err, out)
+	}
+	runGit(t, dir, "config", "user.email", "test@test.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	return dir
+}
+
+// advanceOrigin pushes one new commit to the bare origin repo by doing the
+// commit in a temporary staging clone.
+func advanceOrigin(t *testing.T, bare string) {
+	t.Helper()
+	staging := cloneFrom(t, bare)
+	fname := filepath.Join(staging, "advance.txt")
+	if err := os.WriteFile(fname, []byte("advance"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, staging, "add", "advance.txt")
+	runGit(t, staging, "commit", "-m", "advance origin")
+	runGit(t, staging, "push", "origin", "main")
+}
+
+func makeRegistry(t *testing.T, projects map[string]string) *project.Registry {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "projects.json")
+	reg := &project.Registry{
+		ProjectsDir: t.TempDir(),
+		Projects:    projects,
+	}
+	if err := reg.SaveTo(path); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := project.LoadFrom(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return loaded
+}
+
+func findResult(results []SyncResult, name string) *SyncResult {
+	for i := range results {
+		if results[i].Name == name {
+			return &results[i]
+		}
+	}
+	return nil
+}
+
+func TestSync_CleanAndBehindGetsPulled(t *testing.T) {
+	bare := makeUpstream(t)
+	clone := cloneFrom(t, bare)
+	advanceOrigin(t, bare)
+
+	reg := makeRegistry(t, map[string]string{"demo": clone})
+	results := Sync(context.Background(), reg, git.NewExecClient())
+
+	r := findResult(results, "demo")
+	if r == nil {
+		t.Fatalf("no result for demo; got %+v", results)
+	}
+	if r.Status != StatusPulled {
+		t.Errorf("Status = %q, want %q (detail=%q)", r.Status, StatusPulled, r.Detail)
+	}
+	if r.Branch != "main" {
+		t.Errorf("Branch = %q, want main", r.Branch)
+	}
+	if _, err := os.Stat(filepath.Join(clone, "advance.txt")); err != nil {
+		t.Errorf("advance.txt should exist after fast-forward: %v", err)
+	}
+}
+
+func TestSync_AlreadyUpToDate(t *testing.T) {
+	bare := makeUpstream(t)
+	clone := cloneFrom(t, bare)
+
+	reg := makeRegistry(t, map[string]string{"demo": clone})
+	results := Sync(context.Background(), reg, git.NewExecClient())
+	r := findResult(results, "demo")
+	if r == nil || r.Status != StatusUpToDate {
+		t.Errorf("expected up-to-date, got %+v", r)
+	}
+}
+
+func TestSync_DirtyTreeIsSkipped(t *testing.T) {
+	bare := makeUpstream(t)
+	clone := cloneFrom(t, bare)
+	advanceOrigin(t, bare)
+
+	// Dirty the working tree — untracked file is enough
+	if err := os.WriteFile(filepath.Join(clone, "local.txt"), []byte("wip"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := makeRegistry(t, map[string]string{"demo": clone})
+	results := Sync(context.Background(), reg, git.NewExecClient())
+	r := findResult(results, "demo")
+	if r == nil || r.Status != StatusSkipped {
+		t.Fatalf("expected skipped, got %+v", r)
+	}
+	if !strings.Contains(r.Detail, "dirty") {
+		t.Errorf("Detail should mention dirty, got %q", r.Detail)
+	}
+	// Must NOT have fast-forwarded
+	if _, err := os.Stat(filepath.Join(clone, "advance.txt")); !os.IsNotExist(err) {
+		t.Error("sync should not touch a dirty clone")
+	}
+}
+
+func TestSync_DivergedIsSkipped(t *testing.T) {
+	bare := makeUpstream(t)
+	clone := cloneFrom(t, bare)
+	advanceOrigin(t, bare)
+
+	// Commit a different change locally so we diverge from origin/main.
+	if err := os.WriteFile(filepath.Join(clone, "local.txt"), []byte("local"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, clone, "add", "local.txt")
+	runGit(t, clone, "commit", "-m", "local change")
+
+	reg := makeRegistry(t, map[string]string{"demo": clone})
+	results := Sync(context.Background(), reg, git.NewExecClient())
+	r := findResult(results, "demo")
+	if r == nil {
+		t.Fatalf("no result")
+	}
+	if r.Status != StatusSkipped {
+		t.Errorf("Status = %q, want skipped (detail=%q)", r.Status, r.Detail)
+	}
+	if !strings.Contains(r.Detail, "fast-forward") {
+		t.Errorf("Detail should mention fast-forward, got %q", r.Detail)
+	}
+}
+
+func TestSync_NoUpstreamIsSkipped(t *testing.T) {
+	bare := makeUpstream(t)
+	clone := cloneFrom(t, bare)
+
+	// Check out a new branch with no upstream
+	runGit(t, clone, "checkout", "-b", "feature")
+
+	reg := makeRegistry(t, map[string]string{"demo": clone})
+	results := Sync(context.Background(), reg, git.NewExecClient())
+	r := findResult(results, "demo")
+	if r == nil || r.Status != StatusSkipped {
+		t.Fatalf("expected skipped, got %+v", r)
+	}
+	if !strings.Contains(r.Detail, "upstream") {
+		t.Errorf("Detail should mention upstream, got %q", r.Detail)
+	}
+}
+
+func TestSync_DetachedHeadIsSkipped(t *testing.T) {
+	bare := makeUpstream(t)
+	clone := cloneFrom(t, bare)
+	runGit(t, clone, "checkout", "--detach")
+
+	reg := makeRegistry(t, map[string]string{"demo": clone})
+	results := Sync(context.Background(), reg, git.NewExecClient())
+	r := findResult(results, "demo")
+	if r == nil || r.Status != StatusSkipped {
+		t.Fatalf("expected skipped, got %+v", r)
+	}
+	if !strings.Contains(r.Detail, "detached") {
+		t.Errorf("Detail should mention detached, got %q", r.Detail)
+	}
+}
+
+func TestSync_FetchErrorReported(t *testing.T) {
+	// Point the clone at a non-existent origin so fetch fails.
+	bare := makeUpstream(t)
+	clone := cloneFrom(t, bare)
+	bad := filepath.Join(t.TempDir(), "nonexistent.git")
+	runGit(t, clone, "remote", "set-url", "origin", bad)
+
+	reg := makeRegistry(t, map[string]string{"demo": clone})
+	results := Sync(context.Background(), reg, git.NewExecClient())
+	r := findResult(results, "demo")
+	if r == nil || r.Status != StatusError {
+		t.Fatalf("expected error, got %+v", r)
+	}
+}
+
+func TestSync_ExcludePathSkipsMatchingProject(t *testing.T) {
+	bare := makeUpstream(t)
+	a := cloneFrom(t, bare)
+	b := cloneFrom(t, bare)
+	advanceOrigin(t, bare)
+
+	// Exclude `a` — it should not appear in results at all, and must not be
+	// fast-forwarded. `b` should still be synced normally.
+	reg := makeRegistry(t, map[string]string{"alpha": a, "bravo": b})
+	results := Sync(context.Background(), reg, git.NewExecClient(), a)
+
+	if findResult(results, "alpha") != nil {
+		t.Errorf("alpha should have been excluded, got %+v", results)
+	}
+	if r := findResult(results, "bravo"); r == nil || r.Status != StatusPulled {
+		t.Errorf("bravo should be pulled, got %+v", r)
+	}
+	if _, err := os.Stat(filepath.Join(a, "advance.txt")); !os.IsNotExist(err) {
+		t.Errorf("excluded clone %q must not be fast-forwarded", a)
+	}
+}
+
+func TestSync_BoundedConcurrency(t *testing.T) {
+	// Register more than MaxConcurrency projects. All should complete despite
+	// the cap. This is a smoke test — the main guarantee we care about is that
+	// bounded concurrency doesn't drop any project from the results.
+	bare := makeUpstream(t)
+	projects := make(map[string]string, MaxConcurrency+2)
+	for i := 0; i < MaxConcurrency+2; i++ {
+		projects[fmt.Sprintf("p%02d", i)] = cloneFrom(t, bare)
+	}
+	reg := makeRegistry(t, projects)
+	results := Sync(context.Background(), reg, git.NewExecClient())
+	if len(results) != len(projects) {
+		t.Fatalf("got %d results, want %d", len(results), len(projects))
+	}
+	for _, r := range results {
+		if r.Status != StatusUpToDate {
+			t.Errorf("%s: want up-to-date, got %q (%s)", r.Name, r.Status, r.Detail)
+		}
+	}
+}
+
+func TestSync_SortsByName(t *testing.T) {
+	bare := makeUpstream(t)
+	a := cloneFrom(t, bare)
+	b := cloneFrom(t, bare)
+	c := cloneFrom(t, bare)
+
+	reg := makeRegistry(t, map[string]string{
+		"zebra": a,
+		"alpha": b,
+		"mango": c,
+	})
+	results := Sync(context.Background(), reg, git.NewExecClient())
+	if len(results) != 3 {
+		t.Fatalf("got %d results, want 3", len(results))
+	}
+	want := []string{"alpha", "mango", "zebra"}
+	for i, w := range want {
+		if results[i].Name != w {
+			t.Errorf("results[%d].Name = %q, want %q", i, results[i].Name, w)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Every `klaus` coordinator session and `klaus launch` now fires a non-blocking `git fetch --prune --tags` + `git merge --ff-only @{u}` across every registered project before the foreground work starts. Stale coordinator reads and agents branching from stale `main` should go away.
- Sync is deliberately conservative: any dirty tree, detached HEAD, diverged branch, or missing upstream is reported as `skipped` and the clone is left untouched. klaus never resets, force-updates, or switches branches.
- Adds `klaus sync`, a synchronous version that prints a table and exits non-zero only on errors (skips are expected and do not fail).
- Per-project results append to `~/.klaus/sync.log` so a `tail -f` of that file is the debugging path when something goes wrong.

## Implementation notes
- New package `internal/projectsync` with `Sync(ctx, reg, git.Client)` that fans out one goroutine per project with a 15s per-repo timeout.
- Extends `internal/git.Client` with `IsClean`, `CurrentBranch`, `HasUpstream`, `MergeFastForward`, and `CommitsBehindUpstream`, each with an integration test against a real temp repo.
- Wired into `internal/cmd/session.go` and `internal/cmd/launch.go` via a shared `kickoffBackgroundSync` helper that never blocks startup.

## Test plan
- [x] `go test ./...` passes (includes new projectsync integration tests over real temp repos: clean+behind, up-to-date, dirty, diverged, detached, no-upstream, fetch-error, sort-order)
- [x] `klaus sync --help` renders the new command docs
- [x] `klaus sync` over a dirty clone reports `skipped: dirty tree` with exit 0
- [x] `klaus sync` over a broken remote reports `error:` with exit 1

Run: 20260422-1618-eeb5