### PR TITLE
fix: instruct review fix agents to reply to each PR comment

### DIFF
--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -218,8 +218,9 @@ func TestReviewCommentsDispatchAgent(t *testing.T) {
 
 func TestReviewFixPromptsInstructAgentToReplyToComments(t *testing.T) {
 	cases := []struct {
-		name   string
-		status *PRStatus
+		name       string
+		status     *PRStatus
+		wantLeadIn string
 	}{
 		{
 			name: "changes-requested",
@@ -227,6 +228,7 @@ func TestReviewFixPromptsInstructAgentToReplyToComments(t *testing.T) {
 				PRNumber: "42", State: "OPEN", CI: "passing",
 				ReviewDecision: "CHANGES_REQUESTED", TargetRepo: "owner/repo",
 			},
+			wantLeadIn: "changes requested by reviewers",
 		},
 		{
 			name: "trusted-comments",
@@ -234,9 +236,11 @@ func TestReviewFixPromptsInstructAgentToReplyToComments(t *testing.T) {
 				PRNumber: "42", State: "OPEN", CI: "passing",
 				HasNewTrustedComments: true, TargetRepo: "owner/repo",
 			},
+			wantLeadIn: "trusted reviewer",
 		},
 	}
 
+	prompts := make(map[string]string, len(cases))
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			c, _ := newTestController(t)
@@ -252,6 +256,10 @@ func TestReviewFixPromptsInstructAgentToReplyToComments(t *testing.T) {
 			if launchedPrompt == "" {
 				t.Fatal("expected agent dispatch")
 			}
+			// Path-specific lead-in.
+			if !strings.Contains(launchedPrompt, tc.wantLeadIn) {
+				t.Errorf("prompt missing lead-in %q: %q", tc.wantLeadIn, launchedPrompt)
+			}
 			// Must instruct fetching the comments.
 			if !strings.Contains(launchedPrompt, "gh api repos/owner/repo/pulls/42/comments") {
 				t.Errorf("prompt missing fetch instruction: %q", launchedPrompt)
@@ -259,6 +267,10 @@ func TestReviewFixPromptsInstructAgentToReplyToComments(t *testing.T) {
 			// Must instruct replying to each comment.
 			if !strings.Contains(launchedPrompt, "reply to EACH") {
 				t.Errorf("prompt missing reply-to-each instruction: %q", launchedPrompt)
+			}
+			// Must guard against duplicate replies on re-dispatch.
+			if !strings.Contains(launchedPrompt, "haven't already replied to") {
+				t.Errorf("prompt missing duplicate-reply guard: %q", launchedPrompt)
 			}
 			// Must include the exact replies endpoint format.
 			if !strings.Contains(launchedPrompt, "/comments/{commentId}/replies") {
@@ -268,7 +280,23 @@ func TestReviewFixPromptsInstructAgentToReplyToComments(t *testing.T) {
 			if !strings.Contains(launchedPrompt, "discounted") {
 				t.Errorf("prompt missing discounted-comment guidance: %q", launchedPrompt)
 			}
+			prompts[tc.name] = launchedPrompt
 		})
+	}
+
+	// The shared body (everything from "Fetch the review comments" onward)
+	// must be identical across both dispatch paths so reviewers see consistent
+	// instructions regardless of which transition fired.
+	bodyOf := func(p string) string {
+		i := strings.Index(p, "Fetch the review comments")
+		if i < 0 {
+			t.Fatalf("prompt has no shared body: %q", p)
+		}
+		return p[i:]
+	}
+	if bodyOf(prompts["changes-requested"]) != bodyOf(prompts["trusted-comments"]) {
+		t.Errorf("shared prompt body differs across dispatch paths:\nchanges-requested: %q\ntrusted-comments:  %q",
+			bodyOf(prompts["changes-requested"]), bodyOf(prompts["trusted-comments"]))
 	}
 }
 

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -216,6 +216,62 @@ func TestReviewCommentsDispatchAgent(t *testing.T) {
 	}
 }
 
+func TestReviewFixPromptsInstructAgentToReplyToComments(t *testing.T) {
+	cases := []struct {
+		name   string
+		status *PRStatus
+	}{
+		{
+			name: "changes-requested",
+			status: &PRStatus{
+				PRNumber: "42", State: "OPEN", CI: "passing",
+				ReviewDecision: "CHANGES_REQUESTED", TargetRepo: "owner/repo",
+			},
+		},
+		{
+			name: "trusted-comments",
+			status: &PRStatus{
+				PRNumber: "42", State: "OPEN", CI: "passing",
+				HasNewTrustedComments: true, TargetRepo: "owner/repo",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _ := newTestController(t)
+
+			var launchedPrompt string
+			c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
+				launchedPrompt = prompt
+				return "agent-x", nil
+			})
+
+			c.HandleGHStatus(context.Background(), map[string]*PRStatus{"42": tc.status}, nil)
+
+			if launchedPrompt == "" {
+				t.Fatal("expected agent dispatch")
+			}
+			// Must instruct fetching the comments.
+			if !strings.Contains(launchedPrompt, "gh api repos/owner/repo/pulls/42/comments") {
+				t.Errorf("prompt missing fetch instruction: %q", launchedPrompt)
+			}
+			// Must instruct replying to each comment.
+			if !strings.Contains(launchedPrompt, "reply to EACH") {
+				t.Errorf("prompt missing reply-to-each instruction: %q", launchedPrompt)
+			}
+			// Must include the exact replies endpoint format.
+			if !strings.Contains(launchedPrompt, "/comments/{commentId}/replies") {
+				t.Errorf("prompt missing replies command format: %q", launchedPrompt)
+			}
+			// Must mention discounted comments.
+			if !strings.Contains(launchedPrompt, "discounted") {
+				t.Errorf("prompt missing discounted-comment guidance: %q", launchedPrompt)
+			}
+		})
+	}
+}
+
 func TestMergedPRCleanedUp(t *testing.T) {
 	c, _ := newTestController(t)
 	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {

--- a/internal/pipeline/transitions.go
+++ b/internal/pipeline/transitions.go
@@ -263,15 +263,9 @@ var transitions = []transition{
 				Repo:     status.TargetRepo,
 			})
 
-			prompt := fmt.Sprintf(
-				"PR #%s in %s has changes requested by reviewers. "+
-					"Fetch the review comments with: gh api repos/%s/pulls/%s/comments\n"+
-					"Address each comment in the code, then push your fixes.\n"+
-					"After pushing, reply to EACH review comment with a concise (1-2 sentence) explanation of what you changed. "+
-					"If a comment was intentionally not addressed, reply explaining why it was discounted.\n"+
-					"Use this exact command to reply, substituting the comment id and your explanation:\n"+
-					"  gh api repos/%s/pulls/%s/comments/{commentId}/replies -f body='<explanation>'",
-				ps.PRNumber, status.TargetRepo, status.TargetRepo, ps.PRNumber, status.TargetRepo, ps.PRNumber,
+			prompt := reviewFixPrompt(
+				fmt.Sprintf("PR #%s in %s has changes requested by reviewers.", ps.PRNumber, status.TargetRepo),
+				status.TargetRepo, ps.PRNumber,
 			)
 			ps.pendingLaunchDetail = fmt.Sprintf("Review fix agent for PR #%s", ps.PRNumber)
 			ps.Stage = StageReviewPending
@@ -319,15 +313,9 @@ var transitions = []transition{
 				Repo:     status.TargetRepo,
 			})
 
-			prompt := fmt.Sprintf(
-				"PR #%s in %s has review comments from a trusted reviewer that need to be addressed. "+
-					"Fetch the review comments with: gh api repos/%s/pulls/%s/comments\n"+
-					"Address each comment in the code, then push your fixes.\n"+
-					"After pushing, reply to EACH review comment with a concise (1-2 sentence) explanation of what you changed. "+
-					"If a comment was intentionally not addressed, reply explaining why it was discounted.\n"+
-					"Use this exact command to reply, substituting the comment id and your explanation:\n"+
-					"  gh api repos/%s/pulls/%s/comments/{commentId}/replies -f body='<explanation>'",
-				ps.PRNumber, status.TargetRepo, status.TargetRepo, ps.PRNumber, status.TargetRepo, ps.PRNumber,
+			prompt := reviewFixPrompt(
+				fmt.Sprintf("PR #%s in %s has review comments from a trusted reviewer that need to be addressed.", ps.PRNumber, status.TargetRepo),
+				status.TargetRepo, ps.PRNumber,
 			)
 			ps.pendingLaunchDetail = fmt.Sprintf("Review fix agent for PR #%s (trusted reviewer)", ps.PRNumber)
 			ps.Stage = StageReviewPending
@@ -544,6 +532,27 @@ func emitCIPassedIfNeeded(c *Controller, ps *PRPipelineState, status *PRStatus) 
 			"pr_url":    status.PRURL,
 		})
 	}
+}
+
+// reviewFixPrompt builds the prompt sent to a review-fix agent. The leadIn is
+// the situation-specific opening sentence (e.g. "PR #X has changes requested
+// by reviewers."); the rest of the body is shared so both the changes-requested
+// and trusted-comments dispatch paths produce identical instructions to the agent.
+//
+// The "(that you haven't already replied to)" qualifier matters because a fix
+// agent may be re-dispatched (e.g. after CI fails on its first push). Without
+// it the agent may post duplicate replies on threads it already answered.
+func reviewFixPrompt(leadIn, repo, prNumber string) string {
+	return fmt.Sprintf(
+		"%s "+
+			"Fetch the review comments with: gh api repos/%s/pulls/%s/comments\n"+
+			"Address each comment in the code, then push your fixes.\n"+
+			"After pushing, reply to EACH review comment that you haven't already replied to with a concise (1-2 sentence) explanation of what you changed. "+
+			"If a comment was intentionally not addressed, reply explaining why it was discounted.\n"+
+			"Use this exact command to reply, substituting the comment id and your explanation:\n"+
+			"  gh api repos/%s/pulls/%s/comments/{commentId}/replies -f body='<explanation>'",
+		leadIn, repo, prNumber, repo, prNumber,
+	)
 }
 
 // setApprovedIfNeeded transitions to StageApproved and emits the approval

--- a/internal/pipeline/transitions.go
+++ b/internal/pipeline/transitions.go
@@ -264,8 +264,14 @@ var transitions = []transition{
 			})
 
 			prompt := fmt.Sprintf(
-				"PR #%s has changes requested by reviewers. Address the review comments and push fixes. Check `gh api repos/{owner}/{repo}/pulls/%s/comments` for comment details.",
-				ps.PRNumber, ps.PRNumber,
+				"PR #%s in %s has changes requested by reviewers. "+
+					"Fetch the review comments with: gh api repos/%s/pulls/%s/comments\n"+
+					"Address each comment in the code, then push your fixes.\n"+
+					"After pushing, reply to EACH review comment with a concise (1-2 sentence) explanation of what you changed. "+
+					"If a comment was intentionally not addressed, reply explaining why it was discounted.\n"+
+					"Use this exact command to reply, substituting the comment id and your explanation:\n"+
+					"  gh api repos/%s/pulls/%s/comments/{commentId}/replies -f body='<explanation>'",
+				ps.PRNumber, status.TargetRepo, status.TargetRepo, ps.PRNumber, status.TargetRepo, ps.PRNumber,
 			)
 			ps.pendingLaunchDetail = fmt.Sprintf("Review fix agent for PR #%s", ps.PRNumber)
 			ps.Stage = StageReviewPending
@@ -314,8 +320,14 @@ var transitions = []transition{
 			})
 
 			prompt := fmt.Sprintf(
-				"PR #%s in %s has review comments from a trusted reviewer that need to be addressed. Check the review comments with: gh api repos/%s/pulls/%s/comments",
-				ps.PRNumber, status.TargetRepo, status.TargetRepo, ps.PRNumber,
+				"PR #%s in %s has review comments from a trusted reviewer that need to be addressed. "+
+					"Fetch the review comments with: gh api repos/%s/pulls/%s/comments\n"+
+					"Address each comment in the code, then push your fixes.\n"+
+					"After pushing, reply to EACH review comment with a concise (1-2 sentence) explanation of what you changed. "+
+					"If a comment was intentionally not addressed, reply explaining why it was discounted.\n"+
+					"Use this exact command to reply, substituting the comment id and your explanation:\n"+
+					"  gh api repos/%s/pulls/%s/comments/{commentId}/replies -f body='<explanation>'",
+				ps.PRNumber, status.TargetRepo, status.TargetRepo, ps.PRNumber, status.TargetRepo, ps.PRNumber,
 			)
 			ps.pendingLaunchDetail = fmt.Sprintf("Review fix agent for PR #%s (trusted reviewer)", ps.PRNumber)
 			ps.Stage = StageReviewPending


### PR DESCRIPTION
## Summary
- Updates the two fix-agent prompts in `internal/pipeline/transitions.go` (changes-requested and trusted-comments dispatch paths) to instruct the agent to reply on each review comment thread after pushing fixes.
- Includes the exact `gh api repos/{owner}/{repo}/pulls/{prNumber}/comments/{commentId}/replies` command so the agent doesn't have to figure out the endpoint.
- Tells the agent to also reply when a comment is intentionally discounted, explaining why.

Previously the pipeline would dispatch a fix agent for review feedback, the agent would push code and exit, and the review threads would be silently resolved — reviewers had no signal explaining what was done.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] New table-driven test `TestReviewFixPromptsInstructAgentToReplyToComments` covers both dispatch paths and asserts the prompt contains the fetch instruction, the "reply to EACH" instruction, the `/comments/{commentId}/replies` endpoint format, and the "discounted" guidance.

Run: 20260422-2125-bc52
Fixes #240