### PR TITLE
fix: preserve PRURL set at launch time during finalize

### DIFF
--- a/internal/cmd/hidden.go
+++ b/internal/cmd/hidden.go
@@ -163,6 +163,15 @@ func finalizeFromLog(store run.StateStore, state *run.State) error {
 	}
 	defer f.Close()
 
+	// Preserve PRURL set at launch time (e.g. --pr mode).
+	// Only extract from logs when no URL is already known; otherwise the
+	// regex can clobber the correct value with a false match from agent
+	// tool output (source code, test fixtures, etc.).
+	existingPRURL := ""
+	if state.PRURL != nil {
+		existingPRURL = *state.PRURL
+	}
+
 	// Use line-by-line scanning for robust JSONL parsing.
 	// json.NewDecoder can corrupt its internal state on malformed lines,
 	// causing subsequent events to be silently skipped.
@@ -233,6 +242,10 @@ func finalizeFromLog(store run.StateStore, state *run.State) error {
 				}
 			}
 		}
+	}
+
+	if existingPRURL != "" {
+		state.PRURL = &existingPRURL
 	}
 
 	return store.Save(state)

--- a/internal/cmd/hidden_test.go
+++ b/internal/cmd/hidden_test.go
@@ -389,6 +389,43 @@ not valid json at all
 		}
 		assertPRURL(t, state, "https://github.com/owner/repo/pull/2")
 	})
+
+	t.Run("preserves PRURL set before finalization", func(t *testing.T) {
+		// Simulates --pr mode: launch.go sets state.PRURL to the real PR
+		// before the agent runs. The agent's tool output contains unrelated
+		// PR URLs (e.g. from source code, test fixtures, or comments) that
+		// would otherwise clobber the correct value.
+		logContent := `{"type":"assistant","message":{"content":[{"type":"text","text":"Looking at https://github.com/other/repo/pull/999 for reference"}]}}
+{"type":"tool_result","content":"see https://github.com/some/fixture/pull/123 in test data"}
+{"type":"result","total_cost_usd":1.0,"duration_ms":5000}
+`
+		state, store := setupFinalizeTest(t, logContent)
+		existing := "https://github.com/owner/repo/pull/42"
+		state.PRURL = &existing
+
+		if err := finalizeFromLog(store, state); err != nil {
+			t.Fatalf("finalizeFromLog() error: %v", err)
+		}
+		assertPRURL(t, state, "https://github.com/owner/repo/pull/42")
+	})
+
+	t.Run("extracts PRURL from log when not set before finalization", func(t *testing.T) {
+		// Simulates new-PR mode: state.PRURL is nil until the agent runs
+		// `gh pr create`. Regex extraction fills it in from the log.
+		logContent := `{"type":"assistant","message":{"content":[{"type":"text","text":"Creating PR now."}]}}
+{"type":"tool_result","content":"https://github.com/owner/repo/pull/77\n"}
+{"type":"result","total_cost_usd":1.0,"duration_ms":5000}
+`
+		state, store := setupFinalizeTest(t, logContent)
+		if state.PRURL != nil {
+			t.Fatalf("test precondition: expected nil PRURL before finalize")
+		}
+
+		if err := finalizeFromLog(store, state); err != nil {
+			t.Fatalf("finalizeFromLog() error: %v", err)
+		}
+		assertPRURL(t, state, "https://github.com/owner/repo/pull/77")
+	})
 }
 
 func TestExtractClaudeSessionID(t *testing.T) {


### PR DESCRIPTION
## Summary

- `finalizeFromLog` in `internal/cmd/hidden.go` scans the agent JSONL log for GitHub PR URLs with a broad regex and unconditionally overwrites `state.PRURL`. In `--pr` mode, `launch.go` has already set the correct PRURL before the agent runs, so the regex can clobber that value with a false match from agent tool output (source code, test fixtures, etc.).
- Snapshot `state.PRURL` at the top of `finalizeFromLog` and, if it was already set, restore it after the scan loop. For new-PR runs where PRURL is nil at entry, regex extraction continues to work as before.
- Adds two tests: one confirming an existing PRURL is preserved against a log containing unrelated PR URLs, and one confirming extraction still works when PRURL starts nil.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] New test `preserves_PRURL_set_before_finalization` passes
- [x] New test `extracts_PRURL_from_log_when_not_set_before_finalization` passes

Run: 20260424-1645-74f4
Fixes #243