### PR TITLE
feat: dispatch rebase agents on conflicts without requiring approval

### DIFF
--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -152,8 +152,10 @@ Key behaviors:
   to address the comments. After the agent completes, unresolved review threads
   are automatically marked as resolved.
 
-- **Merge conflicts** — when an approved PR has conflicts, a rebase agent is
-  dispatched to rebase onto main, resolve conflicts, run tests, and push.
+- **Merge conflicts** — when a PR has conflicts with passing CI, a rebase agent
+  is dispatched to rebase onto main, resolve conflicts, run tests, and push.
+  Approval is not required; the rebase circuit breaker stops after
+  `maxFixAttempts` consecutive failed rebase attempts.
 
 - **Retry logic** — if an agent dispatch fails, the controller retries up to 2
   times with 60-second backoff. A 60-second cooldown prevents duplicate dispatches

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -54,7 +54,8 @@ type PRPipelineState struct {
 	RetryCount              int       // number of launch retries after failure
 	LastFailedAt            time.Time // when the last launch failure occurred
 	LastDispatchAt          time.Time // when the last agent was dispatched (cooldown guard)
-	FixAttempts             int       // number of fix agents dispatched that completed without fixing CI
+	FixAttempts             int       // number of CI-fix agents dispatched that completed without fixing CI
+	RebaseAttempts          int       // number of rebase agents dispatched that completed without resolving conflicts
 
 	pendingLaunchDetail string // transient: detail text for pending launch action
 }

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -998,7 +998,7 @@ func TestRebaseCircuitBreaker(t *testing.T) {
 
 	hasError := false
 	for _, a := range actions {
-		if a.Type == "error" && strings.Contains(a.Detail, "fix attempts failed") {
+		if a.Type == "error" && strings.Contains(a.Detail, "rebase attempts failed") {
 			hasError = true
 		}
 	}
@@ -1023,6 +1023,171 @@ func TestRebaseCircuitBreaker(t *testing.T) {
 		if a.Type == "error" {
 			t.Errorf("expected no duplicate error after stall, got %v", actions)
 		}
+	}
+}
+
+// TestStalledFromCIRecoversWithConflicts verifies that a PR which exhausted
+// its CI fix-attempt budget and went to StageStalled is not blocked from
+// dispatching a rebase agent once CI starts passing — the rebase counter is
+// tracked separately so the rebase agent gets its own budget.
+func TestStalledFromCIRecoversWithConflicts(t *testing.T) {
+	c, _ := newTestController(t)
+
+	launchCount := 0
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
+		launchCount++
+		return fmt.Sprintf("agent-%03d", launchCount), nil
+	})
+
+	// Manually put the PR in StageStalled with FixAttempts maxed out, simulating
+	// having exhausted CI fix attempts before CI started passing.
+	c.mu.Lock()
+	c.prStates["42"] = &PRPipelineState{
+		PRNumber:    "42",
+		Stage:       StageStalled,
+		FixAttempts: maxFixAttempts,
+		LastAgentID: "agent-old",
+	}
+	c.mu.Unlock()
+
+	// CI now passes but conflicts have appeared.
+	statuses := map[string]*PRStatus{
+		"42": {
+			PRNumber: "42", State: "OPEN", CI: "passing",
+			ReviewDecision: "", Conflicts: "yes", TargetRepo: "owner/repo",
+		},
+	}
+	actions := c.HandleGHStatus(context.Background(), statuses, nil)
+
+	if launchCount != 1 {
+		t.Errorf("expected rebase agent to dispatch with fresh budget, got %d launches", launchCount)
+	}
+	for _, a := range actions {
+		if a.Type == "error" {
+			t.Errorf("did not expect circuit-breaker error on first rebase attempt, got %v", actions)
+		}
+	}
+	state := c.PipelineStates()["42"]
+	if state.Stage != StageNeedsRebase {
+		t.Errorf("expected stage needs_rebase after recovery, got %s", state.Stage)
+	}
+	if state.FixAttempts != 0 {
+		t.Errorf("expected FixAttempts reset to 0, got %d", state.FixAttempts)
+	}
+	if state.RebaseAttempts != 0 {
+		t.Errorf("expected RebaseAttempts to start at 0, got %d", state.RebaseAttempts)
+	}
+}
+
+// TestRebaseDispatchDoesNotConsumeCIFixBudget verifies a PR with prior CI
+// fix attempts gets a full rebase budget once CI passes.
+func TestRebaseDispatchDoesNotConsumeCIFixBudget(t *testing.T) {
+	c, _ := newTestController(t)
+
+	launchCount := 0
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
+		launchCount++
+		return fmt.Sprintf("agent-%03d", launchCount), nil
+	})
+
+	// Two prior CI fix attempts that didn't resolve CI yet.
+	c.mu.Lock()
+	c.prStates["42"] = &PRPipelineState{
+		PRNumber:    "42",
+		Stage:       StageCIFailed,
+		FixAttempts: 2,
+		LastAgentID: "agent-old",
+	}
+	c.mu.Unlock()
+
+	statuses := map[string]*PRStatus{
+		"42": {
+			PRNumber: "42", State: "OPEN", CI: "passing",
+			ReviewDecision: "", Conflicts: "yes", TargetRepo: "owner/repo",
+		},
+	}
+
+	// First rebase dispatch: should fire and reset FixAttempts.
+	c.HandleGHStatus(context.Background(), statuses, nil)
+	if launchCount != 1 {
+		t.Fatalf("expected first rebase dispatch, got %d launches", launchCount)
+	}
+	state := c.PipelineStates()["42"]
+	if state.FixAttempts != 0 {
+		t.Errorf("expected FixAttempts reset to 0 once CI passes, got %d", state.FixAttempts)
+	}
+	if state.RebaseAttempts != 0 {
+		t.Errorf("expected RebaseAttempts at 0 after first dispatch, got %d", state.RebaseAttempts)
+	}
+
+	// Two more cycles should still dispatch rebase agents (full rebase budget).
+	for attempt := 2; attempt <= 3; attempt++ {
+		cost := 1.0
+		runStates := []*run.State{
+			{ID: fmt.Sprintf("agent-%03d", attempt-1), TmuxPane: strPtr("%1"), CostUSD: &cost},
+		}
+		c.mu.Lock()
+		c.prStates["42"].LastDispatchAt = time.Now().Add(-61 * time.Second)
+		c.mu.Unlock()
+		c.HandleGHStatus(context.Background(), statuses, runStates)
+		if launchCount != attempt {
+			t.Fatalf("attempt %d: expected %d total launches, got %d", attempt, attempt, launchCount)
+		}
+	}
+}
+
+// TestConflictsWaitDoesNotSpamCIPassedEvent verifies that polling repeatedly
+// while a rebase is in flight (conflicts still present) does not re-emit the
+// AgentCIPassed event on every poll.
+func TestConflictsWaitDoesNotSpamCIPassedEvent(t *testing.T) {
+	c, baseDir := newTestController(t)
+	eventLog := event.NewLog(filepath.Join(baseDir, "session"))
+
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
+		return "agent-rebase", nil
+	})
+
+	// Seed the PR in StageCIPending so the first poll's transition emits
+	// AgentCIPassed exactly once when CI is found passing.
+	c.mu.Lock()
+	c.prStates["42"] = &PRPipelineState{
+		PRNumber: "42",
+		Stage:    StageCIPending,
+	}
+	c.mu.Unlock()
+
+	statuses := map[string]*PRStatus{
+		"42": {
+			PRNumber: "42", State: "OPEN", CI: "passing",
+			ReviewDecision: "", Conflicts: "yes", TargetRepo: "owner/repo",
+		},
+	}
+
+	// Initial poll dispatches rebase agent and emits AgentCIPassed once.
+	c.HandleGHStatus(context.Background(), statuses, nil)
+
+	// Subsequent polls hit conflicts-wait (agent still running — unfinalized
+	// run with a live pane is treated as running). Each must not re-emit
+	// AgentCIPassed.
+	runStates := []*run.State{
+		{ID: "agent-rebase", TmuxPane: strPtr("%1")},
+	}
+	for i := 0; i < 5; i++ {
+		c.HandleGHStatus(context.Background(), statuses, runStates)
+	}
+
+	events, err := eventLog.Read()
+	if err != nil {
+		t.Fatalf("reading event log: %v", err)
+	}
+	ciPassedCount := 0
+	for _, e := range events {
+		if e.Type == event.AgentCIPassed {
+			ciPassedCount++
+		}
+	}
+	if ciPassedCount != 1 {
+		t.Errorf("expected exactly 1 AgentCIPassed event, got %d (events: %v)", ciPassedCount, events)
 	}
 }
 

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -883,6 +883,149 @@ func TestRebaseDispatchRetryOnFailure(t *testing.T) {
 	}
 }
 
+func TestUnapprovedConflictsDispatchesRebase(t *testing.T) {
+	c, _ := newTestController(t)
+
+	mergeCount := 0
+	c.SetMergePRs(func(ctx context.Context, repo string, prNumbers []string) error {
+		mergeCount++
+		return nil
+	})
+
+	var launchedPrompt string
+	launchCount := 0
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
+		launchedPrompt = prompt
+		launchCount++
+		return "agent-rebase", nil
+	})
+
+	// CI passing, no review decision, no klaus internal approval, but conflicts present.
+	statuses := map[string]*PRStatus{
+		"42": {
+			PRNumber: "42", State: "OPEN", CI: "passing",
+			ReviewDecision: "", Conflicts: "yes", TargetRepo: "owner/repo",
+		},
+	}
+
+	actions := c.HandleGHStatus(context.Background(), statuses, nil)
+
+	if mergeCount != 0 {
+		t.Error("should not merge when conflicts exist")
+	}
+	if launchCount != 1 {
+		t.Errorf("expected 1 rebase agent launch for unapproved PR with conflicts, got %d", launchCount)
+	}
+	if !strings.Contains(launchedPrompt, "merge conflicts") {
+		t.Errorf("expected rebase prompt, got %q", launchedPrompt)
+	}
+
+	hasLaunch := false
+	for _, a := range actions {
+		if a.Type == "launch" && strings.Contains(a.Detail, "Rebase") {
+			hasLaunch = true
+		}
+	}
+	if !hasLaunch {
+		t.Errorf("expected rebase launch action, got %v", actions)
+	}
+
+	state := c.PipelineStates()["42"]
+	if state.Stage != StageNeedsRebase {
+		t.Errorf("expected stage needs_rebase, got %s", state.Stage)
+	}
+	// Approval-related side effects must not have run.
+	if state.Stage == StageApproved {
+		t.Error("rebase dispatch should not transition unapproved PR to approved stage")
+	}
+}
+
+func TestRebaseCircuitBreaker(t *testing.T) {
+	c, _ := newTestController(t)
+
+	launchCount := 0
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
+		launchCount++
+		return fmt.Sprintf("agent-%03d", launchCount), nil
+	})
+
+	statuses := map[string]*PRStatus{
+		"42": {
+			PRNumber: "42", State: "OPEN", CI: "passing",
+			ReviewDecision: "", Conflicts: "yes", TargetRepo: "owner/repo",
+		},
+	}
+
+	// Dispatch 1: initial rebase agent.
+	c.HandleGHStatus(context.Background(), statuses, nil)
+	if launchCount != 1 {
+		t.Fatalf("expected 1 launch, got %d", launchCount)
+	}
+
+	for attempt := 2; attempt <= 3; attempt++ {
+		// Simulate agent completion (finalized with cost) without resolving conflicts.
+		cost := 1.0
+		runStates := []*run.State{
+			{ID: fmt.Sprintf("agent-%03d", attempt-1), TmuxPane: strPtr("%1"), CostUSD: &cost},
+		}
+
+		// Expire the dispatch cooldown.
+		c.mu.Lock()
+		c.prStates["42"].LastDispatchAt = time.Now().Add(-61 * time.Second)
+		c.mu.Unlock()
+
+		// Conflicts still present -> should re-dispatch rebase.
+		c.HandleGHStatus(context.Background(), statuses, runStates)
+		if launchCount != attempt {
+			t.Fatalf("attempt %d: expected %d launches, got %d", attempt, attempt, launchCount)
+		}
+	}
+
+	// Three rebase agents have been dispatched. Simulate agent 3 completing.
+	cost := 1.0
+	runStates := []*run.State{
+		{ID: "agent-003", TmuxPane: strPtr("%1"), CostUSD: &cost},
+	}
+	c.mu.Lock()
+	c.prStates["42"].LastDispatchAt = time.Now().Add(-61 * time.Second)
+	c.mu.Unlock()
+
+	// Conflicts persist -> circuit breaker trips; no 4th dispatch.
+	actions := c.HandleGHStatus(context.Background(), statuses, runStates)
+	if launchCount != 3 {
+		t.Errorf("expected circuit breaker to stop at 3 launches, got %d", launchCount)
+	}
+
+	hasError := false
+	for _, a := range actions {
+		if a.Type == "error" && strings.Contains(a.Detail, "fix attempts failed") {
+			hasError = true
+		}
+	}
+	if !hasError {
+		t.Errorf("expected error action from rebase circuit breaker, got %v", actions)
+	}
+
+	if c.PipelineStates()["42"].Stage != StageStalled {
+		t.Errorf("expected stalled stage, got %s", c.PipelineStates()["42"].Stage)
+	}
+
+	// Subsequent poll while still stalled and conflicts present must not re-dispatch
+	// or emit duplicate stall errors.
+	c.mu.Lock()
+	c.prStates["42"].LastDispatchAt = time.Now().Add(-61 * time.Second)
+	c.mu.Unlock()
+	actions = c.HandleGHStatus(context.Background(), statuses, runStates)
+	if launchCount != 3 {
+		t.Errorf("expected no further dispatches after stall, got %d", launchCount)
+	}
+	for _, a := range actions {
+		if a.Type == "error" {
+			t.Errorf("expected no duplicate error after stall, got %v", actions)
+		}
+	}
+}
+
 func TestApprovedNoConflictsMerges(t *testing.T) {
 	c, _ := newTestController(t)
 	c.SetAutoMergeOnApproval(true)

--- a/internal/pipeline/transitions.go
+++ b/internal/pipeline/transitions.go
@@ -142,22 +142,49 @@ var transitions = []transition{
 		},
 	},
 
-	// ── CI passing + approved + conflicts → rebase ──────────────────────
+	// ── CI passing + conflicts → rebase ─────────────────────────────────
 
 	{
-		Name: "ci-passing/approved-conflicts-dispatch-rebase",
+		Name: "ci-passing/rebase-circuit-breaker-already-stalled",
 		Guard: allOf(
 			ciPassing,
-			isApproved,
+			hasConflicts,
+			fixAttemptsExhausted,
+			agentNotRunning,
+			inStage(StageStalled),
+		),
+		Apply: func(_ *Controller, _ *PRPipelineState, _ *PRStatus, _ []*run.State) ([]Action, []ActionDescriptor) {
+			return nil, nil
+		},
+	},
+	{
+		Name: "ci-passing/conflicts-dispatch-rebase",
+		Guard: allOf(
+			ciPassing,
 			hasConflicts,
 			agentNotRunning,
 			cooldownExpired,
 		),
 		Apply: func(c *Controller, ps *PRPipelineState, status *PRStatus, runStates []*run.State) ([]Action, []ActionDescriptor) {
-			ps.FixAttempts = 0
 			emitCIPassedIfNeeded(c, ps, status)
-			setApprovedIfNeeded(c, ps, status)
-			c.markRunStatesApproved(ps.PRNumber, runStates)
+
+			// Count a failed rebase attempt when a previous agent finished but conflicts persist.
+			if ps.Stage == StageNeedsRebase && ps.LastAgentID != "" {
+				ps.FixAttempts++
+			}
+
+			// Re-check circuit breaker after incrementing.
+			if ps.FixAttempts >= maxFixAttempts {
+				ps.Stage = StageStalled
+				c.logger.Warn("rebase agent circuit breaker tripped",
+					"pr", ps.PRNumber,
+					"attempts", ps.FixAttempts,
+				)
+				return []Action{{
+					Type:   "error",
+					Detail: fmt.Sprintf("PR #%s: %d fix attempts failed, stopping", ps.PRNumber, ps.FixAttempts),
+				}}, nil
+			}
 
 			var descs []ActionDescriptor
 			descs = append(descs, ActionDescriptor{
@@ -182,17 +209,13 @@ var transitions = []transition{
 		},
 	},
 	{
-		Name: "ci-passing/approved-conflicts-wait",
+		Name: "ci-passing/conflicts-wait",
 		Guard: allOf(
 			ciPassing,
-			isApproved,
 			hasConflicts,
 		),
-		Apply: func(c *Controller, ps *PRPipelineState, status *PRStatus, runStates []*run.State) ([]Action, []ActionDescriptor) {
-			ps.FixAttempts = 0
+		Apply: func(c *Controller, ps *PRPipelineState, status *PRStatus, _ []*run.State) ([]Action, []ActionDescriptor) {
 			emitCIPassedIfNeeded(c, ps, status)
-			setApprovedIfNeeded(c, ps, status)
-			c.markRunStatesApproved(ps.PRNumber, runStates)
 			return nil, nil
 		},
 	},

--- a/internal/pipeline/transitions.go
+++ b/internal/pipeline/transitions.go
@@ -149,7 +149,7 @@ var transitions = []transition{
 		Guard: allOf(
 			ciPassing,
 			hasConflicts,
-			fixAttemptsExhausted,
+			rebaseAttemptsExhausted,
 			agentNotRunning,
 			inStage(StageStalled),
 		),
@@ -168,21 +168,25 @@ var transitions = []transition{
 		Apply: func(c *Controller, ps *PRPipelineState, status *PRStatus, runStates []*run.State) ([]Action, []ActionDescriptor) {
 			emitCIPassedIfNeeded(c, ps, status)
 
+			// CI is now passing — any prior CI-fix attempts no longer count against
+			// the rebase agent's budget. RebaseAttempts is tracked separately.
+			ps.FixAttempts = 0
+
 			// Count a failed rebase attempt when a previous agent finished but conflicts persist.
 			if ps.Stage == StageNeedsRebase && ps.LastAgentID != "" {
-				ps.FixAttempts++
+				ps.RebaseAttempts++
 			}
 
-			// Re-check circuit breaker after incrementing.
-			if ps.FixAttempts >= maxFixAttempts {
+			// Re-check rebase circuit breaker after incrementing.
+			if ps.RebaseAttempts >= maxFixAttempts {
 				ps.Stage = StageStalled
 				c.logger.Warn("rebase agent circuit breaker tripped",
 					"pr", ps.PRNumber,
-					"attempts", ps.FixAttempts,
+					"attempts", ps.RebaseAttempts,
 				)
 				return []Action{{
 					Type:   "error",
-					Detail: fmt.Sprintf("PR #%s: %d fix attempts failed, stopping", ps.PRNumber, ps.FixAttempts),
+					Detail: fmt.Sprintf("PR #%s: %d rebase attempts failed, stopping", ps.PRNumber, ps.RebaseAttempts),
 				}}, nil
 			}
 
@@ -216,6 +220,13 @@ var transitions = []transition{
 		),
 		Apply: func(c *Controller, ps *PRPipelineState, status *PRStatus, _ []*run.State) ([]Action, []ActionDescriptor) {
 			emitCIPassedIfNeeded(c, ps, status)
+			// Move stage out of CI-failed/pending stages so emitCIPassedIfNeeded
+			// doesn't fire on every poll while the rebase dispatch is gated on
+			// cooldown or an in-flight agent. Preserve Stalled so the circuit
+			// breaker remains observable.
+			if ps.Stage != StageStalled && ps.Stage != StageNeedsRebase {
+				ps.Stage = StageNeedsRebase
+			}
 			return nil, nil
 		},
 	},
@@ -232,6 +243,7 @@ var transitions = []transition{
 		),
 		Apply: func(c *Controller, ps *PRPipelineState, status *PRStatus, runStates []*run.State) ([]Action, []ActionDescriptor) {
 			ps.FixAttempts = 0
+			ps.RebaseAttempts = 0
 			emitCIPassedIfNeeded(c, ps, status)
 			setApprovedIfNeeded(c, ps, status)
 			c.markRunStatesApproved(ps.PRNumber, runStates)
@@ -253,6 +265,7 @@ var transitions = []transition{
 		),
 		Apply: func(c *Controller, ps *PRPipelineState, status *PRStatus, runStates []*run.State) ([]Action, []ActionDescriptor) {
 			ps.FixAttempts = 0
+			ps.RebaseAttempts = 0
 			emitCIPassedIfNeeded(c, ps, status)
 			setApprovedIfNeeded(c, ps, status)
 			c.markRunStatesApproved(ps.PRNumber, runStates)
@@ -272,6 +285,7 @@ var transitions = []transition{
 		),
 		Apply: func(c *Controller, ps *PRPipelineState, status *PRStatus, runStates []*run.State) ([]Action, []ActionDescriptor) {
 			ps.FixAttempts = 0
+			ps.RebaseAttempts = 0
 			emitCIPassedIfNeeded(c, ps, status)
 
 			var descs []ActionDescriptor
@@ -310,6 +324,7 @@ var transitions = []transition{
 		),
 		Apply: func(c *Controller, ps *PRPipelineState, status *PRStatus, _ []*run.State) ([]Action, []ActionDescriptor) {
 			ps.FixAttempts = 0
+			ps.RebaseAttempts = 0
 			emitCIPassedIfNeeded(c, ps, status)
 			return nil, nil
 		},
@@ -327,6 +342,7 @@ var transitions = []transition{
 		),
 		Apply: func(c *Controller, ps *PRPipelineState, status *PRStatus, _ []*run.State) ([]Action, []ActionDescriptor) {
 			ps.FixAttempts = 0
+			ps.RebaseAttempts = 0
 			emitCIPassedIfNeeded(c, ps, status)
 
 			var descs []ActionDescriptor
@@ -364,6 +380,7 @@ var transitions = []transition{
 		),
 		Apply: func(c *Controller, ps *PRPipelineState, status *PRStatus, _ []*run.State) ([]Action, []ActionDescriptor) {
 			ps.FixAttempts = 0
+			ps.RebaseAttempts = 0
 			emitCIPassedIfNeeded(c, ps, status)
 			if ps.Stage != StageCIPassed {
 				c.emitEvent(ps.PRNumber, event.PRAwaitingApproval, map[string]interface{}{
@@ -382,6 +399,7 @@ var transitions = []transition{
 		Guard: ciPassing,
 		Apply: func(_ *Controller, ps *PRPipelineState, _ *PRStatus, _ []*run.State) ([]Action, []ActionDescriptor) {
 			ps.FixAttempts = 0
+			ps.RebaseAttempts = 0
 			return nil, nil
 		},
 	},
@@ -396,6 +414,7 @@ var transitions = []transition{
 		),
 		Apply: func(_ *Controller, ps *PRPipelineState, _ *PRStatus, _ []*run.State) ([]Action, []ActionDescriptor) {
 			ps.FixAttempts = 0
+			ps.RebaseAttempts = 0
 			if ps.Stage == StageStalled {
 				ps.Stage = StageCIPending
 			}
@@ -474,6 +493,10 @@ func fixAttemptsExhausted(_ *Controller, ps *PRPipelineState, _ *PRStatus, _ []*
 	return ps.FixAttempts >= maxFixAttempts
 }
 
+func rebaseAttemptsExhausted(_ *Controller, ps *PRPipelineState, _ *PRStatus, _ []*run.State) bool {
+	return ps.RebaseAttempts >= maxFixAttempts
+}
+
 // Stage guards.
 
 func inStage(s Stage) guardFunc {
@@ -547,9 +570,10 @@ func autoMergeEnabled(c *Controller, _ *PRPipelineState, _ *PRStatus, _ []*run.S
 // ── Shared helpers used by Apply functions ──────────────────────────────
 
 // emitCIPassedIfNeeded emits the CI-passed event when transitioning from
-// stages where CI was not previously known to be passing.
+// stages where CI was not previously known to be passing. StageNeedsRebase is
+// excluded so that polls during an in-flight rebase don't re-emit the event.
 func emitCIPassedIfNeeded(c *Controller, ps *PRPipelineState, status *PRStatus) {
-	if ps.Stage == StageCIFailed || ps.Stage == StageCIPending || ps.Stage == StageReviewPending || ps.Stage == StageNeedsRebase {
+	if ps.Stage == StageCIFailed || ps.Stage == StageCIPending || ps.Stage == StageReviewPending {
 		c.emitEvent(ps.PRNumber, event.AgentCIPassed, map[string]interface{}{
 			"pr_number": ps.PRNumber,
 			"pr_url":    status.PRURL,


### PR DESCRIPTION
## Summary

The pipeline was inconsistent: CI fix agents fired as soon as CI failed (no approval needed), but rebase agents only fired once a PR had been approved. That left unapproved PRs stuck on conflicts even though CI breakage was being auto-fixed.

This change drops the `isApproved` guard from the rebase dispatch (and its companion wait branch) and removes the approval side-effects from those Apply functions, since the PR isn't actually being approved at that point. Approval is still required for AUTO-MERGE — only the REBASE dispatch is now approval-independent.

To prevent infinite rebase loops on a PR that keeps conflicting, the rebase Apply now mirrors the CI fix agent's circuit breaker: it increments `ps.FixAttempts` when a previous rebase agent finished and conflicts persist, trips the breaker via `maxFixAttempts`, and a new short-circuit transition suppresses repeated stall errors once the PR is in `StageStalled`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] New test: `TestUnapprovedConflictsDispatchesRebase` — unapproved PR with CI passing + conflicts dispatches rebase, stage moves to `needs_rebase`
- [x] New test: `TestRebaseCircuitBreaker` — three rebase dispatches with persistent conflicts, then stall and no further dispatches/duplicate errors
- [x] Existing rebase/conflict tests still pass

Run: 20260427-0656-9c07