### PR TITLE
fix: validate Claude session exists before passing --resume

### DIFF
--- a/internal/cmd/hidden.go
+++ b/internal/cmd/hidden.go
@@ -280,6 +280,15 @@ func claudeSessionExists(sessionUUID string) bool {
 	if sessionUUID == "" {
 		return false
 	}
+	// Validate the UUID before interpolating into a filepath.Glob pattern:
+	// reject anything containing glob metacharacters or path separators so a
+	// crafted log entry can't escape the projects directory or match
+	// unintended files.
+	for _, r := range sessionUUID {
+		if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-') {
+			return false
+		}
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return false

--- a/internal/cmd/hidden.go
+++ b/internal/cmd/hidden.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"regexp"
 
 	"github.com/patflynn/klaus/internal/config"
@@ -269,6 +270,26 @@ func extractPRNumberFromURL(prURL string) string {
 		return ""
 	}
 	return matches[1]
+}
+
+// claudeSessionExists returns true if a Claude session JSONL file with the
+// given UUID exists under ~/.claude/projects/. Claude stores each session at
+// ~/.claude/projects/<encoded-project-dir>/<session-uuid>.jsonl; if the file
+// has been cleaned up, "claude --resume <uuid>" exits at startup with 0 turns.
+func claudeSessionExists(sessionUUID string) bool {
+	if sessionUUID == "" {
+		return false
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	pattern := filepath.Join(home, ".claude", "projects", "*", sessionUUID+".jsonl")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return false
+	}
+	return len(matches) > 0
 }
 
 // ExtractClaudeSessionID parses a Claude stream-json JSONL log file and

--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -272,15 +272,24 @@ are synced back after completion. Use --local to force local execution, or
 		logFile := filepath.Join(store.LogDir(), id+".jsonl")
 
 		// Resolve the Claude session UUID from the previous run's JSONL log.
-		// claude --resume expects a UUID v4, not the klaus run ID.
+		// claude --resume expects a UUID v4, not the klaus run ID. The session
+		// must also still exist on disk under ~/.claude/projects/; if it's
+		// been cleaned up, claude --resume exits at startup with 0 turns.
 		var resolvedResume string
 		if resumeFrom != "" {
 			if s, loadErr := store.Load(resumeFrom); loadErr == nil && s.LogFile != nil {
-				resolvedResume = ExtractClaudeSessionID(*s.LogFile)
+				candidate := ExtractClaudeSessionID(*s.LogFile)
+				if candidate != "" {
+					if claudeSessionExists(candidate) {
+						resolvedResume = candidate
+					} else {
+						fmt.Fprintf(os.Stderr, "warning: prior Claude session %s no longer exists on disk, starting fresh\n", candidate)
+					}
+				}
 			}
 			// If we couldn't extract a session UUID (e.g., previous agent
-			// also failed with no output), skip --resume entirely and
-			// let claude start a fresh session.
+			// also failed with no output) or the session has been cleaned
+			// up, skip --resume entirely and let claude start fresh.
 		}
 
 		// Build the claude command

--- a/internal/cmd/launch_test.go
+++ b/internal/cmd/launch_test.go
@@ -1,12 +1,15 @@
 package cmd
 
 import (
+	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/patflynn/klaus/internal/config"
 	"github.com/patflynn/klaus/internal/project"
+	"github.com/patflynn/klaus/internal/run"
 )
 
 func TestFormatPaneTitle(t *testing.T) {
@@ -479,6 +482,116 @@ func TestLaunchCmdHasResumeFromFlag(t *testing.T) {
 	}
 	if f.DefValue != "" {
 		t.Errorf("--resume-from default value should be empty, got %q", f.DefValue)
+	}
+}
+
+func TestClaudeSessionExists(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	projDir := filepath.Join(home, ".claude", "projects", "-some-encoded-dir")
+	if err := os.MkdirAll(projDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	const presentUUID = "79dcfb08-4de4-45f4-b7db-056bccbc3a00"
+	if err := os.WriteFile(filepath.Join(projDir, presentUUID+".jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if !claudeSessionExists(presentUUID) {
+		t.Errorf("claudeSessionExists(%q) = false, want true", presentUUID)
+	}
+	if claudeSessionExists("00000000-0000-0000-0000-000000000000") {
+		t.Error("claudeSessionExists(missing UUID) = true, want false")
+	}
+	if claudeSessionExists("") {
+		t.Error("claudeSessionExists(\"\") = true, want false")
+	}
+}
+
+// TestResumeFallsBackWhenSessionMissing covers the bug from PR #529: a prior
+// run's log file extracts a Claude session UUID, but the session file itself
+// has been cleaned up. Without validation, we'd pass --resume <uuid> and
+// claude would exit at startup with 0 turns. With validation, we skip the
+// flag and start a fresh session.
+func TestResumeFallsBackWhenSessionMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Set up a klaus state store with a prior run whose log file references
+	// a Claude session UUID that does NOT exist on disk.
+	baseDir := filepath.Join(home, ".klaus", "sessions", "session-test")
+	store := run.NewHomeDirStoreFromPath(baseDir)
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+
+	const priorRunID = "20260509-1355-6139"
+	const orphanUUID = "79dcfb08-4de4-45f4-b7db-056bccbc3a00"
+
+	logFile := filepath.Join(store.LogDir(), priorRunID+".jsonl")
+	resultEvent := map[string]interface{}{
+		"type":       "result",
+		"session_id": orphanUUID,
+	}
+	data, _ := json.Marshal(resultEvent)
+	if err := os.WriteFile(logFile, append(data, '\n'), 0o644); err != nil {
+		t.Fatalf("WriteFile log: %v", err)
+	}
+
+	priorState := &run.State{
+		ID:        priorRunID,
+		Prompt:    "fix CI",
+		LogFile:   &logFile,
+		CreatedAt: "2026-05-09T13:55:00Z",
+	}
+	if err := store.Save(priorState); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// The Claude session under ~/.claude/projects/ does NOT exist for orphanUUID.
+	// Mirror the resolve block in launch.go RunE.
+	s, err := store.Load(priorRunID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if s.LogFile == nil {
+		t.Fatal("LogFile is nil after Save/Load round-trip")
+	}
+	candidate := ExtractClaudeSessionID(*s.LogFile)
+	if candidate != orphanUUID {
+		t.Fatalf("ExtractClaudeSessionID = %q, want %q", candidate, orphanUUID)
+	}
+
+	var resolvedResume string
+	if claudeSessionExists(candidate) {
+		resolvedResume = candidate
+	}
+	if resolvedResume != "" {
+		t.Errorf("resolvedResume = %q, want empty (session is missing on disk)", resolvedResume)
+	}
+
+	// The downstream claude command should NOT include --resume.
+	cmd := buildClaudeCommand("sys", "5", "do stuff", "20260509-1400-aaaa", resolvedResume)
+	if strings.Contains(cmd, "--resume") {
+		t.Errorf("expected no --resume flag when session is missing, got: %s", cmd)
+	}
+
+	// Sanity check: when the session DOES exist, we keep --resume.
+	projDir := filepath.Join(home, ".claude", "projects", "-encoded")
+	if err := os.MkdirAll(projDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projDir, orphanUUID+".jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile session: %v", err)
+	}
+	if !claudeSessionExists(orphanUUID) {
+		t.Fatal("claudeSessionExists should now return true after creating the file")
+	}
+	cmdResumed := buildClaudeCommand("sys", "5", "do stuff", "20260509-1400-aaaa", orphanUUID)
+	if !strings.Contains(cmdResumed, "--resume '"+orphanUUID+"'") {
+		t.Errorf("expected --resume flag when session exists, got: %s", cmdResumed)
 	}
 }
 

--- a/internal/cmd/launch_test.go
+++ b/internal/cmd/launch_test.go
@@ -508,6 +508,14 @@ func TestClaudeSessionExists(t *testing.T) {
 	if claudeSessionExists("") {
 		t.Error("claudeSessionExists(\"\") = true, want false")
 	}
+
+	// Reject inputs containing glob metacharacters or path separators even if
+	// matching files happen to exist on disk.
+	for _, bad := range []string{"*", "?", "../" + presentUUID, presentUUID + "/..", "[a-z]" + presentUUID[5:], presentUUID + "\x00"} {
+		if claudeSessionExists(bad) {
+			t.Errorf("claudeSessionExists(%q) = true, want false (invalid characters)", bad)
+		}
+	}
 }
 
 // TestResumeFallsBackWhenSessionMissing covers the bug from PR #529: a prior


### PR DESCRIPTION
## Summary

PR #529's rebase agent (run `20260509-1355-6139`) was dispatched, exited
immediately with 0 turns, and left the pipeline in a stale `rebasing` state.
The Claude result event was:

```
{
  type: "result",
  subtype: "error_during_execution",
  duration_ms: 0,
  num_turns: 0,
  is_error: true,
  errors: ["No conversation found with session ID: 79dcfb08-4de4-45f4-b7db-056bccbc3a00"]
}
```

The agent run technically "completed" (just with 0 work), so downstream
guards (`agentNotRunning`, `cooldownExpired`, `fixAttemptsExhausted`) gated
further dispatches and the PR sat in `rebasing` indefinitely.

The bug: klaus extracts a Claude session UUID from the prior run's log and
passes it as `claude --resume <uuid>`, but doesn't check whether the
session file still exists under `~/.claude/projects/`. If it's been
cleaned up (prune, retention, etc.), claude refuses to start.

This affects all four `ResumeFrom: ps.LastAgentID` dispatch sites in
`internal/pipeline/transitions.go` (CI fix, rebase, review-comment fix,
changes-requested fix) — they all inherit a stale resume target when the
prior agent's Claude session has been cleaned up.

## Fix

- Add `claudeSessionExists(uuid)` helper that globs
  `~/.claude/projects/*/<uuid>.jsonl` to check the session file is still
  present.
- Extend the existing resolve block in `internal/cmd/launch.go` to
  validate the extracted UUID against the helper. If it's missing, log
  a warning to stderr and fall back to a fresh launch (same path as when
  extraction itself fails).

This is a correctness bug. The fix preserves the intent (resume context
across related agent runs when possible) and adds graceful fallback.
Whether different task types should share Claude session context at all
(e.g., rebase resuming a CI-fix session) is a separate semantic question
out of scope here.

## Test plan

- [x] `TestClaudeSessionExists` — covers present, missing, and empty UUIDs
- [x] `TestResumeFallsBackWhenSessionMissing` — extracts a UUID from a
  saved log, verifies that with no on-disk session the resolved resume
  is empty and the built claude command has no `--resume` flag; with the
  session present, `--resume` is included
- [x] `go build ./...` clean
- [x] `go test ./...` passes

Run: 20260509-1412-0d9a