### PR TITLE
Add per-project description field to registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The coordinator session uses these — you generally don't run them directly:
 | `klaus project add <owner/repo>` | Register a project (clones if needed) |
 | `klaus project list` | Show registered projects |
 | `klaus project remove <name>` | Unregister a project |
+| `klaus project describe <name> <desc>` | Set a one-line description (empty string clears it) |
 | `klaus project set-dir <path>` | Set the default projects directory |
 | `klaus sync` | Fetch and fast-forward every registered project |
 | `klaus new <project-name>` | Scaffold a new project using principles-based generation |
@@ -213,6 +214,8 @@ klaus project add owner/repo --path .     # register an existing local checkout
 klaus project add my-tool                 # search your GitHub repos by name
 klaus project list                        # show all registered projects
 klaus project remove my-tool              # unregister (does not delete the clone)
+klaus project describe my-tool "CLI for X"  # add a one-line description
+klaus project describe my-tool ""         # clear the description
 klaus project set-dir ~/hack              # set the default clone directory
 ```
 

--- a/internal/cmd/project.go
+++ b/internal/cmd/project.go
@@ -24,6 +24,7 @@ The registry maps project names to local paths and is stored in ~/.klaus/project
   klaus project add owner/repo --path . Register with explicit local path
   klaus project list                    Show registered projects
   klaus project remove <name>           Unregister a project
+  klaus project describe <name> <desc>  Set a one-line description (empty to clear)
   klaus project set-dir ~/hack          Set the default projects directory`,
 }
 
@@ -60,6 +61,22 @@ var projectSetDirCmd = &cobra.Command{
 	Short: "Set the default projects directory",
 	Args:  cobra.ExactArgs(1),
 	RunE:  runProjectSetDir,
+}
+
+var projectDescribeCmd = &cobra.Command{
+	Use:   "describe <name> <description>",
+	Short: "Set a one-line description for a registered project (empty string clears it)",
+	Long: `Set a freeform one-line description for a registered project.
+
+The description is shown in 'klaus project list' and included in the session
+coordinator's system prompt so the coordinator knows what each project is for.
+
+Pass an empty string to clear an existing description:
+
+  klaus project describe my-tool "CLI for managing X"
+  klaus project describe my-tool ""`,
+	Args: cobra.ExactArgs(2),
+	RunE: runProjectDescribe,
 }
 
 func runProjectAdd(cmd *cobra.Command, args []string) error {
@@ -156,11 +173,39 @@ func runProjectList(cmd *cobra.Command, _ []string) error {
 
 	for name, localPath := range projects {
 		remote := gitRemoteURL(localPath)
+		desc := reg.Description(name)
+		line := fmt.Sprintf("%-20s %s", name, localPath)
 		if remote != "" {
-			fmt.Fprintf(cmd.OutOrStdout(), "%-20s %s  (%s)\n", name, localPath, remote)
-		} else {
-			fmt.Fprintf(cmd.OutOrStdout(), "%-20s %s\n", name, localPath)
+			line += fmt.Sprintf("  (%s)", remote)
 		}
+		if desc != "" {
+			line += " — " + desc
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), line)
+	}
+	return nil
+}
+
+func runProjectDescribe(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	description := args[1]
+
+	reg, err := project.Load()
+	if err != nil {
+		return err
+	}
+
+	if err := reg.Describe(name, description); err != nil {
+		return err
+	}
+	if err := reg.Save(); err != nil {
+		return err
+	}
+
+	if description == "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Cleared description for %s\n", name)
+	} else {
+		fmt.Fprintf(cmd.OutOrStdout(), "Set description for %s: %s\n", name, description)
 	}
 	return nil
 }
@@ -297,5 +342,6 @@ func init() {
 	projectCmd.AddCommand(projectListCmd)
 	projectCmd.AddCommand(projectRemoveCmd)
 	projectCmd.AddCommand(projectSetDirCmd)
+	projectCmd.AddCommand(projectDescribeCmd)
 	rootCmd.AddCommand(projectCmd)
 }

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -279,7 +279,7 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 	// Load project list for session prompt
 	var projectList string
 	if reg, loadErr := project.Load(); loadErr == nil {
-		projectList = config.FormatProjectList(reg.List())
+		projectList = config.FormatProjectList(reg.List(), reg.Descriptions)
 	}
 
 	// Render session system prompt

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -466,15 +466,21 @@ func RenderSessionPrompt(repoRoot string, vars PromptVars) (string, error) {
 	return renderPromptFromFile(repoRoot, "session-prompt.md", defaultSessionPromptTemplate, vars)
 }
 
-// FormatProjectList formats a map of project name → local path as a bulleted list
-// for use in the session prompt. Returns empty string if no projects are registered.
-func FormatProjectList(projects map[string]string) string {
+// FormatProjectList formats project name → local path (and optional description)
+// as a bulleted list for use in the session prompt. Returns empty string if no
+// projects are registered. When a description is present for a project, it is
+// appended after an em dash.
+func FormatProjectList(projects, descriptions map[string]string) string {
 	if len(projects) == 0 {
 		return ""
 	}
 	var lines []string
 	for name, localPath := range projects {
-		lines = append(lines, fmt.Sprintf("- %s (%s)", name, contractHomeForDisplay(localPath)))
+		line := fmt.Sprintf("- %s (%s)", name, contractHomeForDisplay(localPath))
+		if d := descriptions[name]; d != "" {
+			line += " — " + d
+		}
+		lines = append(lines, line)
 	}
 	// Sort for deterministic output
 	sortStrings(lines)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -665,24 +665,24 @@ func TestRenderSessionPromptWithoutProjects(t *testing.T) {
 
 func TestFormatProjectList(t *testing.T) {
 	t.Run("empty projects", func(t *testing.T) {
-		result := FormatProjectList(map[string]string{})
+		result := FormatProjectList(map[string]string{}, nil)
 		if result != "" {
 			t.Errorf("expected empty string for empty projects, got %q", result)
 		}
 	})
 
 	t.Run("nil projects", func(t *testing.T) {
-		result := FormatProjectList(nil)
+		result := FormatProjectList(nil, nil)
 		if result != "" {
 			t.Errorf("expected empty string for nil projects, got %q", result)
 		}
 	})
 
-	t.Run("single project", func(t *testing.T) {
+	t.Run("single project no description", func(t *testing.T) {
 		result := FormatProjectList(map[string]string{
 			"my-proj": "/tmp/my-proj",
-		})
-		if !strings.Contains(result, "- my-proj (/tmp/my-proj)") {
+		}, nil)
+		if result != "- my-proj (/tmp/my-proj)" {
 			t.Errorf("unexpected format: %q", result)
 		}
 	})
@@ -691,7 +691,7 @@ func TestFormatProjectList(t *testing.T) {
 		result := FormatProjectList(map[string]string{
 			"zebra": "/tmp/zebra",
 			"alpha": "/tmp/alpha",
-		})
+		}, nil)
 		lines := strings.Split(result, "\n")
 		if len(lines) != 2 {
 			t.Fatalf("expected 2 lines, got %d: %q", len(lines), result)
@@ -701,6 +701,37 @@ func TestFormatProjectList(t *testing.T) {
 		}
 		if !strings.HasPrefix(lines[1], "- zebra") {
 			t.Errorf("expected second line to be zebra, got %q", lines[1])
+		}
+	})
+
+	t.Run("with description uses em dash", func(t *testing.T) {
+		result := FormatProjectList(
+			map[string]string{"my-proj": "/tmp/my-proj"},
+			map[string]string{"my-proj": "Does the thing"},
+		)
+		want := "- my-proj (/tmp/my-proj) — Does the thing"
+		if result != want {
+			t.Errorf("FormatProjectList = %q, want %q", result, want)
+		}
+	})
+
+	t.Run("description present for some projects", func(t *testing.T) {
+		result := FormatProjectList(
+			map[string]string{
+				"alpha": "/tmp/alpha",
+				"zebra": "/tmp/zebra",
+			},
+			map[string]string{"alpha": "First letter"},
+		)
+		lines := strings.Split(result, "\n")
+		if len(lines) != 2 {
+			t.Fatalf("expected 2 lines, got %d: %q", len(lines), result)
+		}
+		if lines[0] != "- alpha (/tmp/alpha) — First letter" {
+			t.Errorf("alpha line = %q", lines[0])
+		}
+		if lines[1] != "- zebra (/tmp/zebra)" {
+			t.Errorf("zebra line = %q", lines[1])
 		}
 	})
 }

--- a/internal/project/registry.go
+++ b/internal/project/registry.go
@@ -122,12 +122,7 @@ func (r *Registry) saveTo(path string) error {
 	for name, p := range r.Projects {
 		out.Projects[name] = contractHome(p)
 	}
-	if len(r.Descriptions) > 0 {
-		out.Descriptions = make(map[string]string, len(r.Descriptions))
-		for name, d := range r.Descriptions {
-			out.Descriptions[name] = d
-		}
-	}
+	out.Descriptions = r.Descriptions
 
 	data, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
@@ -164,6 +159,7 @@ func (r *Registry) Describe(name, description string) error {
 	if _, exists := r.Projects[name]; !exists {
 		return fmt.Errorf("project %q is not registered", name)
 	}
+	description = strings.Join(strings.Fields(description), " ")
 	if description == "" {
 		delete(r.Descriptions, name)
 		return nil

--- a/internal/project/registry.go
+++ b/internal/project/registry.go
@@ -11,8 +11,9 @@ import (
 // Registry holds the project registry: a default projects directory
 // and a map of project name to local path.
 type Registry struct {
-	ProjectsDir string            `json:"projects_dir"`
-	Projects    map[string]string `json:"projects"`
+	ProjectsDir  string            `json:"projects_dir"`
+	Projects     map[string]string `json:"projects"`
+	Descriptions map[string]string `json:"descriptions,omitempty"`
 }
 
 // registryPath returns the path to ~/.klaus/projects.json.
@@ -78,6 +79,9 @@ func loadFrom(path string) (*Registry, error) {
 	if reg.Projects == nil {
 		reg.Projects = make(map[string]string)
 	}
+	if reg.Descriptions == nil {
+		reg.Descriptions = make(map[string]string)
+	}
 	return &reg, nil
 }
 
@@ -88,8 +92,9 @@ func defaultRegistry() (*Registry, error) {
 		return nil, fmt.Errorf("resolving home dir: %w", err)
 	}
 	return &Registry{
-		ProjectsDir: filepath.Join(home, "src"),
-		Projects:    make(map[string]string),
+		ProjectsDir:  filepath.Join(home, "src"),
+		Projects:     make(map[string]string),
+		Descriptions: make(map[string]string),
 	}, nil
 }
 
@@ -117,6 +122,12 @@ func (r *Registry) saveTo(path string) error {
 	for name, p := range r.Projects {
 		out.Projects[name] = contractHome(p)
 	}
+	if len(r.Descriptions) > 0 {
+		out.Descriptions = make(map[string]string, len(r.Descriptions))
+		for name, d := range r.Descriptions {
+			out.Descriptions[name] = d
+		}
+	}
 
 	data, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
@@ -142,7 +153,31 @@ func (r *Registry) Remove(name string) error {
 		return fmt.Errorf("project %q is not registered", name)
 	}
 	delete(r.Projects, name)
+	delete(r.Descriptions, name)
 	return nil
+}
+
+// Describe sets or clears a freeform description for a registered project.
+// An empty description deletes any stored description for the name.
+// Returns an error if the project is not registered.
+func (r *Registry) Describe(name, description string) error {
+	if _, exists := r.Projects[name]; !exists {
+		return fmt.Errorf("project %q is not registered", name)
+	}
+	if description == "" {
+		delete(r.Descriptions, name)
+		return nil
+	}
+	if r.Descriptions == nil {
+		r.Descriptions = make(map[string]string)
+	}
+	r.Descriptions[name] = description
+	return nil
+}
+
+// Description returns the stored description for a project, or "" if none.
+func (r *Registry) Description(name string) string {
+	return r.Descriptions[name]
 }
 
 // Get returns the local path for a project, expanding ~ if present.

--- a/internal/project/registry_test.go
+++ b/internal/project/registry_test.go
@@ -259,6 +259,153 @@ func TestRoundTripWithTildePaths(t *testing.T) {
 	}
 }
 
+func TestDescribeAndDescription(t *testing.T) {
+	reg := &Registry{
+		ProjectsDir: "/tmp/projects",
+		Projects:    map[string]string{"foo": "/tmp/foo"},
+	}
+
+	if got := reg.Description("foo"); got != "" {
+		t.Errorf("Description before set = %q, want empty", got)
+	}
+
+	if err := reg.Describe("foo", "the foo tool"); err != nil {
+		t.Fatalf("Describe: %v", err)
+	}
+	if got := reg.Description("foo"); got != "the foo tool" {
+		t.Errorf("Description = %q, want %q", got, "the foo tool")
+	}
+}
+
+func TestDescribeUnregisteredProjectErrors(t *testing.T) {
+	reg := &Registry{
+		ProjectsDir: "/tmp/projects",
+		Projects:    make(map[string]string),
+	}
+
+	if err := reg.Describe("nope", "anything"); err == nil {
+		t.Fatal("expected error for unregistered project, got nil")
+	}
+}
+
+func TestDescribeEmptyClearsEntry(t *testing.T) {
+	reg := &Registry{
+		ProjectsDir:  "/tmp/projects",
+		Projects:     map[string]string{"foo": "/tmp/foo"},
+		Descriptions: map[string]string{"foo": "old"},
+	}
+
+	if err := reg.Describe("foo", ""); err != nil {
+		t.Fatalf("Describe with empty: %v", err)
+	}
+	if _, ok := reg.Descriptions["foo"]; ok {
+		t.Error("expected description entry to be deleted on empty input")
+	}
+	if got := reg.Description("foo"); got != "" {
+		t.Errorf("Description after clear = %q, want empty", got)
+	}
+}
+
+func TestRemoveCleansUpDescription(t *testing.T) {
+	reg := &Registry{
+		ProjectsDir:  "/tmp/projects",
+		Projects:     map[string]string{"foo": "/tmp/foo"},
+		Descriptions: map[string]string{"foo": "the foo tool"},
+	}
+
+	if err := reg.Remove("foo"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if _, ok := reg.Descriptions["foo"]; ok {
+		t.Error("Remove should also delete the description entry")
+	}
+}
+
+func TestDescriptionsRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "projects.json")
+
+	reg := &Registry{
+		ProjectsDir:  "/tmp/projects",
+		Projects:     map[string]string{"foo": "/tmp/foo", "bar": "/tmp/bar"},
+		Descriptions: map[string]string{"foo": "foo tool"},
+	}
+
+	if err := reg.SaveTo(path); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	loaded, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+
+	if got := loaded.Description("foo"); got != "foo tool" {
+		t.Errorf("Description(foo) after round-trip = %q, want %q", got, "foo tool")
+	}
+	if got := loaded.Description("bar"); got != "" {
+		t.Errorf("Description(bar) after round-trip = %q, want empty", got)
+	}
+}
+
+func TestLoadLegacyJSONWithoutDescriptionsKey(t *testing.T) {
+	// Mirror the literal shape of an existing projects.json from before the
+	// descriptions field was added — no `descriptions` key at all.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "projects.json")
+
+	if err := os.WriteFile(path, []byte(`{
+		"projects_dir": "~/hack",
+		"projects": {"klaus": "~/hack/klaus"}
+	}`), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	reg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom legacy file: %v", err)
+	}
+
+	if reg.Descriptions == nil {
+		t.Error("Descriptions should be initialized to non-nil empty map for legacy files")
+	}
+	if got := reg.Description("klaus"); got != "" {
+		t.Errorf("Description(klaus) = %q, want empty for legacy file", got)
+	}
+
+	// Setting a description on a legacy-loaded registry should still work.
+	if err := reg.Describe("klaus", "self-hosting orchestrator"); err != nil {
+		t.Fatalf("Describe after legacy load: %v", err)
+	}
+	if got := reg.Description("klaus"); got != "self-hosting orchestrator" {
+		t.Errorf("Description after Describe = %q", got)
+	}
+}
+
+func TestSaveOmitsDescriptionsKeyWhenEmpty(t *testing.T) {
+	// When no descriptions are set, the saved JSON should not include a
+	// `descriptions` key (omitempty), keeping diffs clean for users who
+	// don't use this feature.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "projects.json")
+
+	reg := &Registry{
+		ProjectsDir: "/tmp/projects",
+		Projects:    map[string]string{"foo": "/tmp/foo"},
+	}
+	if err := reg.SaveTo(path); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if contains(string(data), "descriptions") {
+		t.Errorf("saved file should not contain `descriptions` when none set:\n%s", data)
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }

--- a/internal/project/registry_test.go
+++ b/internal/project/registry_test.go
@@ -288,6 +288,28 @@ func TestDescribeUnregisteredProjectErrors(t *testing.T) {
 	}
 }
 
+func TestDescribeNormalizesWhitespace(t *testing.T) {
+	reg := &Registry{
+		ProjectsDir: "/tmp/projects",
+		Projects:    map[string]string{"foo": "/tmp/foo"},
+	}
+
+	if err := reg.Describe("foo", "  the\tfoo\n tool  "); err != nil {
+		t.Fatalf("Describe: %v", err)
+	}
+	if got := reg.Description("foo"); got != "the foo tool" {
+		t.Errorf("Description = %q, want %q", got, "the foo tool")
+	}
+
+	// Whitespace-only input should be treated as empty and clear the entry.
+	if err := reg.Describe("foo", "   \t\n  "); err != nil {
+		t.Fatalf("Describe whitespace-only: %v", err)
+	}
+	if _, ok := reg.Descriptions["foo"]; ok {
+		t.Error("expected whitespace-only description to clear entry")
+	}
+}
+
 func TestDescribeEmptyClearsEntry(t *testing.T) {
 	reg := &Registry{
 		ProjectsDir:  "/tmp/projects",


### PR DESCRIPTION
## Summary

Cheap subset of #250: add an optional one-line `description` field per project so the coordinator session prompt knows what each registered project is for. None of the richer ideas in #250 (stack detection, gh polling, CLAUDE.md/AGENTS.md ingestion) are implemented here.

## Changes

- `internal/project/registry.go`: new `Descriptions map[string]string` (omitempty) on `Registry`, plus `Describe(name, description)`, `Description(name)`. `Remove` cleans up the description entry.
- `internal/config/config.go`: `FormatProjectList` now takes `(projects, descriptions)`. When a description is set, it's appended after an em dash.
- `internal/cmd/project.go`: new `klaus project describe <name> <description>` subcommand. `klaus project list` appends the description to each line when present. Empty description clears the entry.
- `internal/cmd/session.go`: passes `reg.Descriptions` into `FormatProjectList`.
- README updated to document the new subcommand.

## Backwards compatibility

The `descriptions` JSON key uses `omitempty` and the loader initializes a non-nil empty map when absent — existing `~/.klaus/projects.json` files load unchanged, and registries with no descriptions still serialize without a `descriptions` key.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all packages pass)
- [x] New tests cover round-trip of descriptions, legacy JSON load (no descriptions key), `Describe` errors for unregistered project, empty-description clears entry, `Remove` cleans up description, em-dash format in `FormatProjectList`, and that the saved JSON omits the `descriptions` key when none are set.
- [x] Verified `klaus project --help` and `klaus project describe --help` render correctly.

Run: 20260510-1609-36b9