### PR TITLE
pipeline: suppress auto-dispatch when a pr-fix run is already active

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ PR created → CI pending → CI passed → Approved → Merged
 - **Approved + CI green + no conflicts** — auto-merge (when `auto_merge_on_approval` is enabled)
 - **Merge conflicts** — a rebase agent resolves them before merging
 
+When a `pr-fix` run is already active on a PR — including coordinator-launched runs from `klaus launch --pr` — the pipeline will not auto-dispatch additional fix or rebase agents on it. This prevents races during multi-step refactors where intermediate commits may fail CI before the run completes.
+
 Pipeline stages per PR: `ci_pending` → `ci_passed` → `approved` → `merged`, with failure paths back through `ci_failed` or `changes_requested`.
 
 You can also drive the pipeline manually with `klaus approve` and `klaus merge`.

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -571,6 +571,26 @@ func (c *Controller) isRunning(s *run.State) bool {
 	return s.IsAgentRunningWith(c.tmuxDeps)
 }
 
+// anyPRFixRunning returns true if any pr-fix run is currently active on the
+// given PR, regardless of whether the controller itself dispatched it. This
+// detects coordinator-launched pr-fix runs (`klaus launch --pr <num>`) that
+// the controller has no record of, so it can avoid racing with them while
+// they are pushing incremental commits.
+func (c *Controller) anyPRFixRunning(prNumber string, runStates []*run.State) bool {
+	for _, s := range runStates {
+		if s == nil || s.Type != "pr-fix" {
+			continue
+		}
+		if !runStateMatchesPR(s, prNumber) {
+			continue
+		}
+		if c.isRunning(s) {
+			return true
+		}
+	}
+	return false
+}
+
 // truncateError returns a short, single-line version of an error message.
 // It strips cobra "Usage:" help text and truncates to maxLen.
 func truncateError(s string, maxLen int) string {

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -2205,6 +2205,142 @@ func TestSessionResumeFailingCISeedsCorrectly(t *testing.T) {
 	}
 }
 
+// TestCoordinatorLaunchedPRFixSuppresses verifies the controller does NOT
+// dispatch a competing fix agent when a coordinator-launched pr-fix run
+// (e.g. from `klaus launch --pr 42 ...`) is already active on the same PR.
+// This is the real-world incident on flux PR #66, where intermediate commits
+// during a multi-step refactor failed CI, the pipeline dispatched its own
+// fix agent, and the two agents revert-warred.
+func TestCoordinatorLaunchedPRFixSuppresses(t *testing.T) {
+	c, _ := newTestController(t)
+
+	launchCount := 0
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
+		launchCount++
+		return "pipeline-agent", nil
+	})
+
+	// Coordinator-launched pr-fix run: Type set, running pane, PRURL matches PR 42.
+	// Note: the pipeline never recorded it in ps.LastAgentID.
+	runStates := []*run.State{
+		{
+			ID:       "coord-fix-001",
+			Type:     "pr-fix",
+			PRURL:    strPtr("https://github.com/owner/repo/pull/42"),
+			TmuxPane: strPtr("%7"),
+		},
+	}
+
+	statuses := map[string]*PRStatus{
+		"42": {PRNumber: "42", State: "OPEN", CI: "failing", TargetRepo: "owner/repo"},
+	}
+
+	c.HandleGHStatus(context.Background(), statuses, runStates)
+
+	if launchCount != 0 {
+		t.Errorf("expected pipeline to suppress dispatch while coordinator pr-fix run is active, got %d launches", launchCount)
+	}
+}
+
+// TestCoordinatorLaunchedPRFixSuppressesViaPRField covers the case where the
+// coordinator-launched run has its PR field populated (rather than PRURL).
+// Both forms should trigger the guard.
+func TestCoordinatorLaunchedPRFixSuppressesViaPRField(t *testing.T) {
+	c, _ := newTestController(t)
+
+	launchCount := 0
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
+		launchCount++
+		return "pipeline-agent", nil
+	})
+
+	runStates := []*run.State{
+		{
+			ID:       "coord-fix-002",
+			Type:     "pr-fix",
+			PR:       strPtr("42"),
+			TmuxPane: strPtr("%8"),
+		},
+	}
+
+	statuses := map[string]*PRStatus{
+		"42": {PRNumber: "42", State: "OPEN", CI: "failing", TargetRepo: "owner/repo"},
+	}
+
+	c.HandleGHStatus(context.Background(), statuses, runStates)
+
+	if launchCount != 0 {
+		t.Errorf("expected suppression via PR field match, got %d launches", launchCount)
+	}
+}
+
+// TestCoordinatorLaunchedPRFixFinishedAllowsDispatch verifies that once the
+// coordinator-launched pr-fix run completes (finalized, pane idle), the
+// pipeline is free to dispatch its own fix agent on a CI failure.
+func TestCoordinatorLaunchedPRFixFinishedAllowsDispatch(t *testing.T) {
+	c, _ := newTestController(t)
+
+	launchCount := 0
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
+		launchCount++
+		return "pipeline-agent", nil
+	})
+
+	// Coordinator run is finalized (CostUSD set) — IsAgentRunning treats this
+	// as not running when the pane is idle (testTmuxDeps reports PaneIsIdle=true).
+	cost := 0.42
+	runStates := []*run.State{
+		{
+			ID:       "coord-fix-001",
+			Type:     "pr-fix",
+			PRURL:    strPtr("https://github.com/owner/repo/pull/42"),
+			TmuxPane: strPtr("%7"),
+			CostUSD:  &cost,
+		},
+	}
+
+	statuses := map[string]*PRStatus{
+		"42": {PRNumber: "42", State: "OPEN", CI: "failing", TargetRepo: "owner/repo"},
+	}
+
+	c.HandleGHStatus(context.Background(), statuses, runStates)
+
+	if launchCount != 1 {
+		t.Errorf("expected dispatch after coordinator pr-fix run finished, got %d launches", launchCount)
+	}
+}
+
+// TestCoordinatorLaunchedNonPRFixDoesNotSuppress ensures only pr-fix runs trip
+// the guard — other run types on the same PR shouldn't block the pipeline.
+func TestCoordinatorLaunchedNonPRFixDoesNotSuppress(t *testing.T) {
+	c, _ := newTestController(t)
+
+	launchCount := 0
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
+		launchCount++
+		return "pipeline-agent", nil
+	})
+
+	runStates := []*run.State{
+		{
+			ID:       "coord-other",
+			Type:     "session", // not a pr-fix
+			PR:       strPtr("42"),
+			TmuxPane: strPtr("%9"),
+		},
+	}
+
+	statuses := map[string]*PRStatus{
+		"42": {PRNumber: "42", State: "OPEN", CI: "failing", TargetRepo: "owner/repo"},
+	}
+
+	c.HandleGHStatus(context.Background(), statuses, runStates)
+
+	if launchCount != 1 {
+		t.Errorf("expected dispatch when only non-pr-fix runs are active, got %d launches", launchCount)
+	}
+}
+
 func strPtr(s string) *string {
 	return &s
 }

--- a/internal/pipeline/transitions.go
+++ b/internal/pipeline/transitions.go
@@ -473,8 +473,17 @@ func ciPendingOrUnknown(_ *Controller, _ *PRPipelineState, status *PRStatus, _ [
 
 // Agent status guards.
 
-func agentNotRunning(_ *Controller, ps *PRPipelineState, _ *PRStatus, _ []*run.State) bool {
-	return !ps.AgentRunning
+// agentNotRunning gates dispatch on there being no active agent for this PR.
+// It checks both the controller's last-dispatched agent (ps.AgentRunning) and
+// any pr-fix run in runStates that matches the PR — the latter catches
+// coordinator-launched runs (`klaus launch --pr`) that the controller did not
+// dispatch itself, preventing the pipeline from racing them with a competing
+// fix agent.
+func agentNotRunning(c *Controller, ps *PRPipelineState, _ *PRStatus, runStates []*run.State) bool {
+	if ps.AgentRunning {
+		return false
+	}
+	return !c.anyPRFixRunning(ps.PRNumber, runStates)
 }
 
 func cooldownExpired(_ *Controller, ps *PRPipelineState, _ *PRStatus, _ []*run.State) bool {


### PR DESCRIPTION
## Summary

- The pipeline's dispatch guard previously only knew about agents the controller itself dispatched. Coordinator-launched `pr-fix` runs (from `klaus launch --pr <num>`) were invisible to it.
- During a multi-step refactor, intermediate commits can legitimately fail CI before the coordinator run completes. The pipeline would observe the CI failure and dispatch its own competing fix agent → race / revert wars.
- Observed in the wild on flux PR #66, where a pipeline-dispatched fix agent reverted a deletion an in-flight coordinator-launched `pr-fix` run had made.

## Fix

Tighten the `agentNotRunning` guard to also detect any `pr-fix` run in the current run state list that matches the PR and is still running, regardless of who dispatched it. New helper `Controller.anyPRFixRunning(prNumber, runStates)` scans by `Type == "pr-fix"` and the existing `runStateMatchesPR` predicate (matches either the `PR` field or a `PRURL` ending in `/<prNumber>`).

The existing `ps.AgentRunning` fast-path is kept — they are complementary, not redundant.

Documented in the README under "The PR pipeline."

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] New tests in `internal/pipeline/pipeline_test.go`:
  - `TestCoordinatorLaunchedPRFixSuppresses` — PRURL match
  - `TestCoordinatorLaunchedPRFixSuppressesViaPRField` — PR field match
  - `TestCoordinatorLaunchedPRFixFinishedAllowsDispatch` — guard releases once the coordinator run is finalized
  - `TestCoordinatorLaunchedNonPRFixDoesNotSuppress` — only `pr-fix` runs trip the guard
- [x] Existing regression case (no double-dispatch of pipeline's own fix agent) is already covered by `TestNoDuplicateAgentDispatch`; the new guard subsumes the old check via the `ps.AgentRunning` fast-path and is verified to still pass.

Run: 20260518-0855-c010