### PR TITLE
security: scope github-app token permissions in nightly-release workflow

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Summary

zizmor's `github-app` audit flagged the `create-github-app-token` step in `nightly-release.yml` for inheriting blanket installation permissions. This was blocking PR #253.

Scope the token to the minimum required permission:

- `permission-contents: write` — needed to push the new version tag and to update the GitHub release notes via `gh release edit` (release management falls under the `contents` permission for GitHub Apps).

The workflow does not touch pull requests or any other resources, so no additional scopes are required.

## Verification

- `nix run nixpkgs#zizmor -- . --no-online-audits` reports no findings (22 suppressed).
- `go build ./...` and `go test ./...` pass.

Run: 20260518-1248-98d6