### PR TITLE
project: add --description flag with gh repo view fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,13 +213,16 @@ Manage a persistent registry of projects. The registry maps short names to local
 ```bash
 klaus project add owner/repo              # clone into projects dir and register
 klaus project add owner/repo --path .     # register an existing local checkout
+klaus project add owner/repo -d "CLI for X"  # register with an explicit description
 klaus project add my-tool                 # search your GitHub repos by name
 klaus project list                        # show all registered projects
 klaus project remove my-tool              # unregister (does not delete the clone)
-klaus project describe my-tool "CLI for X"  # add a one-line description
+klaus project describe my-tool "CLI for X"  # add or update the one-line description
 klaus project describe my-tool ""         # clear the description
 klaus project set-dir ~/hack              # set the default clone directory
 ```
+
+When `klaus project add` is called without `-d/--description`, klaus tries `gh repo view --json description` to pick up the GitHub description automatically. If gh is unavailable or the repo has no description, the project is registered without one — you can backfill later with `klaus project describe`. Descriptions show up in `klaus project list` and in the session coordinator's `## Registered projects` block.
 
 ### `klaus webhook`
 

--- a/internal/cmd/project.go
+++ b/internal/cmd/project.go
@@ -20,12 +20,13 @@ var projectCmd = &cobra.Command{
 
 The registry maps project names to local paths and is stored in ~/.klaus/projects.json.
 
-  klaus project add owner/repo          Clone and register a project
-  klaus project add owner/repo --path . Register with explicit local path
-  klaus project list                    Show registered projects
-  klaus project remove <name>           Unregister a project
-  klaus project describe <name> <desc>  Set a one-line description (empty to clear)
-  klaus project set-dir ~/hack          Set the default projects directory`,
+  klaus project add owner/repo                       Clone and register a project
+  klaus project add owner/repo --path .              Register with explicit local path
+  klaus project add owner/repo -d "what it does"     Register with a description
+  klaus project list                                 Show registered projects
+  klaus project remove <name>                        Unregister a project
+  klaus project describe <name> <desc>               Set a one-line description (empty to clear)
+  klaus project set-dir ~/hack                       Set the default projects directory`,
 }
 
 var projectAddCmd = &cobra.Command{
@@ -37,7 +38,12 @@ With owner/repo format, clones the repo into the projects directory and register
 With just a name, searches your GitHub repos for a match.
 
 If --path is provided, registers the project at that path (must be an existing git repo).
-If the repo is already cloned at the expected path, it is registered without re-cloning.`,
+If the repo is already cloned at the expected path, it is registered without re-cloning.
+
+If --description is provided, it is stored as the project's one-line description.
+When --description is omitted, klaus tries 'gh repo view --json description' to fetch
+the GitHub description automatically; if that fails or returns empty, no description
+is stored (you can set one later with 'klaus project describe').`,
 	Args: cobra.ExactArgs(1),
 	RunE: runProjectAdd,
 }
@@ -82,13 +88,14 @@ Pass an empty string to clear an existing description:
 func runProjectAdd(cmd *cobra.Command, args []string) error {
 	ref := args[0]
 	explicitPath, _ := cmd.Flags().GetString("path")
+	description, _ := cmd.Flags().GetString("description")
 
 	reg, err := project.Load()
 	if err != nil {
 		return err
 	}
 
-	deps := DefaultProjectDeps()
+	deps := getProjectDeps()
 	var owner, repoName, cloneURL string
 
 	if strings.Contains(ref, "/") {
@@ -106,6 +113,12 @@ func runProjectAdd(cmd *cobra.Command, args []string) error {
 		}
 		owner = ghOwner
 		cloneURL = ghURL
+	}
+
+	// If the user didn't supply --description, try to pull one from GitHub.
+	// Best-effort: any error or empty result leaves description blank.
+	if description == "" && owner != "" && repoName != "" {
+		description = deps.FetchDescription(owner + "/" + repoName)
 	}
 
 	if explicitPath != "" {
@@ -126,10 +139,15 @@ func runProjectAdd(cmd *cobra.Command, args []string) error {
 		if err := reg.Add(repoName, absPath); err != nil {
 			return err
 		}
+		if description != "" {
+			if err := reg.Describe(repoName, description); err != nil {
+				return err
+			}
+		}
 		if err := reg.Save(); err != nil {
 			return err
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "Registered %s → %s\n", repoName, absPath)
+		printRegistered(cmd, repoName, absPath, description)
 		return nil
 	}
 
@@ -152,11 +170,24 @@ func runProjectAdd(cmd *cobra.Command, args []string) error {
 	if err := reg.Add(repoName, targetDir); err != nil {
 		return err
 	}
+	if description != "" {
+		if err := reg.Describe(repoName, description); err != nil {
+			return err
+		}
+	}
 	if err := reg.Save(); err != nil {
 		return err
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "Registered %s → %s\n", repoName, targetDir)
+	printRegistered(cmd, repoName, targetDir, description)
 	return nil
+}
+
+func printRegistered(cmd *cobra.Command, name, path, description string) {
+	if description != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Registered %s → %s — %s\n", name, path, description)
+		return
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Registered %s → %s\n", name, path)
 }
 
 func runProjectList(cmd *cobra.Command, _ []string) error {
@@ -264,6 +295,10 @@ type ghRepoEntry struct {
 type ProjectDeps struct {
 	ResolveGitHubRepo func(name string) (string, string, error)
 	GitClone          func(url, targetDir string) error
+	// FetchDescription returns the GitHub description for owner/repo, or "" on
+	// any failure (missing binary, auth issue, no description set). It must
+	// never return an error — a missing description is not an error condition.
+	FetchDescription func(repoSlug string) string
 }
 
 // DefaultProjectDeps returns ProjectDeps wired to real implementations.
@@ -271,7 +306,23 @@ func DefaultProjectDeps() ProjectDeps {
 	return ProjectDeps{
 		ResolveGitHubRepo: defaultResolveGitHubRepo,
 		GitClone:          defaultGitClone,
+		FetchDescription:  defaultFetchDescription,
 	}
+}
+
+// getProjectDeps lets tests swap in stub dependencies without touching cobra.
+var getProjectDeps = DefaultProjectDeps
+
+// defaultFetchDescription shells out to `gh repo view <slug> --json description -q .description`.
+// Returns "" if gh is unavailable, unauthenticated, the repo doesn't exist, or
+// the repo has no description set. All failure modes collapse to empty so that
+// `klaus project add` does not fail just because a description couldn't be fetched.
+func defaultFetchDescription(repoSlug string) string {
+	out, err := exec.Command("gh", "repo", "view", repoSlug, "--json", "description", "-q", ".description").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // defaultResolveGitHubRepo searches the user's GitHub repos for a name match.
@@ -338,6 +389,7 @@ func gitRemoteURL(repoDir string) string {
 
 func init() {
 	projectAddCmd.Flags().String("path", "", "Register with an explicit local path instead of cloning")
+	projectAddCmd.Flags().StringP("description", "d", "", "One-line description for the project (falls back to 'gh repo view' if unset)")
 	projectCmd.AddCommand(projectAddCmd)
 	projectCmd.AddCommand(projectListCmd)
 	projectCmd.AddCommand(projectRemoveCmd)

--- a/internal/cmd/project_test.go
+++ b/internal/cmd/project_test.go
@@ -1,0 +1,159 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/patflynn/klaus/internal/project"
+)
+
+// withStubProjectDeps swaps getProjectDeps for a stub that returns the given
+// description (and no-op clone/resolve). Restores on test cleanup.
+func withStubProjectDeps(t *testing.T, description string) {
+	t.Helper()
+	prev := getProjectDeps
+	getProjectDeps = func() ProjectDeps {
+		return ProjectDeps{
+			ResolveGitHubRepo: func(name string) (string, string, error) {
+				return "stub-owner", "https://example.invalid/stub.git", nil
+			},
+			GitClone: func(url, targetDir string) error {
+				return initGitRepoErr(targetDir)
+			},
+			FetchDescription: func(repoSlug string) string {
+				return description
+			},
+		}
+	}
+	t.Cleanup(func() { getProjectDeps = prev })
+}
+
+// initGitRepoErr is the error-returning sibling of initGitRepo for use inside
+// stub GitClone implementations (where we don't have a *testing.T).
+func initGitRepoErr(dir string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		return err
+	}
+	return nil
+}
+
+// invokeProjectAdd resets the projectAddCmd flags and calls runProjectAdd
+// directly. ref is the positional argument; path/description are flag values
+// ("" leaves the flag unset). Returns the captured stdout/stderr.
+func invokeProjectAdd(t *testing.T, ref, path, description string) string {
+	t.Helper()
+	// Reset flags so values don't leak between tests.
+	if err := projectAddCmd.Flags().Set("path", path); err != nil {
+		t.Fatal(err)
+	}
+	if err := projectAddCmd.Flags().Set("description", description); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = projectAddCmd.Flags().Set("path", "")
+		_ = projectAddCmd.Flags().Set("description", "")
+	})
+
+	buf := &bytes.Buffer{}
+	projectAddCmd.SetOut(buf)
+	projectAddCmd.SetErr(buf)
+	if err := runProjectAdd(projectAddCmd, []string{ref}); err != nil {
+		t.Fatalf("runProjectAdd(%q): %v\n%s", ref, err, buf.String())
+	}
+	return buf.String()
+}
+
+func TestProjectAddExplicitDescription(t *testing.T) {
+	home := withTempHome(t)
+	withStubProjectDeps(t, "should-not-be-used")
+
+	repoDir := filepath.Join(t.TempDir(), "mytool")
+	initGitRepo(t, repoDir)
+
+	out := invokeProjectAdd(t, "owner/mytool", repoDir, "my cool tool")
+	if !strings.Contains(out, "my cool tool") {
+		t.Errorf("expected output to mention description, got: %q", out)
+	}
+
+	reg, err := project.LoadFrom(filepath.Join(home, ".klaus", "projects.json"))
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if got := reg.Description("mytool"); got != "my cool tool" {
+		t.Errorf("Description = %q, want %q", got, "my cool tool")
+	}
+	if _, ok := reg.Get("mytool"); !ok {
+		t.Error("project mytool not registered")
+	}
+}
+
+func TestProjectAddGhDescriptionFallback(t *testing.T) {
+	home := withTempHome(t)
+	withStubProjectDeps(t, "from-github")
+
+	repoDir := filepath.Join(t.TempDir(), "mytool")
+	initGitRepo(t, repoDir)
+
+	out := invokeProjectAdd(t, "owner/mytool", repoDir, "")
+	if !strings.Contains(out, "from-github") {
+		t.Errorf("expected output to include fallback description, got: %q", out)
+	}
+
+	reg, err := project.LoadFrom(filepath.Join(home, ".klaus", "projects.json"))
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if got := reg.Description("mytool"); got != "from-github" {
+		t.Errorf("Description = %q, want %q", got, "from-github")
+	}
+}
+
+func TestProjectAddNoDescriptionWhenGhEmpty(t *testing.T) {
+	home := withTempHome(t)
+	withStubProjectDeps(t, "") // gh returns empty -> no description
+
+	repoDir := filepath.Join(t.TempDir(), "mytool")
+	initGitRepo(t, repoDir)
+
+	out := invokeProjectAdd(t, "owner/mytool", repoDir, "")
+	// The output should not include an em dash since no description.
+	if strings.Contains(out, "—") {
+		t.Errorf("unexpected em-dash in output: %q", out)
+	}
+
+	reg, err := project.LoadFrom(filepath.Join(home, ".klaus", "projects.json"))
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if got := reg.Description("mytool"); got != "" {
+		t.Errorf("Description = %q, want empty", got)
+	}
+	if _, ok := reg.Get("mytool"); !ok {
+		t.Error("project mytool not registered")
+	}
+}
+
+func TestProjectAddExplicitOverridesGh(t *testing.T) {
+	// --description should win over the gh fetch.
+	home := withTempHome(t)
+	withStubProjectDeps(t, "from-github")
+
+	repoDir := filepath.Join(t.TempDir(), "mytool")
+	initGitRepo(t, repoDir)
+
+	invokeProjectAdd(t, "owner/mytool", repoDir, "explicit wins")
+
+	reg, err := project.LoadFrom(filepath.Join(home, ".klaus", "projects.json"))
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if got := reg.Description("mytool"); got != "explicit wins" {
+		t.Errorf("Description = %q, want %q", got, "explicit wins")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `klaus project add owner/repo --description "..."` (alias `-d`) so a one-line description can be set at registration time.
- When `--description` is omitted, klaus best-effort fetches the GitHub description via `gh repo view --json description -q .description`. Any failure (missing gh, auth issue, no description set) silently leaves the description blank.
- The fetch hook lives on `ProjectDeps.FetchDescription` so tests can stub it without shelling out. Existing description plumbing (`Registry.Describe` / `FormatProjectList` em-dash rendering) is reused unchanged.

## Test plan
- [x] `go build ./...` passes.
- [x] `go test ./...` passes.
- [x] New `internal/cmd/project_test.go` covers: explicit `--description`, gh fallback populating the description, gh returning empty (no description stored), and explicit overriding gh.
- [ ] Manual: `klaus project add owner/repo -d "blah"` registers the project and prints `Registered name → path — blah`.
- [ ] Manual: `klaus project add owner/repo` (no flag) picks up the GitHub description when gh is authenticated.

Run: 20260518-1411-5d1c8f8b