### PR TITLE
Add klaus watch command for real-time pipeline event streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,21 @@ Pipeline stages per PR: `ci_pending` → `ci_passed` → `approved` → `merged`
 
 You can also drive the pipeline manually with `klaus approve` and `klaus merge`.
 
+### Real-time event channel
+
+Pipeline events (PR created/approved/merged, CI passed/failed, agent errors) are appended to `~/.klaus/sessions/$KLAUS_SESSION_ID/events.jsonl` and exposed as a streaming channel via `klaus watch`. It's designed for [Claude Code's Monitor tool](https://docs.anthropic.com/en/docs/claude-code) — each matching event becomes a notification injected into the coordinator's context between turns, so the coordinator can react to merges or CI failures without you having to mention them.
+
+```bash
+klaus watch                          # default filter, follow new events
+klaus watch --since-start            # replay everything in the file, then follow
+klaus watch --filter pr:merged       # narrow to a single event type (repeatable)
+klaus watch --filter-out pr:approved # subtract from the default filter
+klaus watch --json                   # raw JSONL passthrough
+klaus watch --list-types             # show live and reserved event types
+```
+
+The coordinator session's system prompt automatically suggests arming a persistent Monitor on `klaus watch` at startup. The dashboard reads the same `events.jsonl` file independently — both consumers can run side by side.
+
 ## Install
 
 ### Nix flake (recommended)
@@ -108,6 +123,7 @@ The coordinator session uses these — you generally don't run them directly:
 | `klaus webhook check` | Check registered projects for GitHub webhook configuration |
 | `klaus webhook setup [project]` | Create missing webhooks for registered projects |
 | `klaus dashboard` | Live TUI dashboard for monitoring agents and PRs |
+| `klaus watch` | Stream pipeline events line-by-line (designed for Claude Code's Monitor tool) |
 | `klaus approve <pr>...` | Approve PRs for merging |
 | `klaus merge <pr>...` | Sequentially merge PRs with conflict resolution |
 | `klaus init` | Scaffold `.klaus/` config (optional, for customization) |

--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -1,0 +1,545 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/patflynn/klaus/internal/event"
+	"github.com/patflynn/klaus/internal/run"
+	"github.com/spf13/cobra"
+)
+
+// defaultWatchFilter is the set of event types emitted as notifications when
+// 'klaus watch' is run with no --filter flags. It intentionally includes some
+// types that aren't emitted yet (reserved entries) so the filter remains
+// forward-compatible as the pipeline grows.
+var defaultWatchFilter = []string{
+	event.AgentPRCreated, // live
+	"agent:error",        // reserved
+	event.PRApproved,     // live
+	event.PRMerged,       // live
+	"ci:failed",          // reserved (closest live equivalent: agent:ci-failed)
+	"ci:passed",          // reserved (closest live equivalent: agent:ci-passed)
+	"pr:comment",         // reserved
+}
+
+// knownEventTypes maps event types to a one-line description and whether the
+// type is currently emitted somewhere in klaus ("live") or reserved for future
+// use. --list-types renders this table.
+var knownEventTypes = []eventTypeInfo{
+	{event.AgentStarted, "live", "An agent run started"},
+	{event.AgentCompleted, "live", "An agent run finished (success or failure)"},
+	{event.AgentPRCreated, "live", "An agent published a PR"},
+	{event.AgentCIPassed, "live", "CI passed on an agent-owned PR"},
+	{event.AgentCIFailed, "live", "CI failed on an agent-owned PR"},
+	{event.AgentNeedsAttention, "live", "An agent stopped and needs operator input"},
+	{event.PRAwaitingApproval, "live", "A PR is ready for human approval"},
+	{event.PRApproved, "live", "A PR was approved"},
+	{event.PRMerged, "live", "A PR merged"},
+	{"agent:error", "reserved", "Reserved for unrecoverable agent failures (not currently emitted; use agent:needs-attention)"},
+	{"ci:failed", "reserved", "Reserved short name (currently emitted as agent:ci-failed)"},
+	{"ci:passed", "reserved", "Reserved short name (currently emitted as agent:ci-passed)"},
+	{"pr:comment", "reserved", "Reserved for trusted-reviewer comment notifications (not currently emitted)"},
+}
+
+type eventTypeInfo struct {
+	Type   string
+	Status string // "live" or "reserved"
+	Desc   string
+}
+
+var watchCmd = &cobra.Command{
+	Use:   "watch",
+	Short: "Stream session pipeline events as a real-time channel",
+	Long: `Stream structured pipeline events from the current klaus session as a
+line-buffered text channel. Designed for Claude Code's Monitor tool — each
+matching event becomes one notification.
+
+Events are read from ~/.klaus/sessions/$KLAUS_SESSION_ID/events.jsonl,
+followed via fsnotify, and emitted to stdout one line at a time. The default
+filter selects events the coordinator typically wants to react to:
+
+  agent:pr-created, agent:error, pr:approved, pr:merged,
+  ci:failed, ci:passed, pr:comment
+
+Some of those types are reserved (not currently emitted) but kept in the
+default filter so this command stays forward-compatible. Run 'klaus watch
+--list-types' to see which types are live vs reserved.
+
+Passing --filter REPLACES the default. --filter-out is always subtracted.
+Both flags are repeatable and use OR semantics within each flag.`,
+	Example: `  # Default filter, follow new events from now:
+  klaus watch
+
+  # Only react when a PR merges:
+  klaus watch --filter pr:merged
+
+  # Default filter minus pr:approved (e.g. don't notify on self-approvals):
+  klaus watch --filter-out pr:approved
+
+  # Replay everything in the file, then keep following:
+  klaus watch --since-start
+
+  # Raw JSONL passthrough for downstream tools:
+  klaus watch --json`,
+	RunE: runWatch,
+}
+
+func init() {
+	watchCmd.Flags().StringSlice("filter", nil, "Event type to include (repeatable, OR semantics). Replaces the default filter when set.")
+	watchCmd.Flags().StringSlice("filter-out", nil, "Event type to exclude (repeatable). Applied after --filter.")
+	watchCmd.Flags().Bool("since-start", false, "Emit events already in the file before tailing new ones.")
+	watchCmd.Flags().Bool("json", false, "Emit raw JSONL lines instead of human-formatted summaries.")
+	watchCmd.Flags().Bool("list-types", false, "Print known event types (live and reserved) and exit.")
+	watchCmd.Flags().String("session-id", "", "Override $KLAUS_SESSION_ID (mainly for testing).")
+	rootCmd.AddCommand(watchCmd)
+}
+
+func runWatch(cmd *cobra.Command, args []string) error {
+	listTypes, _ := cmd.Flags().GetBool("list-types")
+	if listTypes {
+		printKnownEventTypes(cmd.OutOrStdout())
+		return nil
+	}
+
+	filterIn, _ := cmd.Flags().GetStringSlice("filter")
+	filterOut, _ := cmd.Flags().GetStringSlice("filter-out")
+	sinceStart, _ := cmd.Flags().GetBool("since-start")
+	asJSON, _ := cmd.Flags().GetBool("json")
+	sessionOverride, _ := cmd.Flags().GetString("session-id")
+
+	sessionID := sessionOverride
+	if sessionID == "" {
+		sessionID = os.Getenv(sessionIDEnv)
+	}
+	if sessionID == "" {
+		return fmt.Errorf("klaus watch must be run inside a klaus session (KLAUS_SESSION_ID is not set; use --session-id to override)")
+	}
+
+	sessionsDir, err := run.SessionsDir()
+	if err != nil {
+		return err
+	}
+	eventsPath := filepath.Join(sessionsDir, sessionID, "events.jsonl")
+
+	flt := buildFilter(filterIn, filterOut)
+
+	ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	return streamEvents(ctx, eventsPath, flt, sinceStart, asJSON, cmd.OutOrStdout())
+}
+
+// watchFilter decides whether a given event type should be emitted.
+type watchFilter struct {
+	include map[string]struct{} // empty means "match anything"
+	exclude map[string]struct{}
+}
+
+func buildFilter(includeFlags, excludeFlags []string) watchFilter {
+	include := includeFlags
+	if len(include) == 0 {
+		include = defaultWatchFilter
+	}
+	inc := make(map[string]struct{}, len(include))
+	for _, t := range include {
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		inc[t] = struct{}{}
+	}
+	exc := make(map[string]struct{}, len(excludeFlags))
+	for _, t := range excludeFlags {
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		exc[t] = struct{}{}
+	}
+	return watchFilter{include: inc, exclude: exc}
+}
+
+func (f watchFilter) matches(eventType string) bool {
+	if _, blocked := f.exclude[eventType]; blocked {
+		return false
+	}
+	if len(f.include) == 0 {
+		return true
+	}
+	_, ok := f.include[eventType]
+	return ok
+}
+
+// streamEvents waits for the events file to exist, then follows it with
+// fsnotify until ctx is cancelled. New lines that pass the filter are written
+// to out as either formatted summaries or raw JSON.
+func streamEvents(ctx context.Context, path string, flt watchFilter, sinceStart, asJSON bool, out io.Writer) error {
+	if err := waitForFile(ctx, path, 10*time.Second); err != nil {
+		return err
+	}
+	// If ctx was cancelled during the wait, exit cleanly without trying to
+	// open the file (it may never have appeared).
+	if ctx.Err() != nil {
+		return nil
+	}
+
+	dir := filepath.Dir(path)
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("creating file watcher: %w", err)
+	}
+	defer watcher.Close()
+	if err := watcher.Add(dir); err != nil {
+		return fmt.Errorf("watching %s: %w", dir, err)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("opening events file: %w", err)
+	}
+	defer func() {
+		if f != nil {
+			f.Close()
+		}
+	}()
+
+	currentInode := statInode(path)
+
+	if !sinceStart {
+		if _, err := f.Seek(0, io.SeekEnd); err != nil {
+			return fmt.Errorf("seeking to end of events file: %w", err)
+		}
+	}
+
+	// Buffer for accumulating partial lines across reads.
+	var pending []byte
+
+	drain := func() error {
+		buf := make([]byte, 32*1024)
+		for {
+			n, err := f.Read(buf)
+			if n > 0 {
+				pending = append(pending, buf[:n]...)
+				for {
+					idx := bytes.IndexByte(pending, '\n')
+					if idx < 0 {
+						break
+					}
+					line := pending[:idx]
+					pending = pending[idx+1:]
+					if len(line) == 0 {
+						continue
+					}
+					if err := emitLine(line, flt, asJSON, out); err != nil {
+						return err
+					}
+				}
+			}
+			if err == io.EOF {
+				return nil
+			}
+			if err != nil {
+				return fmt.Errorf("reading events file: %w", err)
+			}
+		}
+	}
+
+	if err := drain(); err != nil {
+		return err
+	}
+
+	reopen := func() error {
+		if f != nil {
+			f.Close()
+		}
+		nf, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		f = nf
+		pending = pending[:0]
+		currentInode = statInode(path)
+		return nil
+	}
+
+	// Even with fsnotify, a periodic inode/size check catches edge cases
+	// (e.g. file replaced after a notification was missed).
+	const poll = 500 * time.Millisecond
+	ticker := time.NewTicker(poll)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case ev, ok := <-watcher.Events:
+			if !ok {
+				return nil
+			}
+			if filepath.Clean(ev.Name) != filepath.Clean(path) {
+				continue
+			}
+			if ev.Op&(fsnotify.Create|fsnotify.Rename|fsnotify.Remove) != 0 {
+				if _, err := os.Stat(path); err == nil {
+					if err := reopen(); err != nil {
+						return fmt.Errorf("reopening events file after rotation: %w", err)
+					}
+					if err := drain(); err != nil {
+						return err
+					}
+				}
+				continue
+			}
+			if ev.Op&(fsnotify.Write|fsnotify.Chmod) != 0 {
+				if err := drain(); err != nil {
+					return err
+				}
+			}
+		case werr, ok := <-watcher.Errors:
+			if !ok {
+				return nil
+			}
+			// Watcher errors are non-fatal — log to stderr and keep going.
+			fmt.Fprintf(os.Stderr, "klaus watch: watcher error: %v\n", werr)
+		case <-ticker.C:
+			// Defensive: catch missed write notifications and inode swaps.
+			newInode := statInode(path)
+			if newInode != 0 && newInode != currentInode {
+				if err := reopen(); err != nil {
+					return fmt.Errorf("reopening events file after inode change: %w", err)
+				}
+			}
+			if err := drain(); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func emitLine(line []byte, flt watchFilter, asJSON bool, out io.Writer) error {
+	var evt event.Event
+	if err := json.Unmarshal(line, &evt); err != nil {
+		// Skip malformed lines silently — matches event.Log.Read behavior.
+		return nil
+	}
+	if !flt.matches(evt.Type) {
+		return nil
+	}
+	if asJSON {
+		if _, err := out.Write(line); err != nil {
+			return err
+		}
+		_, err := out.Write([]byte{'\n'})
+		return err
+	}
+	if _, err := fmt.Fprintln(out, formatEvent(evt)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// formatEvent renders a single event as a one-line summary. Output shape:
+//
+//	HH:MM:SS  <run_id>  <type>  <one-line summary>
+func formatEvent(evt event.Event) string {
+	ts := evt.Timestamp
+	if parsed, err := time.Parse(time.RFC3339, evt.Timestamp); err == nil {
+		ts = parsed.Local().Format("15:04:05")
+	}
+	runID := evt.RunID
+	if runID == "" {
+		runID = "-"
+	}
+	return fmt.Sprintf("%s  %s  %-22s  %s", ts, runID, evt.Type, eventSummary(evt))
+}
+
+func eventSummary(evt event.Event) string {
+	d := evt.Data
+	get := func(k string) string {
+		if d == nil {
+			return ""
+		}
+		v, ok := d[k]
+		if !ok || v == nil {
+			return ""
+		}
+		switch x := v.(type) {
+		case string:
+			return x
+		case float64:
+			// JSON numbers come back as float64 — trim trailing .0 for integer-ish values.
+			if x == float64(int64(x)) {
+				return fmt.Sprintf("%d", int64(x))
+			}
+			return fmt.Sprintf("%g", x)
+		default:
+			return fmt.Sprintf("%v", v)
+		}
+	}
+
+	prNum := get("pr_number")
+	prURL := get("pr_url")
+
+	switch evt.Type {
+	case event.AgentStarted:
+		prompt := get("prompt")
+		if prompt != "" {
+			return truncateLine(prompt, 80)
+		}
+		return "agent started"
+	case event.AgentCompleted:
+		cost := get("cost_usd")
+		if cost != "" {
+			return fmt.Sprintf("agent completed (cost $%s)", cost)
+		}
+		return "agent completed"
+	case event.AgentPRCreated:
+		if prNum != "" && prURL != "" {
+			return fmt.Sprintf("PR #%s: %s", prNum, prURL)
+		}
+		if prURL != "" {
+			return prURL
+		}
+		return "PR created"
+	case event.AgentCIPassed:
+		if prNum != "" {
+			return fmt.Sprintf("CI passed on PR #%s", prNum)
+		}
+		return "CI passed"
+	case event.AgentCIFailed:
+		if prNum != "" {
+			return fmt.Sprintf("CI failed on PR #%s", prNum)
+		}
+		return "CI failed"
+	case event.AgentNeedsAttention:
+		reason := get("reason")
+		if reason != "" {
+			return fmt.Sprintf("needs attention — %s", reason)
+		}
+		return "needs attention"
+	case event.PRAwaitingApproval:
+		if prNum != "" {
+			return fmt.Sprintf("PR #%s awaiting approval", prNum)
+		}
+		return "PR awaiting approval"
+	case event.PRApproved:
+		if prNum != "" {
+			return fmt.Sprintf("PR #%s approved", prNum)
+		}
+		return "PR approved"
+	case event.PRMerged:
+		if prNum != "" {
+			return fmt.Sprintf("PR #%s merged", prNum)
+		}
+		return "PR merged"
+	}
+
+	// Generic fallback: list known fields in a stable order.
+	if d == nil {
+		return ""
+	}
+	keys := make([]string, 0, len(d))
+	for k := range d {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		v := get(k)
+		if v == "" {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s=%s", k, v))
+	}
+	return strings.Join(parts, " ")
+}
+
+func truncateLine(s string, max int) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	if len(s) <= max {
+		return s
+	}
+	if max <= 1 {
+		return s[:max]
+	}
+	return s[:max-1] + "…"
+}
+
+// waitForFile blocks until path exists or timeout elapses. Polls every 500ms.
+// Returns nil if the file becomes available.
+func waitForFile(ctx context.Context, path string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("stat events file: %w", err)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("events file did not appear within %s: %s", timeout, path)
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+// statInode returns the inode for path, or 0 if unavailable.
+// Used to detect log rotation when fsnotify drops a notification.
+func statInode(path string) uint64 {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	sys, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0
+	}
+	return sys.Ino
+}
+
+func printKnownEventTypes(out io.Writer) {
+	// Group live first, then reserved, alphabetically within each group.
+	live := make([]eventTypeInfo, 0)
+	reserved := make([]eventTypeInfo, 0)
+	for _, t := range knownEventTypes {
+		if t.Status == "reserved" {
+			reserved = append(reserved, t)
+		} else {
+			live = append(live, t)
+		}
+	}
+	sort.Slice(live, func(i, j int) bool { return live[i].Type < live[j].Type })
+	sort.Slice(reserved, func(i, j int) bool { return reserved[i].Type < reserved[j].Type })
+
+	fmt.Fprintln(out, "Live event types (currently emitted by klaus):")
+	for _, t := range live {
+		fmt.Fprintf(out, "  %-24s %s\n", t.Type, t.Desc)
+	}
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Reserved event types (not currently emitted; included in default filter for forward-compat):")
+	for _, t := range reserved {
+		fmt.Fprintf(out, "  %-24s %s\n", t.Type, t.Desc)
+	}
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Default filter:")
+	def := append([]string{}, defaultWatchFilter...)
+	sort.Strings(def)
+	fmt.Fprintln(out, "  "+strings.Join(def, ", "))
+}

--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -468,15 +468,15 @@ func eventSummary(evt event.Event) string {
 }
 
 func truncateLine(s string, max int) string {
-	s = strings.ReplaceAll(s, "\n", " ")
-	s = strings.ReplaceAll(s, "\r", " ")
-	if len(s) <= max {
+	s = strings.Join(strings.Fields(s), " ")
+	runes := []rune(s)
+	if len(runes) <= max {
 		return s
 	}
 	if max <= 1 {
-		return s[:max]
+		return string(runes[:max])
 	}
-	return s[:max-1] + "…"
+	return string(runes[:max-1]) + "…"
 }
 
 // waitForFile blocks until path exists or timeout elapses. Polls every 500ms.

--- a/internal/cmd/watch_test.go
+++ b/internal/cmd/watch_test.go
@@ -90,6 +90,34 @@ func TestWatchFilterMatches(t *testing.T) {
 	}
 }
 
+// TestTruncateLine verifies the genuinely tricky parts of truncateLine: rune
+// (not byte) slicing so multi-byte UTF-8 characters survive truncation, and
+// whitespace collapsing via strings.Fields.
+func TestTruncateLine(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{"shorter than max passes through", "hello", 10, "hello"},
+		{"collapses internal whitespace", "a\nb\tc  d", 20, "a b c d"},
+		{"trims leading and trailing whitespace", "  hi  ", 20, "hi"},
+		{"truncates ASCII with ellipsis", "abcdefghij", 5, "abcd…"},
+		{"counts runes not bytes for length check", "héllo", 5, "héllo"},
+		{"truncates multi-byte runes without splitting", "日本語テスト", 4, "日本語…"},
+		{"max==1 returns one rune (no ellipsis room)", "日本語", 1, "日"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := truncateLine(tc.in, tc.max)
+			if got != tc.want {
+				t.Errorf("truncateLine(%q, %d) = %q, want %q", tc.in, tc.max, got, tc.want)
+			}
+		})
+	}
+}
+
 // klausBinary lazily builds the real klaus binary and returns its path. All
 // integration tests below run klaus as a subprocess so we exercise the full
 // command surface including SIGTERM handling, line-buffered stdout, and

--- a/internal/cmd/watch_test.go
+++ b/internal/cmd/watch_test.go
@@ -1,0 +1,480 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/patflynn/klaus/internal/event"
+)
+
+// TestWatchFilterMatches is a pure unit test for the genuinely-tricky filter
+// helper. Everything else about 'klaus watch' is exercised via the real
+// binary integration test below.
+func TestWatchFilterMatches(t *testing.T) {
+	cases := []struct {
+		name      string
+		include   []string
+		exclude   []string
+		eventType string
+		want      bool
+	}{
+		{
+			name:      "empty include uses default filter; type in default included",
+			eventType: event.AgentPRCreated,
+			want:      true,
+		},
+		{
+			name:      "empty include uses default filter; type not in default excluded",
+			eventType: event.AgentStarted,
+			want:      false,
+		},
+		{
+			name:      "explicit include narrows to listed types",
+			include:   []string{event.PRMerged},
+			eventType: event.PRMerged,
+			want:      true,
+		},
+		{
+			name:      "explicit include excludes everything else",
+			include:   []string{event.PRMerged},
+			eventType: event.AgentPRCreated,
+			want:      false,
+		},
+		{
+			name:      "filter-out subtracts from default",
+			exclude:   []string{event.PRApproved},
+			eventType: event.PRApproved,
+			want:      false,
+		},
+		{
+			name:      "filter-out subtracts from explicit include too",
+			include:   []string{event.PRMerged, event.PRApproved},
+			exclude:   []string{event.PRApproved},
+			eventType: event.PRApproved,
+			want:      false,
+		},
+		{
+			name:      "blank entries in filter are ignored",
+			include:   []string{"", " ", event.PRMerged},
+			eventType: event.PRMerged,
+			want:      true,
+		},
+		{
+			name:      "reserved type ci:failed is in default filter",
+			eventType: "ci:failed",
+			want:      true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := buildFilter(tc.include, tc.exclude)
+			got := f.matches(tc.eventType)
+			if got != tc.want {
+				t.Errorf("matches(%q) with include=%v exclude=%v = %v, want %v",
+					tc.eventType, tc.include, tc.exclude, got, tc.want)
+			}
+		})
+	}
+}
+
+// klausBinary lazily builds the real klaus binary and returns its path. All
+// integration tests below run klaus as a subprocess so we exercise the full
+// command surface including SIGTERM handling, line-buffered stdout, and
+// fsnotify-driven streaming.
+func klausBinary(t *testing.T) string {
+	t.Helper()
+	binDir := t.TempDir()
+	bin := filepath.Join(binDir, "klaus")
+	// internal/cmd is two levels below the module root.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	modRoot := filepath.Dir(filepath.Dir(cwd))
+	build := exec.Command("go", "build", "-o", bin, "./cmd/klaus")
+	build.Dir = modRoot
+	build.Stderr = os.Stderr
+	if err := build.Run(); err != nil {
+		t.Fatalf("go build klaus: %v", err)
+	}
+	return bin
+}
+
+type watchProc struct {
+	cmd    *exec.Cmd
+	stdout *bufio.Scanner
+	stderr *bytes.Buffer
+	done   chan error
+}
+
+func startWatch(t *testing.T, bin, sessionID, home string, args ...string) *watchProc {
+	t.Helper()
+	all := append([]string{"watch", "--session-id", sessionID}, args...)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	cmd := exec.CommandContext(ctx, bin, all...)
+	cmd.Env = append(os.Environ(), "HOME="+home)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("StdoutPipe: %v", err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting klaus watch: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	return &watchProc{cmd: cmd, stdout: scanner, stderr: &stderr, done: done}
+}
+
+func (p *watchProc) nextLine(t *testing.T, timeout time.Duration) string {
+	t.Helper()
+	type result struct {
+		line string
+		ok   bool
+	}
+	ch := make(chan result, 1)
+	go func() {
+		ok := p.stdout.Scan()
+		ch <- result{line: p.stdout.Text(), ok: ok}
+	}()
+	select {
+	case r := <-ch:
+		if !r.ok {
+			t.Fatalf("klaus watch stdout closed (stderr: %s)", p.stderr.String())
+		}
+		return r.line
+	case <-time.After(timeout):
+		t.Fatalf("timed out waiting for line from klaus watch (stderr: %s)", p.stderr.String())
+		return ""
+	}
+}
+
+// stopSIGTERM sends SIGTERM and verifies the process exits cleanly.
+func (p *watchProc) stopSIGTERM(t *testing.T) {
+	t.Helper()
+	if err := p.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("sending SIGTERM: %v", err)
+	}
+	select {
+	case err := <-p.done:
+		if err != nil {
+			// Exit triggered by signal handler is expected to be clean (nil).
+			// signal.NotifyContext + RunE returning nil yields exit code 0.
+			t.Fatalf("klaus watch exited with error after SIGTERM: %v (stderr: %s)", err, p.stderr.String())
+		}
+	case <-time.After(5 * time.Second):
+		_ = p.cmd.Process.Kill()
+		t.Fatalf("klaus watch did not exit within 5s after SIGTERM (stderr: %s)", p.stderr.String())
+	}
+}
+
+// emitter is a helper that appends events to events.jsonl using the same
+// writer the rest of klaus uses.
+type emitter struct {
+	log *event.Log
+}
+
+func newEmitter(sessionDir string) *emitter {
+	return &emitter{log: event.NewLog(sessionDir)}
+}
+
+func (e *emitter) emit(t *testing.T, runID, typ string, data map[string]interface{}) {
+	t.Helper()
+	if err := e.log.Emit(event.New(runID, typ, data)); err != nil {
+		t.Fatalf("emit event: %v", err)
+	}
+}
+
+func setupSessionDir(t *testing.T) (home, sessionID, sessionDir string) {
+	t.Helper()
+	home = t.TempDir()
+	sessionID = "test-watch-session"
+	sessionDir = filepath.Join(home, ".klaus", "sessions", sessionID)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	return
+}
+
+// touchEventsFile pre-creates an empty events.jsonl so 'klaus watch' moves
+// past its waitForFile phase without racing with a concurrent first emit.
+// Production users hit the same race only if the file is created mid-startup,
+// which is harmless — the wait loop polls every 500ms and picks it up.
+func touchEventsFile(t *testing.T, sessionDir string) {
+	t.Helper()
+	f, err := os.OpenFile(filepath.Join(sessionDir, "events.jsonl"), os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("creating events.jsonl: %v", err)
+	}
+	f.Close()
+}
+
+func TestWatchStreamsNewEvents(t *testing.T) {
+	bin := klausBinary(t)
+	home, sessionID, sessionDir := setupSessionDir(t)
+	em := newEmitter(sessionDir)
+
+	// Pre-write one event that should NOT appear (default: tail mode).
+	em.emit(t, "old-run", event.PRMerged, map[string]interface{}{"pr_number": "1"})
+
+	p := startWatch(t, bin, sessionID, home)
+
+	// Give the subprocess a moment to seek to EOF and arm fsnotify.
+	time.Sleep(300 * time.Millisecond)
+
+	em.emit(t, "85", event.PRMerged, map[string]interface{}{"pr_number": "85"})
+	line := p.nextLine(t, 5*time.Second)
+	if !strings.Contains(line, "pr:merged") {
+		t.Errorf("expected pr:merged line, got %q", line)
+	}
+	if !strings.Contains(line, "PR #85 merged") {
+		t.Errorf("expected formatted PR #85 merged summary, got %q", line)
+	}
+
+	em.emit(t, "85", event.AgentPRCreated, map[string]interface{}{
+		"pr_number": "85",
+		"pr_url":    "https://github.com/owner/repo/pull/85",
+	})
+	line = p.nextLine(t, 5*time.Second)
+	if !strings.Contains(line, "agent:pr-created") {
+		t.Errorf("expected agent:pr-created line, got %q", line)
+	}
+	if !strings.Contains(line, "https://github.com/owner/repo/pull/85") {
+		t.Errorf("expected PR URL in line, got %q", line)
+	}
+
+	p.stopSIGTERM(t)
+}
+
+func TestWatchSinceStartReplays(t *testing.T) {
+	bin := klausBinary(t)
+	home, sessionID, sessionDir := setupSessionDir(t)
+	em := newEmitter(sessionDir)
+
+	em.emit(t, "1", event.PRMerged, map[string]interface{}{"pr_number": "1"})
+	em.emit(t, "2", event.PRMerged, map[string]interface{}{"pr_number": "2"})
+
+	p := startWatch(t, bin, sessionID, home, "--since-start")
+
+	line1 := p.nextLine(t, 5*time.Second)
+	if !strings.Contains(line1, "PR #1 merged") {
+		t.Errorf("expected first replayed event for PR #1, got %q", line1)
+	}
+	line2 := p.nextLine(t, 5*time.Second)
+	if !strings.Contains(line2, "PR #2 merged") {
+		t.Errorf("expected second replayed event for PR #2, got %q", line2)
+	}
+
+	p.stopSIGTERM(t)
+}
+
+func TestWatchFilterFlag(t *testing.T) {
+	bin := klausBinary(t)
+	home, sessionID, sessionDir := setupSessionDir(t)
+	em := newEmitter(sessionDir)
+
+	touchEventsFile(t, sessionDir)
+	// --filter narrows to only pr:merged
+	p := startWatch(t, bin, sessionID, home, "--filter", event.PRMerged)
+	time.Sleep(300 * time.Millisecond)
+
+	// This one should be filtered out — default would include it.
+	em.emit(t, "9", event.AgentPRCreated, map[string]interface{}{
+		"pr_number": "9", "pr_url": "https://example.com/pull/9",
+	})
+	// This one passes the filter.
+	em.emit(t, "9", event.PRMerged, map[string]interface{}{"pr_number": "9"})
+
+	line := p.nextLine(t, 5*time.Second)
+	if !strings.Contains(line, "pr:merged") {
+		t.Errorf("expected pr:merged after filtering, got %q", line)
+	}
+	if strings.Contains(line, "agent:pr-created") {
+		t.Errorf("did not expect agent:pr-created to leak past --filter, got %q", line)
+	}
+
+	p.stopSIGTERM(t)
+}
+
+func TestWatchFilterOutFlag(t *testing.T) {
+	bin := klausBinary(t)
+	home, sessionID, sessionDir := setupSessionDir(t)
+	em := newEmitter(sessionDir)
+
+	touchEventsFile(t, sessionDir)
+	p := startWatch(t, bin, sessionID, home, "--filter-out", event.PRApproved)
+	time.Sleep(300 * time.Millisecond)
+
+	em.emit(t, "12", event.PRApproved, map[string]interface{}{"pr_number": "12"})
+	em.emit(t, "12", event.PRMerged, map[string]interface{}{"pr_number": "12"})
+
+	line := p.nextLine(t, 5*time.Second)
+	if strings.Contains(line, "pr:approved") {
+		t.Errorf("pr:approved should have been excluded, got %q", line)
+	}
+	if !strings.Contains(line, "pr:merged") {
+		t.Errorf("expected pr:merged to pass through filter-out, got %q", line)
+	}
+
+	p.stopSIGTERM(t)
+}
+
+func TestWatchJSONPassthrough(t *testing.T) {
+	bin := klausBinary(t)
+	home, sessionID, sessionDir := setupSessionDir(t)
+	em := newEmitter(sessionDir)
+
+	touchEventsFile(t, sessionDir)
+	p := startWatch(t, bin, sessionID, home, "--json")
+	time.Sleep(300 * time.Millisecond)
+
+	em.emit(t, "42", event.PRMerged, map[string]interface{}{
+		"pr_number": "42",
+		"pr_url":    "https://github.com/owner/repo/pull/42",
+	})
+
+	line := p.nextLine(t, 5*time.Second)
+	var evt event.Event
+	if err := json.Unmarshal([]byte(line), &evt); err != nil {
+		t.Fatalf("expected valid JSON line, got %q: %v", line, err)
+	}
+	if evt.Type != event.PRMerged {
+		t.Errorf("type = %q, want %q", evt.Type, event.PRMerged)
+	}
+	if evt.RunID != "42" {
+		t.Errorf("run_id = %q, want %q", evt.RunID, "42")
+	}
+	if evt.Data["pr_number"] != "42" {
+		t.Errorf("pr_number = %v, want 42", evt.Data["pr_number"])
+	}
+
+	// Verify byte-for-byte equivalence to the original line in the events file.
+	// The emitter appends a single JSON object per line so reading the file
+	// gives us the exact line klaus watch should have emitted.
+	raw, err := os.ReadFile(filepath.Join(sessionDir, "events.jsonl"))
+	if err != nil {
+		t.Fatalf("reading events.jsonl: %v", err)
+	}
+	srcLines := strings.Split(strings.TrimRight(string(raw), "\n"), "\n")
+	if len(srcLines) != 1 {
+		t.Fatalf("expected 1 source line, got %d", len(srcLines))
+	}
+	if line != srcLines[0] {
+		t.Errorf("watch --json output not byte-equivalent to source\n got:  %q\n want: %q", line, srcLines[0])
+	}
+
+	p.stopSIGTERM(t)
+}
+
+func TestWatchExitsOnSIGTERMCleanly(t *testing.T) {
+	bin := klausBinary(t)
+	home, sessionID, _ := setupSessionDir(t)
+	// No emits — just confirm SIGTERM during idle wait causes clean exit.
+
+	p := startWatch(t, bin, sessionID, home)
+	time.Sleep(200 * time.Millisecond)
+	p.stopSIGTERM(t)
+}
+
+func TestWatchRequiresSessionID(t *testing.T) {
+	bin := klausBinary(t)
+	cmd := exec.Command(bin, "watch")
+	// Clear KLAUS_SESSION_ID from the env in case the test runner has one set.
+	env := []string{}
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "KLAUS_SESSION_ID=") {
+			continue
+		}
+		env = append(env, e)
+	}
+	cmd.Env = env
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Stdout = io.Discard
+	err := cmd.Run()
+	if err == nil {
+		t.Fatalf("expected klaus watch to fail without KLAUS_SESSION_ID, succeeded")
+	}
+	if !strings.Contains(stderr.String(), "must be run inside a klaus session") {
+		t.Errorf("expected helpful error message about missing session, got: %s", stderr.String())
+	}
+}
+
+func TestWatchListTypes(t *testing.T) {
+	bin := klausBinary(t)
+	cmd := exec.Command(bin, "watch", "--list-types")
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("klaus watch --list-types failed: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Live event types") {
+		t.Errorf("expected 'Live event types' heading, got: %s", out)
+	}
+	if !strings.Contains(out, "Reserved event types") {
+		t.Errorf("expected 'Reserved event types' heading, got: %s", out)
+	}
+	if !strings.Contains(out, event.PRMerged) {
+		t.Errorf("expected pr:merged in output, got: %s", out)
+	}
+	if !strings.Contains(out, "ci:failed") {
+		t.Errorf("expected ci:failed (reserved) in output, got: %s", out)
+	}
+}
+
+// Sanity check that multiple emissions arrive in order.
+func TestWatchPreservesOrder(t *testing.T) {
+	bin := klausBinary(t)
+	home, sessionID, sessionDir := setupSessionDir(t)
+	em := newEmitter(sessionDir)
+
+	touchEventsFile(t, sessionDir)
+	p := startWatch(t, bin, sessionID, home, "--filter", event.PRMerged)
+	time.Sleep(300 * time.Millisecond)
+
+	const n = 5
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < n; i++ {
+			em.emit(t, "ord", event.PRMerged, map[string]interface{}{"pr_number": strconv.Itoa(i)})
+			time.Sleep(50 * time.Millisecond)
+		}
+	}()
+
+	for i := 0; i < n; i++ {
+		line := p.nextLine(t, 5*time.Second)
+		want := "PR #" + strconv.Itoa(i) + " merged"
+		if !strings.Contains(line, want) {
+			t.Errorf("line %d: expected %q in %q", i, want, line)
+		}
+	}
+	wg.Wait()
+	p.stopSIGTERM(t)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -414,6 +414,18 @@ You do NOT need to manually monitor CI or dispatch fix agents — the pipeline h
 - Reviewing agent output when the pipeline stalls
 - Approving PRs that are ready (` + "`klaus approve`" + `)
 
+## Real-time pipeline event channel
+
+Klaus writes structured pipeline events (PR created/approved/merged, CI passed/failed, agent errors, review comments) to a JSONL stream you can subscribe to via Claude Code's Monitor tool. Recommended: at session start, arm a persistent Monitor on this stream so you react to events asynchronously rather than polling klaus status:
+
+Command to arm in Monitor (set persistent: true):
+
+  klaus watch
+
+Each matching event becomes a notification injected into your context between turns. React when relevant — e.g. dispatch a follow-up agent the moment a dependency PR merges, or surface a CI failure to the user without being asked. Use the default filter unless the user asks for something narrower; override with ` + "`klaus watch --filter <type>`" + ` (repeatable). Do not arm more than one watch — the second one duplicates notifications.
+
+Events arrive only while the REPL is idle between turns. If a flurry lands during a long tool call, they batch up until you return. Plan accordingly: a Monitor isn't a guarantee of instant reaction, just a guarantee that you'll see the event before the user has to mention it.
+
 ## State and tracking
 
 - Each agent run creates a state file at ` + "`~/.klaus/sessions/{session-id}/runs/{run-id}.json`" + `


### PR DESCRIPTION
## Summary

Exposes the existing `events.jsonl` pipeline stream as a coordinator-consumable channel via a new `klaus watch` command. The dashboard already reads the same file via fsnotify; this PR adds a CLI consumer designed for Claude Code's [Monitor tool](https://docs.anthropic.com/en/docs/claude-code), where each stdout line becomes a notification injected into the coordinator's context between turns.

Why: today the coordinator only sees PR/CI state changes when the user asks or when it runs `klaus status` by hand. With `klaus watch` armed via Monitor, the coordinator can react asynchronously — auto-dispatching a follow-up agent the moment a dependency PR merges, surfacing a CI failure without prompting, etc.

The session system prompt now suggests arming a persistent Monitor on `klaus watch` at session start.

## What's in this PR

- `internal/cmd/watch.go` — new cobra command. Tails `~/.klaus/sessions/$KLAUS_SESSION_ID/events.jsonl` via fsnotify with a defensive 500ms ticker fallback for missed inotify notifications and inode swaps. Emits one line per event to unbuffered stdout.
- Flags: `--filter` / `--filter-out` (repeatable, OR semantics; `--filter` replaces the default), `--since-start` (replay file then follow), `--json` (raw passthrough), `--list-types` (print known event types and exit), `--session-id` (override env var for testing).
- Default filter: `agent:pr-created, agent:error, pr:approved, pr:merged, ci:failed, ci:passed, pr:comment`. Some of those are reserved (not currently emitted) but kept in the default for forward-compatibility — `--list-types` distinguishes live from reserved.
- `internal/config/config.go` — adds a "Real-time pipeline event channel" section to the default coordinator session prompt.
- `internal/cmd/watch_test.go` — integration tests that build and exec the real binary, plus a unit test for the filter-matching helper (the only piece with non-obvious logic).
- `README.md` — documents the command and adds it to the commands table.

## Example session

```
$ KLAUS_SESSION_ID=20260529-1639-a841ece9 klaus watch
20:23:10  20260529-1619-54f8b21f  agent:pr-created        PR #85: https://github.com/owner/repo/pull/85
20:36:13  85                      pr:approved             PR #85 approved
20:36:13  85                      pr:merged               PR #85 merged

# Narrow to merges only:
$ klaus watch --filter pr:merged

# Default filter minus self-approvals:
$ klaus watch --filter-out pr:approved

# Raw JSONL for downstream tools:
$ klaus watch --json
```

## Test plan

- [x] `go test ./...` passes
- [x] `go build ./...` passes
- [x] `klaus watch` streams new events line-by-line (integration test)
- [x] `--filter` and `--filter-out` scope events correctly (integration test)
- [x] `--since-start` replays existing file entries (integration test)
- [x] `--json` is byte-equivalent passthrough of the source line (integration test)
- [x] SIGTERM exits cleanly with no error (integration test)
- [x] Helpful error when `KLAUS_SESSION_ID` is unset (integration test)
- [x] `--list-types` shows live vs reserved event types (integration test)
- [x] README updated with command entry and "Real-time event channel" subsection
- [x] Session coordinator prompt includes the new "Real-time pipeline event channel" block

Run: 20260529-1648-fd323448