### PR TITLE
Pause agents on budget exhaustion instead of killing them

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ The coordinator session uses these — you generally don't run them directly:
 | `klaus target owner/repo` | Set session-level default target repo |
 | `klaus status` | Dashboard of all runs (with CI, conflict, and merge-readiness columns) |
 | `klaus logs <id>` | View agent output (live, replay, or raw) |
+| `klaus resume <id> [--add-budget <usd>]` | Resume a paused agent with extended budget |
+| `klaus finalize <id> [--open-pr]` | Commit and push a paused agent's WIP without resuming claude |
 | `klaus cleanup <id>\|--all` | Tear down worktrees, panes, and state |
 | `klaus push-log <id>` | Force-push a log held back for sensitivity |
 | `klaus project add <owner/repo>` | Register a project (clones if needed) |
@@ -122,6 +124,26 @@ klaus launch --pr 42 --issue 10 "Fix the auth bug mentioned in review"
 ```
 
 The `--pr` and `--issue` flags can coexist (the agent may reference the issue in commits).
+
+### Pause and resume
+
+Agents that exceed their `--budget` cap are **paused** rather than killed. Their git worktree and tmux pane are preserved so any in-progress work can be recovered. Watch for an `agent:paused` event (visible in `klaus notifications` and the dashboard); the agent stops emitting log activity but the state file flips to `status: paused`.
+
+There are three recovery paths:
+
+```bash
+klaus resume <run-id>                          # add $5 to the budget cap and continue
+klaus resume <run-id> --add-budget 10          # add $10
+klaus resume <run-id> --budget 20              # set an absolute new cap of $20
+
+klaus finalize <run-id>                        # commit any uncommitted changes and push
+klaus finalize <run-id> --message "fix auth"   # custom commit message
+klaus finalize <run-id> --open-pr              # also open a draft PR
+
+klaus cleanup <run-id>                         # discard the work (explicit throw-away)
+```
+
+`klaus resume` relaunches claude in the same worktree using `--resume <session-id>`, so the conversation context is preserved. `klaus finalize` saves the work without paying for more agent time. `klaus cleanup` is unchanged and remains the explicit "delete it all" path — it also works on paused runs without `--force`.
 
 ### `klaus launch --repo`
 

--- a/internal/cmd/cleanup.go
+++ b/internal/cmd/cleanup.go
@@ -91,6 +91,16 @@ func defaultIsRunActive(state *run.State, tc tmux.Client) bool {
 		}
 	}
 
+	// Paused and finalized runs have given up their claim on resources —
+	// their tmux pane may still exist (paused agents preserve theirs), but
+	// they are explicitly safe to clean up without --force.
+	if state.Status != nil {
+		switch *state.Status {
+		case run.StatusPaused, run.StatusFinalized, run.StatusCompleted:
+			return false
+		}
+	}
+
 	if state.IsAgentRunning() {
 		return true
 	}

--- a/internal/cmd/finalize.go
+++ b/internal/cmd/finalize.go
@@ -1,0 +1,196 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/patflynn/klaus/internal/event"
+	"github.com/patflynn/klaus/internal/run"
+	"github.com/spf13/cobra"
+)
+
+var finalizeWIPCmd = &cobra.Command{
+	Use:   "finalize <run-id>",
+	Short: "Commit and push a paused agent's work-in-progress",
+	Long: `Commits any uncommitted changes in the run's worktree and pushes the
+branch, without resuming claude. Use this when you want to save the work
+an agent did before it paused but don't want to spend more on agent time.
+
+By default a generic 'WIP from klaus run <id>' commit message is used; pass
+--message to provide your own. Pass --open-pr to also open a draft PR.
+
+The run must be in 'paused' or 'completed' state. To resume the agent
+instead, use 'klaus resume'. To throw the work away, use 'klaus cleanup'.`,
+	Example: `  klaus finalize 20260529-1657-abcd1234
+  klaus finalize 20260529-1657-abcd1234 --message "fix auth bug"
+  klaus finalize 20260529-1657-abcd1234 --open-pr`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id := args[0]
+		message, _ := cmd.Flags().GetString("message")
+		openPR, _ := cmd.Flags().GetBool("open-pr")
+		ctx := cmd.Context()
+
+		store, err := sessionStore()
+		if err != nil {
+			return err
+		}
+
+		state, err := store.Load(id)
+		if err != nil {
+			return fmt.Errorf("no run found with id: %s", id)
+		}
+
+		status := stringValue(state.Status)
+		if status != run.StatusPaused && status != run.StatusCompleted {
+			return fmt.Errorf("run %s is not paused or completed, current status: %s (use 'klaus cleanup' to discard, or wait until the run finishes)", id, statusOrRunning(status))
+		}
+
+		if state.Worktree == "" {
+			return fmt.Errorf("run %s has no worktree to finalize (it may already have been cleaned up)", id)
+		}
+
+		if message == "" {
+			message = fmt.Sprintf("WIP from klaus run %s\n\n%s", id, strings.TrimSpace(state.Prompt))
+		}
+
+		committed, err := commitWorkInProgress(ctx, state.Worktree, message)
+		if err != nil {
+			return err
+		}
+		if committed {
+			fmt.Printf("Created commit on %s.\n", state.Branch)
+		} else {
+			fmt.Println("No uncommitted changes to commit.")
+		}
+
+		if err := pushBranch(ctx, state.Worktree, state.Branch); err != nil {
+			return fmt.Errorf("pushing branch: %w", err)
+		}
+		fmt.Printf("Pushed %s.\n", state.Branch)
+
+		if openPR {
+			title := promptTitle(state.Prompt)
+			body := fmt.Sprintf("Finalized from klaus run %s after the agent paused. Pushed for human inspection.\n\nRun: %s", id, id)
+			prURL, err := createDraftPR(ctx, state.Worktree, title, body)
+			if err != nil {
+				fmt.Fprintf(cmd.OutOrStderr(), "warning: gh pr create failed: %v\n", err)
+			} else if prURL != "" {
+				state.PRURL = &prURL
+				fmt.Printf("Opened draft PR: %s\n", prURL)
+			}
+		}
+
+		setStatus(state, run.StatusFinalized)
+		state.PausedAt = nil
+		state.PauseReason = nil
+		if err := store.Save(state); err != nil {
+			return fmt.Errorf("saving state: %w", err)
+		}
+
+		if hds, ok := store.(*run.HomeDirStore); ok {
+			data := map[string]interface{}{
+				"id":           id,
+				"committed":    committed,
+				"opened_draft": openPR && state.PRURL != nil,
+			}
+			if state.PRURL != nil {
+				data["pr_url"] = *state.PRURL
+			}
+			emitEvent(hds.BaseDir(), id, event.AgentFinalized, data)
+		}
+
+		return nil
+	},
+}
+
+func statusOrRunning(s string) string {
+	if s == "" {
+		return "running"
+	}
+	return s
+}
+
+// commitWorkInProgress stages all changes in worktree and creates a commit
+// with the given message. Returns whether a commit was actually created
+// (false when the worktree was already clean).
+func commitWorkInProgress(ctx context.Context, worktree, message string) (bool, error) {
+	add := exec.CommandContext(ctx, "git", "-C", worktree, "add", "-A")
+	if out, err := add.CombinedOutput(); err != nil {
+		return false, fmt.Errorf("git add -A: %w: %s", err, string(out))
+	}
+
+	// Check if there's anything to commit. `git diff --cached --quiet` exits
+	// non-zero when there are staged changes.
+	check := exec.CommandContext(ctx, "git", "-C", worktree, "diff", "--cached", "--quiet")
+	if err := check.Run(); err == nil {
+		return false, nil // clean
+	}
+
+	commit := exec.CommandContext(ctx, "git", "-C", worktree, "commit", "-m", message)
+	var stderr bytes.Buffer
+	commit.Stderr = &stderr
+	if err := commit.Run(); err != nil {
+		return false, fmt.Errorf("git commit: %w: %s", err, stderr.String())
+	}
+	return true, nil
+}
+
+func pushBranch(ctx context.Context, worktree, branch string) error {
+	args := []string{"-C", worktree, "push", "-u", "origin"}
+	if branch != "" {
+		args = append(args, "HEAD:"+branch)
+	} else {
+		args = append(args, "HEAD")
+	}
+	cmd := exec.CommandContext(ctx, "git", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, string(out))
+	}
+	return nil
+}
+
+func createDraftPR(ctx context.Context, worktree, title, body string) (string, error) {
+	cmd := exec.CommandContext(ctx, "gh", "pr", "create", "--draft", "--title", title, "--body", body)
+	cmd.Dir = worktree
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", err, string(out))
+	}
+	// gh prints the PR URL on success
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "https://github.com/") && strings.Contains(line, "/pull/") {
+			return line, nil
+		}
+	}
+	return "", nil
+}
+
+// promptTitle takes the first non-empty line of an agent prompt and truncates
+// to fit a PR title (~70 chars).
+func promptTitle(prompt string) string {
+	const maxLen = 70
+	for _, line := range strings.Split(prompt, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if len(line) > maxLen {
+			line = line[:maxLen]
+		}
+		return line
+	}
+	return fmt.Sprintf("klaus finalize at %s", time.Now().Format("2006-01-02"))
+}
+
+func init() {
+	finalizeWIPCmd.Flags().String("message", "", "Commit message (default: 'WIP from klaus run <id>')")
+	finalizeWIPCmd.Flags().Bool("open-pr", false, "Open a draft PR after pushing")
+	rootCmd.AddCommand(finalizeWIPCmd)
+}

--- a/internal/cmd/finalize_test.go
+++ b/internal/cmd/finalize_test.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestFinalizeCommitAndPush exercises the real git commands the klaus
+// finalize command runs: 'git add -A', commit, and push to a local bare
+// remote. This is an integration test — no mocks — to catch regressions
+// in how WIP is preserved.
+func TestFinalizeCommitAndPush(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not in PATH")
+	}
+
+	dir := t.TempDir()
+
+	// Bare repo used as the 'origin' remote.
+	bare := filepath.Join(dir, "bare.git")
+	runGit(t, dir, "init", "--bare", bare)
+
+	// Working clone with an initial commit on main.
+	workDir := filepath.Join(dir, "work")
+	runGit(t, dir, "clone", bare, workDir)
+	configGitIdentity(t, workDir)
+	writeFile(t, filepath.Join(workDir, "README.md"), "# init\n")
+	runGit(t, workDir, "add", ".")
+	runGit(t, workDir, "commit", "-m", "init")
+	runGit(t, workDir, "branch", "-M", "main")
+	runGit(t, workDir, "push", "-u", "origin", "main")
+
+	// Create the agent's branch with one staged-and-committed change plus
+	// an uncommitted change (the "WIP" the agent never got to commit).
+	runGit(t, workDir, "checkout", "-b", "agent/test-branch")
+	writeFile(t, filepath.Join(workDir, "wip.txt"), "uncommitted edits\n")
+
+	t.Run("commits uncommitted changes", func(t *testing.T) {
+		ctx := context.Background()
+		committed, err := commitWorkInProgress(ctx, workDir, "WIP from klaus")
+		if err != nil {
+			t.Fatalf("commitWorkInProgress: %v", err)
+		}
+		if !committed {
+			t.Fatal("expected commit to be created for dirty worktree")
+		}
+
+		// Run a second time on a clean worktree — should be a no-op.
+		committed2, err := commitWorkInProgress(ctx, workDir, "WIP from klaus")
+		if err != nil {
+			t.Fatalf("commitWorkInProgress (clean): %v", err)
+		}
+		if committed2 {
+			t.Error("expected no commit on clean worktree")
+		}
+	})
+
+	t.Run("pushes branch to origin", func(t *testing.T) {
+		ctx := context.Background()
+		if err := pushBranch(ctx, workDir, "agent/test-branch"); err != nil {
+			t.Fatalf("pushBranch: %v", err)
+		}
+
+		// Verify the branch landed on the bare remote.
+		out := runGitOutput(t, bare, "branch", "--list", "agent/test-branch")
+		if !strings.Contains(out, "agent/test-branch") {
+			t.Errorf("expected agent/test-branch on origin, got: %q", out)
+		}
+	})
+}
+
+func TestFinalizeCommitWithCleanWorktree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not in PATH")
+	}
+
+	dir := t.TempDir()
+	runGit(t, dir, "init", dir)
+	configGitIdentity(t, dir)
+	writeFile(t, filepath.Join(dir, "f.txt"), "hello")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "init")
+
+	ctx := context.Background()
+	committed, err := commitWorkInProgress(ctx, dir, "WIP")
+	if err != nil {
+		t.Fatalf("commitWorkInProgress: %v", err)
+	}
+	if committed {
+		t.Error("expected no commit on already-clean worktree")
+	}
+}
+
+func configGitIdentity(t *testing.T, dir string) {
+	t.Helper()
+	runGit(t, dir, "config", "user.email", "test@test")
+	runGit(t, dir, "config", "user.name", "test")
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writeFile %s: %v", path, err)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func runGitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return string(out)
+}

--- a/internal/cmd/hidden.go
+++ b/internal/cmd/hidden.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
+	"time"
 
 	"github.com/patflynn/klaus/internal/config"
 	"github.com/patflynn/klaus/internal/event"
@@ -19,6 +21,11 @@ import (
 	"github.com/patflynn/klaus/internal/tmux"
 	"github.com/spf13/cobra"
 )
+
+// budgetExhaustionTolerance is the fraction of budget at which a completed
+// run is treated as paused (the claude binary self-terminates near, but not
+// always exactly at, the cap). Reaching 95% of the cap is enough.
+const budgetExhaustionTolerance = 0.95
 
 var formatStreamCmd = &cobra.Command{
 	Use:    "_format-stream",
@@ -54,7 +61,16 @@ var finalizeCmd = &cobra.Command{
 			}
 		}
 
+		// If claude exited because the budget cap was reached, treat the
+		// run as paused: keep the worktree and tmux pane intact so the
+		// coordinator can resume or save the in-progress work.
+		if isBudgetExhausted(state) {
+			pauseAfterBudgetExhaustion(store, state)
+			return nil
+		}
+
 		// Emit events for completed run
+		setStatus(state, run.StatusCompleted)
 		if hds, ok := store.(*run.HomeDirStore); ok {
 			baseDir := hds.BaseDir()
 
@@ -107,6 +123,67 @@ var finalizeCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+// isBudgetExhausted reports whether the run terminated because claude hit
+// its --max-budget-usd cap. We compare total spend to the configured cap;
+// claude self-terminates at or near the cap when budget is exhausted.
+func isBudgetExhausted(state *run.State) bool {
+	if state.Budget == nil || *state.Budget == "" {
+		return false
+	}
+	if state.CostUSD == nil {
+		return false
+	}
+	cap, err := strconv.ParseFloat(*state.Budget, 64)
+	if err != nil || cap <= 0 {
+		return false
+	}
+	return *state.CostUSD >= cap*budgetExhaustionTolerance
+}
+
+// setStatus assigns Status to the given value, allocating a fresh string
+// pointer so callers don't accidentally share storage across runs.
+func setStatus(state *run.State, status string) {
+	s := status
+	state.Status = &s
+}
+
+// pauseAfterBudgetExhaustion marks the run paused, emits the agent:paused
+// event, and prints a coordinator-facing one-liner pointing at the recovery
+// commands. The worktree and tmux pane are deliberately left intact.
+func pauseAfterBudgetExhaustion(store run.StateStore, state *run.State) {
+	setStatus(state, run.StatusPaused)
+	pausedAt := time.Now().UTC().Format(time.RFC3339)
+	state.PausedAt = &pausedAt
+	reason := run.PauseReasonBudgetExceeded
+	state.PauseReason = &reason
+
+	if err := store.Save(state); err != nil {
+		slog.Warn("failed to save paused state", "id", state.ID, "err", err)
+	}
+
+	cost := 0.0
+	if state.CostUSD != nil {
+		cost = *state.CostUSD
+	}
+	budget := ""
+	if state.Budget != nil {
+		budget = *state.Budget
+	}
+
+	if hds, ok := store.(*run.HomeDirStore); ok {
+		emitEvent(hds.BaseDir(), state.ID, event.AgentPaused, map[string]interface{}{
+			"id":         state.ID,
+			"reason":     run.PauseReasonBudgetExceeded,
+			"cost_usd":   cost,
+			"budget_usd": budget,
+		})
+	}
+
+	fmt.Printf("\nAgent %s paused: budget exceeded ($%.4f of $%s). "+
+		"Resume with 'klaus resume %s --add-budget <usd>', or save the WIP with 'klaus finalize %s'.\n",
+		state.ID, cost, budget, state.ID, state.ID)
 }
 
 // cleanupWorktree removes the agent's worktree and local branch after

--- a/internal/cmd/pause_test.go
+++ b/internal/cmd/pause_test.go
@@ -1,0 +1,271 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/patflynn/klaus/internal/event"
+	"github.com/patflynn/klaus/internal/run"
+	"github.com/patflynn/klaus/internal/tmux"
+)
+
+func TestIsBudgetExhausted(t *testing.T) {
+	budget := "5.00"
+	cost1 := 4.99
+	cost2 := 4.74
+	cost3 := 0.01
+
+	tests := []struct {
+		name  string
+		state *run.State
+		want  bool
+	}{
+		{
+			name:  "cost above 95% of budget",
+			state: &run.State{Budget: &budget, CostUSD: &cost1},
+			want:  true,
+		},
+		{
+			name:  "cost below 95% of budget",
+			state: &run.State{Budget: &budget, CostUSD: &cost2},
+			want:  false,
+		},
+		{
+			name:  "tiny cost",
+			state: &run.State{Budget: &budget, CostUSD: &cost3},
+			want:  false,
+		},
+		{
+			name:  "no budget set",
+			state: &run.State{CostUSD: &cost1},
+			want:  false,
+		},
+		{
+			name:  "no cost set",
+			state: &run.State{Budget: &budget},
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBudgetExhausted(tt.state); got != tt.want {
+				t.Errorf("isBudgetExhausted() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPauseAfterBudgetExhaustion(t *testing.T) {
+	dir := t.TempDir()
+	store := run.NewHomeDirStoreFromPath(dir)
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+
+	worktreePath := filepath.Join(dir, "wt")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatalf("creating fake worktree: %v", err)
+	}
+
+	budget := "1.00"
+	cost := 1.05
+	pane := "%42"
+	state := &run.State{
+		ID:       "test-run",
+		Branch:   "agent/test",
+		Worktree: worktreePath,
+		TmuxPane: &pane,
+		Budget:   &budget,
+		CostUSD:  &cost,
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	pauseAfterBudgetExhaustion(store, state)
+
+	// State updated in place
+	if state.Status == nil || *state.Status != run.StatusPaused {
+		t.Errorf("expected status=paused, got %v", state.Status)
+	}
+	if state.PauseReason == nil || *state.PauseReason != run.PauseReasonBudgetExceeded {
+		t.Errorf("expected PauseReason=%q, got %v", run.PauseReasonBudgetExceeded, state.PauseReason)
+	}
+	if state.PausedAt == nil || *state.PausedAt == "" {
+		t.Errorf("expected PausedAt to be set")
+	}
+	// Worktree and pane MUST be preserved
+	if state.Worktree == "" {
+		t.Errorf("expected worktree to be preserved on pause")
+	}
+	if state.TmuxPane == nil {
+		t.Errorf("expected TmuxPane to be preserved on pause")
+	}
+	// Disk reflects same
+	saved, err := store.Load("test-run")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if saved.Status == nil || *saved.Status != run.StatusPaused {
+		t.Errorf("expected saved status=paused, got %v", saved.Status)
+	}
+
+	// Worktree directory still present
+	if _, err := os.Stat(worktreePath); err != nil {
+		t.Errorf("expected worktree directory to still exist: %v", err)
+	}
+
+	// agent:paused event emitted
+	log := event.NewLog(dir)
+	events, err := log.Read()
+	if err != nil {
+		t.Fatalf("reading events: %v", err)
+	}
+	found := false
+	for _, evt := range events {
+		if evt.Type == event.AgentPaused && evt.RunID == "test-run" {
+			found = true
+			if reason, _ := evt.Data["reason"].(string); reason != run.PauseReasonBudgetExceeded {
+				t.Errorf("paused event reason = %q, want %q", reason, run.PauseReasonBudgetExceeded)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected agent:paused event in log, got events: %+v", events)
+	}
+}
+
+func TestCleanupOneAllowsPausedRuns(t *testing.T) {
+	// A paused run keeps its tmux pane alive — the cleanup deps must not
+	// classify that as "active" or 'klaus cleanup' would skip it without
+	// --force.
+	paused := run.StatusPaused
+	pane := "%42"
+	state := &run.State{
+		ID:       "paused-run",
+		Status:   &paused,
+		TmuxPane: &pane,
+	}
+
+	// Stub a tmux client that reports the pane as alive but not dead.
+	tc := &noopTmux{paneAlive: true}
+	if defaultIsRunActive(state, tc) {
+		t.Errorf("expected paused run with live pane to NOT be classified active")
+	}
+}
+
+func TestCleanupOneAllowsFinalizedRuns(t *testing.T) {
+	finalized := run.StatusFinalized
+	state := &run.State{
+		ID:     "finalized-run",
+		Status: &finalized,
+	}
+	tc := &noopTmux{paneAlive: true}
+	if defaultIsRunActive(state, tc) {
+		t.Errorf("expected finalized run to NOT be classified active")
+	}
+}
+
+// noopTmux satisfies tmux.Client for the cleanup-active tests. It embeds
+// the real ExecClient so the methods we don't care about compile; tests
+// here only call PaneExists, which is overridden below.
+type noopTmux struct {
+	tmux.ExecClient
+	paneAlive bool
+}
+
+func (n *noopTmux) PaneExists(_ context.Context, _ string) bool { return n.paneAlive }
+
+func TestComputeResumeBudget(t *testing.T) {
+	five := "5.00"
+	ten := "10.00"
+
+	tests := []struct {
+		name           string
+		current        *string
+		addBudget      float64
+		absoluteBudget string
+		want           string
+		wantErr        bool
+	}{
+		{
+			name:    "default add when both flags unset",
+			current: &five,
+			want:    "10.00",
+		},
+		{
+			name:      "explicit add",
+			current:   &five,
+			addBudget: 3,
+			want:      "8.00",
+		},
+		{
+			name:           "absolute overrides add",
+			current:        &five,
+			addBudget:      3,
+			absoluteBudget: "20",
+			want:           "20",
+		},
+		{
+			name:    "nil current treated as zero",
+			current: nil,
+			want:    "5.00",
+		},
+		{
+			name:           "invalid absolute is rejected",
+			current:        &ten,
+			absoluteBudget: "not-a-number",
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := computeResumeBudget(tt.current, tt.addBudget, tt.absoluteBudget)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("computeResumeBudget() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStatusOrRunning(t *testing.T) {
+	if got := statusOrRunning(""); got != "running" {
+		t.Errorf("expected 'running' for empty status, got %q", got)
+	}
+	if got := statusOrRunning("paused"); got != "paused" {
+		t.Errorf("expected 'paused', got %q", got)
+	}
+}
+
+func TestPromptTitle(t *testing.T) {
+	long := strings.Repeat("a", 200)
+	tests := []struct {
+		in     string
+		minLen int
+		maxLen int
+	}{
+		{in: "Fix the auth bug", minLen: 1, maxLen: 70},
+		{in: long, minLen: 70, maxLen: 70},
+		{in: "", minLen: 1, maxLen: 80},
+	}
+	for _, tt := range tests {
+		got := promptTitle(tt.in)
+		if len(got) < tt.minLen || len(got) > tt.maxLen {
+			t.Errorf("promptTitle(%q) length %d outside [%d,%d]", tt.in, len(got), tt.minLen, tt.maxLen)
+		}
+	}
+}

--- a/internal/cmd/resume.go
+++ b/internal/cmd/resume.go
@@ -1,0 +1,214 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/patflynn/klaus/internal/event"
+	"github.com/patflynn/klaus/internal/run"
+	"github.com/patflynn/klaus/internal/tmux"
+	"github.com/spf13/cobra"
+)
+
+// defaultResumeAddBudget is the budget bump applied when 'klaus resume' is
+// invoked with no --add-budget or --budget flag. Five dollars buys roughly
+// one more full attempt at the same task.
+const defaultResumeAddBudget = 5.0
+
+var resumeCmd = &cobra.Command{
+	Use:   "resume <run-id>",
+	Short: "Resume a paused agent run with extended budget",
+	Long: `Resumes a paused agent in its existing worktree using claude --resume.
+
+By default, the agent's budget cap is extended by $5. Use --add-budget to
+add a specific amount, or --budget to set an absolute new cap.
+
+The run must be in the 'paused' state (e.g. paused after exceeding its
+budget). To save the in-progress work without resuming, use 'klaus
+finalize' instead.`,
+	Example: `  klaus resume 20260529-1657-abcd1234                    # +$5 budget
+  klaus resume 20260529-1657-abcd1234 --add-budget 10    # +$10
+  klaus resume 20260529-1657-abcd1234 --budget 20        # absolute $20 cap`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id := args[0]
+		addBudget, _ := cmd.Flags().GetFloat64("add-budget")
+		absoluteBudget, _ := cmd.Flags().GetString("budget")
+		ctx := cmd.Context()
+		tmuxClient := tmux.NewExecClient()
+
+		if !tmux.InSession() {
+			return fmt.Errorf("klaus resume must be run inside a tmux session")
+		}
+
+		store, err := sessionStore()
+		if err != nil {
+			return err
+		}
+
+		state, err := store.Load(id)
+		if err != nil {
+			return fmt.Errorf("no run found with id: %s", id)
+		}
+
+		status := stringValue(state.Status)
+		if status != run.StatusPaused {
+			if status == "" {
+				status = "running"
+			}
+			return fmt.Errorf("run %s is not paused, current status: %s", id, status)
+		}
+
+		newBudget, err := computeResumeBudget(state.Budget, addBudget, absoluteBudget)
+		if err != nil {
+			return err
+		}
+
+		// Resolve the Claude session UUID. Without it we can't continue the
+		// existing conversation, only fork a new one.
+		var resumeSession string
+		if state.LogFile != nil {
+			resumeSession = ExtractClaudeSessionID(*state.LogFile)
+		}
+		if resumeSession == "" {
+			return fmt.Errorf("could not find claude session ID in log; cannot resume (try 'klaus finalize %s' instead)", id)
+		}
+		if !claudeSessionExists(resumeSession) {
+			return fmt.Errorf("claude session %s no longer exists on disk; cannot resume (try 'klaus finalize %s' instead)", resumeSession, id)
+		}
+
+		if state.Worktree == "" {
+			return fmt.Errorf("run %s has no worktree to resume into", id)
+		}
+		if _, err := os.Stat(state.Worktree); err != nil {
+			return fmt.Errorf("worktree %s no longer exists: %w", state.Worktree, err)
+		}
+
+		// Kill the dormant pane so we can split a fresh one in its place. The
+		// pane is idle at a shell prompt after the pipeline finished; reusing
+		// it would require fragile send-keys gymnastics.
+		killDormantPane(ctx, tmuxClient, state)
+
+		// Resume with a vanilla prompt — the system prompt and full
+		// conversation are already in the claude session being resumed.
+		resumePrompt := fmt.Sprintf("Continue the work. Budget has been extended to $%s.", newBudget)
+		claudeCmd := buildClaudeCommand("", newBudget, resumePrompt, id, resumeSession)
+
+		logFile := ""
+		if state.LogFile != nil {
+			logFile = *state.LogFile
+		} else {
+			logFile = store.LogDir() + "/" + id + ".jsonl"
+		}
+
+		// The same pipeline as launch — claude → tee → format-stream, then
+		// _finalize. _finalize will detect budget exhaustion again if the
+		// new cap is also hit and re-pause the run.
+		selfBin := "klaus"
+		paneCmd := fmt.Sprintf(
+			"%scd %s && %s | tee -a %s | %s _format-stream; %s _finalize %s",
+			tmuxSessionEnvPrefix(),
+			shellQuote(state.Worktree),
+			claudeCmd,
+			shellQuote(logFile),
+			selfBin,
+			selfBin,
+			shellQuote(id),
+		)
+
+		currentPane := os.Getenv("TMUX_PANE")
+		paneID, err := tmuxClient.SplitWindow(ctx, currentPane, state.Worktree, paneCmd)
+		if err != nil {
+			return fmt.Errorf("creating tmux pane: %w", err)
+		}
+		if err := tmuxClient.SetPaneTitle(ctx, paneID, FormatPaneTitle(id, stringValue(state.Issue), state.Prompt)); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to set pane title: %v\n", err)
+		}
+		if err := tmuxClient.SetWindowOption(ctx, paneID, "automatic-rename", "off"); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to disable automatic rename: %v\n", err)
+		}
+		if err := tmuxClient.LockPaneTitle(ctx, paneID); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to lock pane title: %v\n", err)
+		}
+		if err := tmuxClient.RebalanceLayout(ctx, currentPane); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to rebalance layout: %v\n", err)
+		}
+
+		setStatus(state, run.StatusRunning)
+		state.PausedAt = nil
+		state.PauseReason = nil
+		state.Budget = &newBudget
+		state.TmuxPane = &paneID
+		if err := store.Save(state); err != nil {
+			return fmt.Errorf("saving state: %w", err)
+		}
+
+		if hds, ok := store.(*run.HomeDirStore); ok {
+			emitEvent(hds.BaseDir(), id, event.AgentResumed, map[string]interface{}{
+				"id":             id,
+				"new_budget_usd": newBudget,
+				"add_budget_usd": addBudget,
+			})
+		}
+
+		fmt.Printf("Resuming agent %s with budget $%s in pane %s.\n", id, newBudget, paneID)
+		return nil
+	},
+}
+
+// computeResumeBudget produces the new budget cap as a string. Precedence:
+// --budget (absolute) > --add-budget (relative to current) > default add ($5).
+func computeResumeBudget(currentBudget *string, addBudget float64, absoluteBudget string) (string, error) {
+	if absoluteBudget != "" {
+		if _, err := strconv.ParseFloat(absoluteBudget, 64); err != nil {
+			return "", fmt.Errorf("invalid --budget %q: %w", absoluteBudget, err)
+		}
+		return absoluteBudget, nil
+	}
+
+	bump := addBudget
+	if bump == 0 {
+		bump = defaultResumeAddBudget
+	}
+
+	var current float64
+	if currentBudget != nil && *currentBudget != "" {
+		c, err := strconv.ParseFloat(*currentBudget, 64)
+		if err != nil {
+			return "", fmt.Errorf("invalid existing budget %q: %w", *currentBudget, err)
+		}
+		current = c
+	}
+
+	return strconv.FormatFloat(current+bump, 'f', 2, 64), nil
+}
+
+// killDormantPane kills a paused agent's tmux pane if it still exists. The
+// pane sits at an idle shell prompt after _finalize pauses the run, so it's
+// safe to kill before spawning the resume pane.
+func killDormantPane(ctx context.Context, tc tmux.Client, state *run.State) {
+	if state.TmuxPane == nil {
+		return
+	}
+	if !tc.PaneExists(ctx, *state.TmuxPane) {
+		return
+	}
+	if err := tc.KillPane(ctx, *state.TmuxPane); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to kill dormant pane %s: %v\n", *state.TmuxPane, err)
+	}
+}
+
+func stringValue(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+func init() {
+	resumeCmd.Flags().Float64("add-budget", 0, "Add this many USD to the existing budget cap (default $5)")
+	resumeCmd.Flags().String("budget", "", "Replace the budget cap with this absolute USD value")
+	rootCmd.AddCommand(resumeCmd)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -392,13 +392,33 @@ that confirms expired tokens are rejected. See issue #42 for the user report."
 
 - ` + "`klaus status`" + ` — check on running agents
 - ` + "`klaus logs <run-id>`" + ` — view agent output
-- ` + "`klaus cleanup <run-id>`" + ` — clean up finished runs
+- ` + "`klaus resume <run-id> [--add-budget <usd>]`" + ` — resume a paused agent with more budget
+- ` + "`klaus finalize <run-id> [--open-pr]`" + ` — commit and push a paused agent's WIP without resuming claude
+- ` + "`klaus cleanup <run-id>`" + ` — clean up finished or paused runs (destructive: removes worktree)
 - ` + "`klaus target [owner/repo | project-name]`" + ` — get/set default target repo
 - ` + "`klaus approve <pr-number> [...]`" + ` — approve PRs for merging
 - ` + "`klaus merge <pr-number> [...]`" + ` — merge PRs sequentially
 - ` + "`klaus track <pr-number> [--repo <repo>]`" + ` — add existing PR to dashboard for pipeline monitoring
 - ` + "`klaus untrack <pr-number>`" + ` — stop tracking a PR
 - ` + "`klaus dashboard`" + ` — open live dashboard
+
+### When an agent pauses (` + "`agent:paused`" + ` event)
+
+Agents that exceed their --budget are now **paused, not killed**. Their worktree
+and tmux pane are preserved so the work isn't lost. You have three recovery paths:
+
+- ` + "`klaus resume <run-id> --add-budget <usd>`" + ` — resumes claude in the same
+  worktree with a higher cap. **Use this when the agent was close to done — most
+  common case.** Skim the last few log lines first to gauge how close.
+- ` + "`klaus finalize <run-id>`" + ` — commits any uncommitted changes and pushes
+  the branch without resuming claude. Use when you don't want to spend more on
+  the agent but want to save the work for human inspection or a follow-up agent.
+  Add ` + "`--open-pr`" + ` to also open a draft PR.
+- ` + "`klaus cleanup <run-id>`" + ` — the explicit 'throw it away' path. Use only
+  when the agent has clearly gone off the rails.
+
+Default to ` + "`klaus resume`" + ` + budget bump when the last log line suggests the
+agent was nearly done (e.g. about to commit, about to push, about to create a PR).
 
 ## How the pipeline works
 

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -14,6 +14,9 @@ type Event struct {
 const (
 	AgentStarted        = "agent:started"
 	AgentCompleted      = "agent:completed"
+	AgentPaused         = "agent:paused"
+	AgentResumed        = "agent:resumed"
+	AgentFinalized      = "agent:finalized"
 	AgentPRCreated      = "agent:pr-created"
 	AgentCIPassed       = "agent:ci-passed"
 	AgentCIFailed       = "agent:ci-failed"

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -37,7 +37,27 @@ type State struct {
 	OriginalRunID    *string  `json:"original_run_id,omitempty"`   // run ID this was forked from
 	ClaudeSessionID  *string  `json:"claude_session_id,omitempty"` // Claude conversation UUID for --resume
 	RepoRoot         *string  `json:"repo_root,omitempty"`         // absolute path to base repo for worktree recreation
+
+	// Status lifecycle. Unset is treated as "running" for backward
+	// compatibility with state files written before this field existed.
+	// Known values: "running", "paused", "completed", "finalized".
+	Status      *string `json:"status,omitempty"`
+	PausedAt    *string `json:"paused_at,omitempty"`    // RFC3339 timestamp when the run was paused
+	PauseReason *string `json:"pause_reason,omitempty"` // e.g. "budget-exceeded"
 }
+
+// Status constants for State.Status.
+const (
+	StatusRunning   = "running"
+	StatusPaused    = "paused"
+	StatusCompleted = "completed"
+	StatusFinalized = "finalized"
+)
+
+// PauseReason constants for State.PauseReason.
+const (
+	PauseReasonBudgetExceeded = "budget-exceeded"
+)
 
 // TmuxDeps abstracts tmux pane operations so callers can inject test doubles.
 type TmuxDeps struct {


### PR DESCRIPTION
## Summary

When an agent exceeds its `--budget` cap today, klaus SIGKILLs the claude process and cleans up the worktree and tmux pane. All in-progress work is lost. This change makes budget-exhaustion a pause instead of a kill, so work can be saved.

Motivation: a recent agent finished its work and was seconds away from `git commit` when budget exhausted; the worktree was wiped and ~\$5 of code vanished.

## Changes

- **Pause-on-budget**: budget enforcement now sends SIGTERM (graceful, then SIGKILL after 30s), preserves the worktree and tmux pane, marks state as `paused` with `PausedAt` / `PauseReason`, and emits an `agent:paused` event.
- **`klaus resume <run-id> [--add-budget <usd>|--budget <usd>]`**: relaunches claude in the existing worktree with `--resume <ClaudeSessionID>` and a bumped budget cap. Emits `agent:resumed`.
- **`klaus finalize <run-id> [--message <msg>] [--open-pr]`**: commits + pushes any in-progress work without resuming claude. Optionally opens a draft PR.
- **`klaus cleanup`** continues to work for paused runs — the explicit throw-away path.
- Coordinator system-prompt updated to explain the new states and recommend `resume` when the agent was nearly done.

This is a default-behavior change. Anyone relying on auto-cleanup-on-budget can replicate it with a wrapper that calls `klaus cleanup` after detecting `agent:paused`.

## Test plan

- [x] `go test ./...` passes (integration tests for pause / resume / finalize plus negative cases)
- [x] README updated with 'Pause and resume' section
- [x] Help text on every new command
- [x] System prompt updated