### PR TITLE
Use draft PR + label for budget-pause persistence (supersedes #258)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ PR created → CI pending → CI passed → Approved → Merged
 
 When a `pr-fix` run is already active on a PR — including coordinator-launched runs from `klaus launch --pr` — the pipeline will not auto-dispatch additional fix or rebase agents on it. This prevents races during multi-step refactors where intermediate commits may fail CI before the run completes.
 
-Pipeline stages per PR: `ci_pending` → `ci_passed` → `approved` → `merged`, with failure paths back through `ci_failed` or `changes_requested`.
+Pipeline stages per PR: `ci_pending` → `ci_passed` → `approved` → `merged`, with failure paths back through `ci_failed` or `changes_requested`. Budget-exhausted agents land in `budget_paused` — see [Budget pause and resume](#budget-pause-and-resume) below.
 
 You can also drive the pipeline manually with `klaus approve` and `klaus merge`.
 
@@ -73,6 +73,30 @@ klaus watch --list-types             # show live and reserved event types
 ```
 
 The coordinator session's system prompt automatically suggests arming a persistent Monitor on `klaus watch` at startup. The dashboard reads the same `events.jsonl` file independently — both consumers can run side by side.
+
+## Budget pause and resume
+
+When an agent exhausts its `--budget` cap, klaus does not silently kill the worktree. Instead it parks the in-progress work on GitHub:
+
+1. Commits any uncommitted changes in the worktree (`WIP from klaus run <id> (budget paused)`).
+2. Pushes the branch to `origin` (with `--force-with-lease`).
+3. Opens a draft PR — or updates the existing one — and applies the `klaus:budget-paused` label.
+4. Posts a one-line PR comment explaining the pause and how to continue.
+5. Cleans up the worktree and tmux pane.
+
+The draft PR + label is the persisted state — klaus does not keep an in-process "paused" status. The dashboard surfaces these as **budget paused, awaiting decision** via the pipeline FSM (which reads the label off GitHub).
+
+To resume, dispatch a fresh agent against the PR's branch:
+
+```bash
+klaus launch --pr <num> "continue the work"
+```
+
+The new agent sees the WIP commit and picks up from there. When the follow-up agent's `_finalize` runs, the `klaus:budget-paused` label is automatically removed and an `agent:resumed` event is emitted. If the follow-up agent *also* exhausts its budget, the cycle repeats (a new WIP commit, label re-applied).
+
+To abandon the work, close the draft PR. To redirect, push manual commits to its branch.
+
+There is no separate `klaus resume` or `klaus finalize` command — `klaus launch --pr` is the only resume path, and `_finalize` handles the WIP commit automatically.
 
 ## Install
 

--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -233,6 +233,7 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				Conflicts:             v.Conflicts,
 				ReviewDecision:        v.ReviewDecision,
 				HasNewTrustedComments: v.HasNewTrustedComments,
+				Labels:                v.Labels,
 			}
 			// Find the PR URL and target repo from run states.
 			for _, s := range m.states {

--- a/internal/cmd/dashboard_commands.go
+++ b/internal/cmd/dashboard_commands.go
@@ -59,6 +59,7 @@ type prStatus struct {
 	Conflicts             string // yes, none, unknown
 	ReviewDecision        string // APPROVED, CHANGES_REQUESTED, etc.
 	HasNewTrustedComments bool   // unaddressed comments from trusted reviewers
+	Labels                []string // applied PR labels (used to surface klaus:budget-paused)
 }
 
 // Commands for the bubbletea event loop.
@@ -183,6 +184,7 @@ func fetchPRStatus(client gh.Client, prNumber, prRef string) *prStatus {
 	ps.CI = client.GetCI(ctx, prRef)
 	ps.Conflicts = client.GetConflicts(ctx, prRef)
 	ps.ReviewDecision = client.GetReviewDecision(ctx, prRef)
+	ps.Labels = client.GetLabels(ctx, prRef)
 
 	// When reviewDecision is not CHANGES_REQUESTED, check for unaddressed
 	// trusted reviewer comments that GitHub doesn't reflect in reviewDecision.

--- a/internal/cmd/hidden.go
+++ b/internal/cmd/hidden.go
@@ -9,8 +9,11 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
+	"strings"
 
 	"github.com/patflynn/klaus/internal/config"
+	"github.com/patflynn/klaus/internal/draft"
 	"github.com/patflynn/klaus/internal/event"
 	"github.com/patflynn/klaus/internal/git"
 	"github.com/patflynn/klaus/internal/run"
@@ -19,6 +22,10 @@ import (
 	"github.com/patflynn/klaus/internal/tmux"
 	"github.com/spf13/cobra"
 )
+
+// budgetPauseRunner is overridable in tests to capture gh/git calls without
+// touching the network. Production uses draft.ExecRunner{}.
+var budgetPauseRunner draft.Runner = draft.ExecRunner{}
 
 var formatStreamCmd = &cobra.Command{
 	Use:    "_format-stream",
@@ -47,35 +54,29 @@ var finalizeCmd = &cobra.Command{
 			return nil // silently ignore if state not found
 		}
 
-		// Parse log for cost/duration/PR URL
+		// Track whether _finalize discovered the PR URL for the first time
+		// in this run. We emit agent:pr-created even on budget pause so the
+		// pipeline starts tracking the (now-draft) PR.
+		hadPRURLBefore := state.PRURL != nil && *state.PRURL != ""
+
+		// Parse log for cost/duration/PR URL and result subtype.
+		var resultSubtype string
 		if state.LogFile != nil {
-			if err := finalizeFromLog(store, state); err != nil {
+			subtype, err := finalizeFromLog(store, state)
+			if err != nil {
 				fmt.Fprintf(os.Stderr, "warning: finalize: %v\n", err)
 			}
+			resultSubtype = subtype
 		}
 
-		// Emit events for completed run
+		ctx := cmd.Context()
+		baseDir := ""
 		if hds, ok := store.(*run.HomeDirStore); ok {
-			baseDir := hds.BaseDir()
-
-			completedData := map[string]interface{}{"id": id}
-			if state.CostUSD != nil {
-				completedData["cost_usd"] = *state.CostUSD
-			}
-			if state.DurationMS != nil {
-				completedData["duration_ms"] = *state.DurationMS
-			}
-			emitEvent(baseDir, id, event.AgentCompleted, completedData)
-
-			if state.PRURL != nil && *state.PRURL != "" {
-				prNum := extractPRNumberFromURL(*state.PRURL)
-				emitEvent(baseDir, id, event.AgentPRCreated, map[string]interface{}{
-					"id":        id,
-					"pr_url":    *state.PRURL,
-					"pr_number": prNum,
-				})
-			}
+			baseDir = hds.BaseDir()
 		}
+
+		// Decide: did this run end normally, or did it exhaust its budget?
+		paused := handleBudgetPauseIfNeeded(ctx, baseDir, state, resultSubtype, hadPRURLBefore)
 
 		// Sync to data ref — use the target repo's clone dir if available,
 		// otherwise fall back to the current git repo.
@@ -94,9 +95,38 @@ var finalizeCmd = &cobra.Command{
 			return nil
 		}
 
-		ctx := cmd.Context()
 		gitClient := git.NewExecClient()
 
+		// For a normal (non-budget) completion against an existing paused
+		// PR, clear the budget-paused label so the dashboard reflects that
+		// the follow-up agent shipped its work. Emit agent:resumed so the
+		// coordinator sees the resumption complete.
+		if !paused && baseDir != "" {
+			clearLabelIfResumed(ctx, baseDir, state)
+		}
+
+		// Emit events for completed run. For paused runs, agent:completed
+		// is intentionally suppressed in favor of agent:paused, since the
+		// run is not "done" — it's parked in a draft PR awaiting continuation.
+		if baseDir != "" && !paused {
+			completedData := map[string]interface{}{"id": id}
+			if state.CostUSD != nil {
+				completedData["cost_usd"] = *state.CostUSD
+			}
+			if state.DurationMS != nil {
+				completedData["duration_ms"] = *state.DurationMS
+			}
+			emitEvent(baseDir, id, event.AgentCompleted, completedData)
+
+			if state.PRURL != nil && *state.PRURL != "" {
+				prNum := extractPRNumberFromURL(*state.PRURL)
+				emitEvent(baseDir, id, event.AgentPRCreated, map[string]interface{}{
+					"id":        id,
+					"pr_url":    *state.PRURL,
+					"pr_number": prNum,
+				})
+			}
+		}
 		syncRunToDataRef(ctx, syncRoot, store, gitClient, cfg.DataRef, state)
 
 		cleanupWorktree(ctx, store, gitClient, state)
@@ -107,6 +137,161 @@ var finalizeCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+// handleBudgetPauseIfNeeded decides whether the just-finalized run hit its
+// budget cap, and if so commits/pushes the WIP, ensures a draft PR with
+// the budget-paused label, and emits agent:paused (plus agent:pr-created
+// if a PR was newly discovered or created).
+//
+// Returns true if the budget-pause flow was taken (so the caller can
+// suppress the normal agent:completed event).
+func handleBudgetPauseIfNeeded(ctx context.Context, baseDir string, state *run.State, resultSubtype string, hadPRURLBefore bool) bool {
+	if !isBudgetExhausted(state, resultSubtype) {
+		return false
+	}
+	if state.Worktree == "" {
+		// Nothing to push: worktree already cleaned up. Best-effort skip.
+		return false
+	}
+
+	budgetUSD := 0.0
+	if state.Budget != nil {
+		if v, err := strconv.ParseFloat(*state.Budget, 64); err == nil {
+			budgetUSD = v
+		}
+	}
+	cost := 0.0
+	if state.CostUSD != nil {
+		cost = *state.CostUSD
+	}
+
+	repo := ""
+	if state.TargetRepo != nil {
+		repo = *state.TargetRepo
+	}
+	if !strings.Contains(repo, "/") {
+		// Bare project name — gh can't use it. Let gh infer from the
+		// worktree's remote.
+		repo = ""
+	}
+
+	existingPR := ""
+	if state.PR != nil {
+		existingPR = *state.PR
+	}
+
+	in := draft.PauseInput{
+		RunID:      state.ID,
+		Worktree:   state.Worktree,
+		Branch:     state.Branch,
+		Repo:       repo,
+		Prompt:     state.Prompt,
+		CostUSD:    cost,
+		BudgetUSD:  budgetUSD,
+		ExistingPR: existingPR,
+	}
+
+	out, err := draft.HandleBudgetPause(ctx, budgetPauseRunner, in)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: budget-pause flow failed: %v\n", err)
+		// Fall through: emit no agent:paused event, treat as a regular
+		// (failed) completion so the caller's normal-event branch fires.
+		return false
+	}
+
+	// Persist the discovered PR URL so the dashboard picks up the draft PR.
+	if out.PRURL != "" {
+		state.PRURL = &out.PRURL
+	}
+	if out.PRNumber != "" {
+		pr := out.PRNumber
+		state.PR = &pr
+	}
+
+	if baseDir != "" {
+		data := map[string]interface{}{
+			"id":         state.ID,
+			"pr_number":  out.PRNumber,
+			"pr_url":     out.PRURL,
+			"cost_usd":   cost,
+			"budget_usd": budgetUSD,
+			"reason":     "budget_exhausted",
+		}
+		emitEvent(baseDir, state.ID, event.AgentPaused, data)
+
+		// If this is the first time klaus has seen the PR URL for this run
+		// (either because the agent created it on this final flush, or
+		// because we just created it), emit agent:pr-created so the
+		// pipeline starts tracking it.
+		if !hadPRURLBefore && out.PRURL != "" {
+			emitEvent(baseDir, state.ID, event.AgentPRCreated, map[string]interface{}{
+				"id":        state.ID,
+				"pr_url":    out.PRURL,
+				"pr_number": out.PRNumber,
+			})
+		}
+	}
+	return true
+}
+
+// isBudgetExhausted decides whether the just-completed run terminated
+// because it hit the budget cap. The signal is: claude did NOT emit a
+// success result event AND observed cost is at least 95% of the budget cap.
+//
+// When the result event is "success", we trust claude and never treat the
+// run as paused even if cost is near cap.
+//
+// When the result event is absent (early kill, crash, stream truncation)
+// OR has a non-success subtype, we apply the 95% heuristic. This avoids
+// false positives where cost ramped fast for an unrelated reason.
+func isBudgetExhausted(state *run.State, resultSubtype string) bool {
+	if state.Budget == nil || state.CostUSD == nil {
+		return false
+	}
+	cap, err := strconv.ParseFloat(*state.Budget, 64)
+	if err != nil || cap <= 0 {
+		return false
+	}
+	if resultSubtype == "success" {
+		return false
+	}
+	return draft.BudgetExhausted(*state.CostUSD, cap)
+}
+
+// clearLabelIfResumed removes the klaus:budget-paused label if it was set
+// on the run's PR, and emits agent:resumed so the dashboard reflects the
+// pause being resolved. Called only on successful (non-paused) finalize.
+func clearLabelIfResumed(ctx context.Context, baseDir string, state *run.State) {
+	if state.PR == nil || *state.PR == "" {
+		return
+	}
+	repo := ""
+	if state.TargetRepo != nil && strings.Contains(*state.TargetRepo, "/") {
+		repo = *state.TargetRepo
+	}
+	workdir := state.Worktree
+	if workdir == "" && state.CloneDir != nil {
+		workdir = *state.CloneDir
+	}
+
+	had, err := draft.HasBudgetPausedLabel(ctx, budgetPauseRunner, workdir, repo, *state.PR)
+	if err != nil || !had {
+		return
+	}
+	if err := draft.ClearBudgetPausedLabel(ctx, budgetPauseRunner, workdir, repo, *state.PR); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: clearing budget-paused label: %v\n", err)
+		return
+	}
+
+	data := map[string]interface{}{
+		"id":        state.ID,
+		"pr_number": *state.PR,
+	}
+	if state.PRURL != nil {
+		data["pr_url"] = *state.PRURL
+	}
+	emitEvent(baseDir, state.ID, event.AgentResumed, data)
 }
 
 // cleanupWorktree removes the agent's worktree and local branch after
@@ -157,10 +342,15 @@ func killAgentPane(ctx context.Context, store run.StateStore, tc tmux.Client, st
 	}
 }
 
-func finalizeFromLog(store run.StateStore, state *run.State) error {
+// finalizeFromLog parses the agent's JSONL log, mutates state with the
+// observed cost / duration / PR URL, and returns the subtype of the last
+// "result" event (e.g. "success", "error_max_turns", or empty if no
+// result event was emitted). The subtype lets the caller distinguish a
+// successful completion from a budget-cap kill.
+func finalizeFromLog(store run.StateStore, state *run.State) (string, error) {
 	f, err := os.Open(*state.LogFile)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer f.Close()
 
@@ -179,6 +369,7 @@ func finalizeFromLog(store run.StateStore, state *run.State) error {
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
 
+	var resultSubtype string
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		if len(line) == 0 {
@@ -187,6 +378,7 @@ func finalizeFromLog(store run.StateStore, state *run.State) error {
 
 		var ev struct {
 			Type         string  `json:"type"`
+			Subtype      string  `json:"subtype"`
 			TotalCostUSD float64 `json:"total_cost_usd"`
 			DurationMS   int64   `json:"duration_ms"`
 			Message      *struct {
@@ -210,6 +402,9 @@ func finalizeFromLog(store run.StateStore, state *run.State) error {
 			}
 			if ev.DurationMS > 0 {
 				state.DurationMS = &ev.DurationMS
+			}
+			if ev.Subtype != "" {
+				resultSubtype = ev.Subtype
 			}
 		case "assistant":
 			if ev.Message != nil {
@@ -249,7 +444,7 @@ func finalizeFromLog(store run.StateStore, state *run.State) error {
 		state.PRURL = &existingPRURL
 	}
 
-	return store.Save(state)
+	return resultSubtype, store.Save(state)
 }
 
 // prURLExtractRegex matches GitHub PR URLs in free-form text, including

--- a/internal/cmd/hidden_test.go
+++ b/internal/cmd/hidden_test.go
@@ -305,7 +305,7 @@ func TestFinalizeFromLog(t *testing.T) {
 {"type":"result","total_cost_usd":1.5,"duration_ms":30000}
 `
 		state, store := setupFinalizeTest(t, logContent)
-		if err := finalizeFromLog(store, state); err != nil {
+		if _, err := finalizeFromLog(store, state); err != nil {
 			t.Fatalf("finalizeFromLog() error: %v", err)
 		}
 		assertPRURL(t, state, "https://github.com/owner/repo/pull/42")
@@ -321,7 +321,7 @@ func TestFinalizeFromLog(t *testing.T) {
 {"type":"result","total_cost_usd":2.0,"duration_ms":45000}
 `
 		state, store := setupFinalizeTest(t, logContent)
-		if err := finalizeFromLog(store, state); err != nil {
+		if _, err := finalizeFromLog(store, state); err != nil {
 			t.Fatalf("finalizeFromLog() error: %v", err)
 		}
 		assertPRURL(t, state, "https://github.com/owner/repo/pull/99")
@@ -333,7 +333,7 @@ func TestFinalizeFromLog(t *testing.T) {
 {"type":"result","total_cost_usd":1.0,"duration_ms":10000}
 `
 		state, store := setupFinalizeTest(t, logContent)
-		if err := finalizeFromLog(store, state); err != nil {
+		if _, err := finalizeFromLog(store, state); err != nil {
 			t.Fatalf("finalizeFromLog() error: %v", err)
 		}
 		assertPRURL(t, state, "https://github.com/owner/repo/pull/7")
@@ -344,7 +344,7 @@ func TestFinalizeFromLog(t *testing.T) {
 {"type":"result","total_cost_usd":1.0,"duration_ms":5000}
 `
 		state, store := setupFinalizeTest(t, logContent)
-		if err := finalizeFromLog(store, state); err != nil {
+		if _, err := finalizeFromLog(store, state); err != nil {
 			t.Fatalf("finalizeFromLog() error: %v", err)
 		}
 		assertPRURL(t, state, "https://github.com/owner/repo/pull/42")
@@ -358,7 +358,7 @@ not valid json at all
 {"type":"result","total_cost_usd":0.5,"duration_ms":2000}
 `
 		state, store := setupFinalizeTest(t, logContent)
-		if err := finalizeFromLog(store, state); err != nil {
+		if _, err := finalizeFromLog(store, state); err != nil {
 			t.Fatalf("finalizeFromLog() error: %v", err)
 		}
 		assertPRURL(t, state, "https://github.com/owner/repo/pull/5")
@@ -370,7 +370,7 @@ not valid json at all
 {"type":"result","total_cost_usd":0.1,"duration_ms":1000}
 `
 		state, store := setupFinalizeTest(t, logContent)
-		if err := finalizeFromLog(store, state); err != nil {
+		if _, err := finalizeFromLog(store, state); err != nil {
 			t.Fatalf("finalizeFromLog() error: %v", err)
 		}
 		if state.PRURL != nil {
@@ -384,7 +384,7 @@ not valid json at all
 {"type":"result","total_cost_usd":1.0,"duration_ms":5000}
 `
 		state, store := setupFinalizeTest(t, logContent)
-		if err := finalizeFromLog(store, state); err != nil {
+		if _, err := finalizeFromLog(store, state); err != nil {
 			t.Fatalf("finalizeFromLog() error: %v", err)
 		}
 		assertPRURL(t, state, "https://github.com/owner/repo/pull/2")
@@ -403,7 +403,7 @@ not valid json at all
 		existing := "https://github.com/owner/repo/pull/42"
 		state.PRURL = &existing
 
-		if err := finalizeFromLog(store, state); err != nil {
+		if _, err := finalizeFromLog(store, state); err != nil {
 			t.Fatalf("finalizeFromLog() error: %v", err)
 		}
 		assertPRURL(t, state, "https://github.com/owner/repo/pull/42")
@@ -421,7 +421,7 @@ not valid json at all
 			t.Fatalf("test precondition: expected nil PRURL before finalize")
 		}
 
-		if err := finalizeFromLog(store, state); err != nil {
+		if _, err := finalizeFromLog(store, state); err != nil {
 			t.Fatalf("finalizeFromLog() error: %v", err)
 		}
 		assertPRURL(t, state, "https://github.com/owner/repo/pull/77")

--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/patflynn/klaus/internal/config"
+	"github.com/patflynn/klaus/internal/draft"
 	"github.com/patflynn/klaus/internal/event"
 	"github.com/patflynn/klaus/internal/git"
 	gh "github.com/patflynn/klaus/internal/github"
@@ -31,7 +32,11 @@ matches a registered project (no owner/ prefix), the project's local path is
 used directly. Otherwise, the repo is cloned from GitHub.
 
 Use --pr to push fixes to an existing PR's branch instead of creating a new
-PR. The agent will commit and push to the PR branch directly.
+PR. The agent will commit and push to the PR branch directly. This is also
+how you resume a budget-paused PR: launch a fresh agent against the paused
+PR and it picks up from the WIP commit klaus left on the branch. When the
+follow-up agent's _finalize runs, the 'klaus:budget-paused' label is cleared
+automatically.
 
 When sandbox_host is configured in ~/.klaus/config.json, agents run remotely
 via SSH on the sandbox host. The worktree is synced before launch and results
@@ -418,6 +423,20 @@ are synced back after completion. Use --local to force local execution, or
 				startedData["target_repo"] = *normalizedTarget
 			}
 			emitEvent(hds.BaseDir(), id, event.AgentStarted, startedData)
+
+			// If this is a launch against a budget-paused PR, emit
+			// agent:resumed so the coordinator (and dashboard) know the
+			// pause is being acted on.
+			if isPRFix && prNumber != "" {
+				ghRepoArg := resolveGHRepo(repoRef, repoRoot)
+				if paused, perr := draft.HasBudgetPausedLabel(ctx, draft.ExecRunner{}, worktree, ghRepoArg, prNumber); perr == nil && paused {
+					emitEvent(hds.BaseDir(), id, event.AgentResumed, map[string]interface{}{
+						"id":        id,
+						"pr_number": prNumber,
+						"pr_url":    prURL,
+					})
+				}
+			}
 		}
 
 		fmt.Printf("  pane:     %s\n", paneID)
@@ -685,7 +704,7 @@ func pinDashboardToBottom(ctx context.Context, currentPane string, store run.Sta
 
 func init() {
 	launchCmd.Flags().String("issue", "", "GitHub issue number to reference")
-	launchCmd.Flags().String("pr", "", "Push fixes to an existing PR's branch instead of creating a new PR")
+	launchCmd.Flags().String("pr", "", "Push fixes to an existing PR's branch instead of creating a new PR (also the way to resume a budget-paused PR — the agent picks up from the WIP commit)")
 	launchCmd.Flags().String("budget", "", "Max spend in USD (default from config)")
 	launchCmd.Flags().String("repo", "", "Target repo: registered project name, owner/repo, or full URL")
 	launchCmd.Flags().Bool("local", false, "Force local execution even when sandbox is configured")

--- a/internal/cmd/pause_test.go
+++ b/internal/cmd/pause_test.go
@@ -1,0 +1,499 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/patflynn/klaus/internal/draft"
+	"github.com/patflynn/klaus/internal/event"
+	"github.com/patflynn/klaus/internal/run"
+)
+
+// fakeRunner records gh/git calls and lets a test stub gh responses by
+// matching substrings in the joined args. git calls are forwarded to the
+// real git binary so worktree manipulation actually happens — that's the
+// whole point of these tests (validate the WIP commit + push reach the
+// filesystem).
+type fakeRunner struct {
+	realGit draft.ExecRunner
+	ghCalls [][]string
+	ghStubs []ghStub
+}
+
+type ghStub struct {
+	match []string
+	out   string
+	err   error
+}
+
+func (f *fakeRunner) Git(ctx context.Context, workdir string, args ...string) (string, error) {
+	return f.realGit.Git(ctx, workdir, args...)
+}
+
+func (f *fakeRunner) GH(_ context.Context, _ string, args ...string) (string, error) {
+	cp := append([]string(nil), args...)
+	f.ghCalls = append(f.ghCalls, cp)
+	joined := strings.Join(args, " ")
+	for _, s := range f.ghStubs {
+		all := true
+		for _, m := range s.match {
+			if !strings.Contains(joined, m) {
+				all = false
+				break
+			}
+		}
+		if all {
+			return s.out, s.err
+		}
+	}
+	return "", nil
+}
+
+func (f *fakeRunner) findCall(parts ...string) []string {
+	for _, c := range f.ghCalls {
+		all := true
+		for _, p := range parts {
+			found := false
+			for _, a := range c {
+				if a == p {
+					found = true
+					break
+				}
+			}
+			if !found {
+				all = false
+				break
+			}
+		}
+		if all {
+			return c
+		}
+	}
+	return nil
+}
+
+// setupBareRemote creates a bare repo to act as origin, an initial clone, a
+// worktree with one dirty file, and returns the paths.
+func setupBareRemote(t *testing.T) (origin, repo, worktree, branch string) {
+	t.Helper()
+	root := t.TempDir()
+
+	origin = filepath.Join(root, "origin.git")
+	runGitCmd(t, root, "init", "--bare", origin)
+
+	repo = filepath.Join(root, "repo")
+	runGitCmd(t, root, "clone", origin, repo)
+	runGitCmd(t, repo, "config", "user.email", "test@test")
+	runGitCmd(t, repo, "config", "user.name", "test")
+
+	// Seed initial commit on main.
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("# repo\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGitCmd(t, repo, "add", "README.md")
+	runGitCmd(t, repo, "commit", "-m", "init")
+	runGitCmd(t, repo, "branch", "-M", "main")
+	runGitCmd(t, repo, "push", "-u", "origin", "main")
+
+	branch = "agent/test-pause"
+	worktree = filepath.Join(root, "wt")
+	runGitCmd(t, repo, "worktree", "add", worktree, "-b", branch)
+	runGitCmd(t, worktree, "config", "user.email", "test@test")
+	runGitCmd(t, worktree, "config", "user.name", "test")
+
+	// Add a dirty file (uncommitted) to simulate work-in-progress.
+	if err := os.WriteFile(filepath.Join(worktree, "wip.txt"), []byte("partial work\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	return origin, repo, worktree, branch
+}
+
+func TestBudgetPauseFlow_EndToEnd(t *testing.T) {
+	_, _, worktree, branch := setupBareRemote(t)
+
+	r := &fakeRunner{}
+	// gh pr list returns nothing → triggers create.
+	r.ghStubs = append(r.ghStubs,
+		ghStub{match: []string{"pr", "list", "--head"}, out: "", err: nil},
+		ghStub{match: []string{"pr", "create", "--draft"}, out: "https://github.com/owner/repo/pull/777\n", err: nil},
+	)
+
+	in := draft.PauseInput{
+		RunID:     "20260529-1729-zzzz",
+		Worktree:  worktree,
+		Branch:    branch,
+		Repo:      "owner/repo",
+		Prompt:    "fix the auth bug",
+		CostUSD:   4.98,
+		BudgetUSD: 5.00,
+	}
+	out, err := draft.HandleBudgetPause(context.Background(), r, in)
+	if err != nil {
+		t.Fatalf("HandleBudgetPause: %v", err)
+	}
+
+	if !out.CommittedWIP {
+		t.Error("expected CommittedWIP=true (worktree had dirty file)")
+	}
+	if !out.CreatedNewPR {
+		t.Error("expected CreatedNewPR=true (no existing PR)")
+	}
+	if out.PRNumber != "777" {
+		t.Errorf("expected PRNumber=777, got %q", out.PRNumber)
+	}
+
+	// Verify the WIP commit landed: git log on the branch must show a
+	// commit referencing the run ID.
+	logOut, err := r.realGit.Git(context.Background(), worktree, "log", "-1", "--format=%s")
+	if err != nil {
+		t.Fatalf("git log: %v", err)
+	}
+	if !strings.Contains(logOut, "WIP from klaus run 20260529-1729-zzzz") {
+		t.Errorf("expected WIP commit message, got %q", strings.TrimSpace(logOut))
+	}
+
+	// Verify the branch was pushed to origin.
+	listOut, err := r.realGit.Git(context.Background(), worktree, "ls-remote", "origin", branch)
+	if err != nil {
+		t.Fatalf("ls-remote: %v", err)
+	}
+	if strings.TrimSpace(listOut) == "" {
+		t.Error("expected branch pushed to origin, got empty ls-remote")
+	}
+
+	// Verify gh was driven through the pause sequence.
+	if r.findCall("label", "create", "klaus:budget-paused") == nil {
+		t.Error("expected gh label create call")
+	}
+	if r.findCall("pr", "create", "--draft", "--head", branch) == nil {
+		t.Error("expected gh pr create --draft call")
+	}
+	if r.findCall("pr", "edit", "777", "--add-label") == nil {
+		t.Error("expected gh pr edit --add-label call")
+	}
+	if c := r.findCall("pr", "comment", "777"); c == nil {
+		t.Error("expected gh pr comment call")
+	} else {
+		joined := strings.Join(c, " ")
+		if !strings.Contains(joined, "$4.98") || !strings.Contains(joined, "$5.00") {
+			t.Errorf("expected comment body with cost/budget, got %q", joined)
+		}
+	}
+}
+
+func TestBudgetPauseFlow_ReusesExistingPR(t *testing.T) {
+	_, _, worktree, branch := setupBareRemote(t)
+
+	r := &fakeRunner{}
+	r.ghStubs = append(r.ghStubs,
+		// lookup existing PR returns number+url
+		ghStub{match: []string{"pr", "view", "55", "--repo", "owner/repo", "--json"}, out: "55\nhttps://github.com/owner/repo/pull/55\n"},
+	)
+
+	in := draft.PauseInput{
+		RunID:      "20260529-1729-aaaa",
+		Worktree:   worktree,
+		Branch:     branch,
+		Repo:       "owner/repo",
+		Prompt:     "second attempt",
+		CostUSD:    4.95,
+		BudgetUSD:  5.00,
+		ExistingPR: "55",
+	}
+	out, err := draft.HandleBudgetPause(context.Background(), r, in)
+	if err != nil {
+		t.Fatalf("HandleBudgetPause: %v", err)
+	}
+
+	if out.CreatedNewPR {
+		t.Error("expected to reuse PR #55, not create a new one")
+	}
+	if out.PRNumber != "55" {
+		t.Errorf("expected PR #55, got %q", out.PRNumber)
+	}
+	// Should not have called pr create.
+	if c := r.findCall("pr", "create"); c != nil {
+		t.Errorf("expected no gh pr create, got %v", c)
+	}
+	// Should still apply label and comment.
+	if r.findCall("pr", "edit", "55", "--add-label") == nil {
+		t.Error("expected label apply on existing PR")
+	}
+	if r.findCall("pr", "comment", "55") == nil {
+		t.Error("expected PR comment on existing PR")
+	}
+}
+
+func TestIsBudgetExhausted(t *testing.T) {
+	cost := 4.95
+	budget5 := "5.00"
+	budget10 := "10.00"
+	tests := []struct {
+		name    string
+		state   *run.State
+		subtype string
+		want    bool
+	}{
+		{
+			name:    "95 percent with non-success subtype",
+			state:   &run.State{CostUSD: &cost, Budget: &budget5},
+			subtype: "",
+			want:    true,
+		},
+		{
+			name:    "95 percent but success subtype",
+			state:   &run.State{CostUSD: &cost, Budget: &budget5},
+			subtype: "success",
+			want:    false,
+		},
+		{
+			name:    "below 95 percent",
+			state:   &run.State{CostUSD: &cost, Budget: &budget10},
+			subtype: "",
+			want:    false,
+		},
+		{
+			name:    "no budget",
+			state:   &run.State{CostUSD: &cost},
+			subtype: "",
+			want:    false,
+		},
+		{
+			name:    "no cost",
+			state:   &run.State{Budget: &budget5},
+			subtype: "",
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isBudgetExhausted(tt.state, tt.subtype)
+			if got != tt.want {
+				t.Errorf("isBudgetExhausted = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFinalizeBudgetPauseEmitsEvents drives the full _finalize budget-pause
+// path end-to-end: a dirty worktree + a result-event-less log + cost near
+// the cap → expects the WIP commit, the gh pause calls, agent:paused +
+// agent:pr-created events in events.jsonl, and the worktree removed.
+func TestFinalizeBudgetPauseEmitsEvents(t *testing.T) {
+	_, repo, worktree, branch := setupBareRemote(t)
+
+	sessionID := "20260529-1729-test-session"
+	// Set up the HomeDirStore at a temp KLAUS sessions dir.
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv(sessionIDEnv, sessionID)
+	store, err := run.NewHomeDirStore(sessionID)
+	if err != nil {
+		t.Fatalf("NewHomeDirStore: %v", err)
+	}
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+
+	// Build a fake log file with cost near budget cap, no success subtype.
+	runID := "20260529-1729-runxx"
+	logFile := filepath.Join(store.LogDir(), runID+".jsonl")
+	logContent := `{"type":"system","subtype":"init","model":"claude-sonnet-4-5"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"working..."}]}}
+{"type":"result","subtype":"error_max_turns","total_cost_usd":4.95,"duration_ms":30000}
+`
+	if err := os.WriteFile(logFile, []byte(logContent), 0644); err != nil {
+		t.Fatalf("writing log: %v", err)
+	}
+
+	budget := "5.00"
+	targetRepo := "owner/repo"
+	state := &run.State{
+		ID:         runID,
+		Prompt:     "fix the auth bug in handler",
+		Branch:     branch,
+		Worktree:   worktree,
+		CreatedAt:  "2026-05-29T17:00:00Z",
+		LogFile:    &logFile,
+		Budget:     &budget,
+		TargetRepo: &targetRepo,
+		CloneDir:   &repo,
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatalf("saving state: %v", err)
+	}
+
+	// Inject the fake gh runner; keep real git.
+	r := &fakeRunner{}
+	r.ghStubs = []ghStub{
+		{match: []string{"pr", "list", "--head"}, out: ""},
+		{match: []string{"pr", "create", "--draft"}, out: "https://github.com/owner/repo/pull/123\n"},
+	}
+	prev := budgetPauseRunner
+	budgetPauseRunner = r
+	defer func() { budgetPauseRunner = prev }()
+
+	// Run _finalize.
+	finalizeCmd.SetContext(context.Background())
+	if err := finalizeCmd.RunE(finalizeCmd, []string{runID}); err != nil {
+		t.Fatalf("_finalize: %v", err)
+	}
+
+	// Assert: gh pause calls were issued.
+	if r.findCall("pr", "create", "--draft") == nil {
+		t.Error("expected gh pr create --draft (no prior PR was set on state)")
+	}
+	if r.findCall("pr", "edit", "123", "--add-label") == nil {
+		t.Error("expected gh label apply on PR 123")
+	}
+	if r.findCall("pr", "comment", "123") == nil {
+		t.Error("expected gh pr comment on PR 123")
+	}
+
+	// Assert: events log contains agent:paused.
+	evtFile := filepath.Join(store.BaseDir(), "events.jsonl")
+	data, err := os.ReadFile(evtFile)
+	if err != nil {
+		t.Fatalf("reading events.jsonl: %v", err)
+	}
+	pausedFound := false
+	prCreatedFound := false
+	completedFound := false
+	for _, line := range strings.Split(string(data), "\n") {
+		if line == "" {
+			continue
+		}
+		var ev struct {
+			RunID string                 `json:"run_id"`
+			Type  string                 `json:"type"`
+			Data  map[string]interface{} `json:"data"`
+		}
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			continue
+		}
+		if ev.Type == event.AgentPaused && ev.RunID == runID {
+			pausedFound = true
+			if got, _ := ev.Data["pr_number"].(string); got != "123" {
+				t.Errorf("agent:paused pr_number = %q, want 123", got)
+			}
+		}
+		if ev.Type == event.AgentPRCreated && ev.RunID == runID {
+			prCreatedFound = true
+		}
+		if ev.Type == event.AgentCompleted && ev.RunID == runID {
+			completedFound = true
+		}
+	}
+	if !pausedFound {
+		t.Error("expected agent:paused event in events.jsonl")
+	}
+	if !prCreatedFound {
+		t.Error("expected agent:pr-created event in events.jsonl (PR was discovered)")
+	}
+	if completedFound {
+		t.Error("agent:completed should be suppressed when the run is paused")
+	}
+
+	// Assert: worktree was cleaned up by _finalize's cleanupWorktree step.
+	if _, err := os.Stat(worktree); !os.IsNotExist(err) {
+		t.Errorf("expected worktree removed after _finalize, stat err = %v", err)
+	}
+
+	// Assert: the WIP commit was pushed to origin.
+	pushed, err := r.realGit.Git(context.Background(), repo, "ls-remote", "origin", branch)
+	if err != nil {
+		t.Fatalf("ls-remote: %v", err)
+	}
+	if strings.TrimSpace(pushed) == "" {
+		t.Error("expected branch pushed to origin, got empty ls-remote")
+	}
+}
+
+// TestFinalizeClearsBudgetPausedLabel verifies that a normal-completion
+// _finalize against a PR that carries the budget-paused label removes the
+// label and emits agent:resumed.
+func TestFinalizeClearsBudgetPausedLabel(t *testing.T) {
+	_, repo, worktree, branch := setupBareRemote(t)
+
+	sessionID := "20260529-1729-clear-session"
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv(sessionIDEnv, sessionID)
+	store, err := run.NewHomeDirStore(sessionID)
+	if err != nil {
+		t.Fatalf("NewHomeDirStore: %v", err)
+	}
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+
+	// Log: success subtype, cost well below cap.
+	runID := "20260529-1729-runzz"
+	logFile := filepath.Join(store.LogDir(), runID+".jsonl")
+	logContent := `{"type":"result","subtype":"success","total_cost_usd":0.5,"duration_ms":10000}
+`
+	if err := os.WriteFile(logFile, []byte(logContent), 0644); err != nil {
+		t.Fatalf("writing log: %v", err)
+	}
+
+	prNum := "200"
+	prURL := "https://github.com/owner/repo/pull/200"
+	budget := "5.00"
+	targetRepo := "owner/repo"
+	state := &run.State{
+		ID:         runID,
+		Prompt:     "finish what the paused agent started",
+		PR:         &prNum,
+		PRURL:      &prURL,
+		Branch:     branch,
+		Worktree:   worktree,
+		CreatedAt:  "2026-05-29T17:00:00Z",
+		LogFile:    &logFile,
+		Budget:     &budget,
+		TargetRepo: &targetRepo,
+		CloneDir:   &repo,
+		Type:       "pr-fix",
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatalf("saving state: %v", err)
+	}
+
+	// gh stubs: HasBudgetPausedLabel returns the label, ClearBudgetPausedLabel succeeds.
+	r := &fakeRunner{}
+	r.ghStubs = []ghStub{
+		{match: []string{"pr", "view", "200", "--repo", "owner/repo", "--json", "labels"}, out: "klaus:budget-paused\n"},
+		{match: []string{"pr", "edit", "200", "--repo", "owner/repo", "--remove-label"}, out: ""},
+	}
+	prev := budgetPauseRunner
+	budgetPauseRunner = r
+	defer func() { budgetPauseRunner = prev }()
+
+	finalizeCmd.SetContext(context.Background())
+	if err := finalizeCmd.RunE(finalizeCmd, []string{runID}); err != nil {
+		t.Fatalf("_finalize: %v", err)
+	}
+
+	if r.findCall("pr", "edit", "200", "--remove-label") == nil {
+		t.Error("expected gh pr edit --remove-label on follow-up finalize")
+	}
+
+	// Assert agent:resumed emitted, agent:completed also emitted.
+	evtFile := filepath.Join(store.BaseDir(), "events.jsonl")
+	data, _ := os.ReadFile(evtFile)
+	if !strings.Contains(string(data), event.AgentResumed) {
+		t.Error("expected agent:resumed event")
+	}
+	if !strings.Contains(string(data), event.AgentCompleted) {
+		t.Error("expected agent:completed event on normal finalize")
+	}
+	// Verify we did NOT trigger the budget-pause flow this time.
+	if r.findCall("pr", "create", "--draft") != nil {
+		t.Error("should not run pause flow on a successful completion")
+	}
+}
+

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -453,6 +453,25 @@ What happens after ` + "`klaus launch`" + `:
 5. Dashboard detects state change and updates display
 6. Pipeline evaluates the PR and manages CI/review/merge cycle
 
+### When an agent pauses (agent:paused event)
+
+Agents that exceed their ` + "`--budget`" + ` are paused by:
+1. Committing any work-in-progress to their branch.
+2. Pushing the branch to origin.
+3. Opening or updating a draft PR with the ` + "`klaus:budget-paused`" + ` label.
+4. Posting an explanatory PR comment.
+5. Terminating cleanly (worktree removed, tmux pane closed).
+
+The work is safe in the draft PR. To continue:
+
+- ` + "`klaus launch --pr <num> \"continue the work\"`" + ` dispatches a fresh agent against the PR's branch. The new agent re-orients from the WIP commit and finishes the work. This is cheaper than human intervention but does cost one re-exploration of the repo.
+- Close the PR in GitHub to abandon.
+- Add commits manually to the PR branch if you want to redirect.
+
+The ` + "`klaus:budget-paused`" + ` label is automatically cleared when a follow-up agent ` + "`_finalize`" + `s. If you see the label persist after a launch, that's a signal the follow-up itself failed (paused or crashed).
+
+There is NO ` + "`klaus resume`" + ` or ` + "`klaus finalize`" + ` command. The draft PR plus label IS the persisted state; ` + "`klaus launch --pr`" + ` is the resume path.
+
 ## Gotchas and common issues
 
 - **Worktree conflicts**: When using --pr to push fixes to an existing PR, the PR's branch cannot be checked out in the main repo clone. If you get a worktree error, switch the main repo to main first.

--- a/internal/draft/draft.go
+++ b/internal/draft/draft.go
@@ -1,0 +1,372 @@
+// Package draft handles the budget-pause persistence flow: when an agent
+// exhausts its budget, klaus commits any work-in-progress to the agent's
+// branch, pushes it, and ensures a draft PR exists carrying a
+// "klaus:budget-paused" label plus an explanatory comment.
+//
+// The draft PR is the persistence layer for paused state — there is no
+// in-process Status field. The pipeline FSM later reads the label off
+// GitHub to surface the paused stage in the dashboard.
+package draft
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/patflynn/klaus/internal/event"
+)
+
+// Runner abstracts the shell commands (git, gh) the pause flow needs.
+// Tests inject a fake runner; production uses ExecRunner.
+type Runner interface {
+	// Git runs a git command in workdir and returns stdout. Stderr is
+	// captured in the error.
+	Git(ctx context.Context, workdir string, args ...string) (string, error)
+	// GH runs a gh command (cwd irrelevant for most calls but accepted so
+	// PR-create can run inside the worktree). Returns stdout, with stderr
+	// captured in the error.
+	GH(ctx context.Context, workdir string, args ...string) (string, error)
+}
+
+// ExecRunner runs real git/gh commands via os/exec.
+type ExecRunner struct{}
+
+func (ExecRunner) Git(ctx context.Context, workdir string, args ...string) (string, error) {
+	c := exec.CommandContext(ctx, "git", args...)
+	c.Dir = workdir
+	out, err := c.Output()
+	if err != nil {
+		var stderr string
+		if ee, ok := err.(*exec.ExitError); ok {
+			stderr = string(ee.Stderr)
+		}
+		return string(out), fmt.Errorf("git %s: %w (stderr: %s)", strings.Join(args, " "), err, strings.TrimSpace(stderr))
+	}
+	return string(out), nil
+}
+
+func (ExecRunner) GH(ctx context.Context, workdir string, args ...string) (string, error) {
+	c := exec.CommandContext(ctx, "gh", args...)
+	c.Dir = workdir
+	out, err := c.Output()
+	if err != nil {
+		var stderr string
+		if ee, ok := err.(*exec.ExitError); ok {
+			stderr = string(ee.Stderr)
+		}
+		return string(out), fmt.Errorf("gh %s: %w (stderr: %s)", strings.Join(args, " "), err, strings.TrimSpace(stderr))
+	}
+	return string(out), nil
+}
+
+// PauseInput carries everything HandleBudgetPause needs to commit, push,
+// and surface the paused state on GitHub.
+type PauseInput struct {
+	RunID      string  // klaus run ID
+	Worktree   string  // path to the agent's worktree
+	Branch     string  // branch name to push
+	Repo       string  // owner/repo for gh commands; if empty, gh infers from cwd
+	Prompt     string  // original agent prompt (used in WIP commit + PR body)
+	CostUSD    float64 // observed spend
+	BudgetUSD  float64 // budget cap (0 if unknown)
+	ExistingPR string  // PR number if known; empty means "discover or create"
+}
+
+// PauseOutput reports what HandleBudgetPause observed/created.
+type PauseOutput struct {
+	PRNumber       string // the PR number (created or pre-existing)
+	PRURL          string // the PR URL
+	CreatedNewPR   bool   // true if HandleBudgetPause created the PR
+	CommittedWIP   bool   // true if there were uncommitted changes that got committed
+}
+
+// HandleBudgetPause performs the WIP-commit + push + draft-PR + label + comment
+// dance for budget exhaustion. Returns details of what was created so the
+// caller can emit corresponding events.
+//
+// The flow is idempotent on the GitHub side: re-running against an already-
+// labeled draft PR will not create duplicate PRs but will add a duplicate
+// comment. Callers should not retry on success.
+func HandleBudgetPause(ctx context.Context, r Runner, in PauseInput) (PauseOutput, error) {
+	out := PauseOutput{}
+
+	// Step 1: commit any uncommitted changes.
+	committed, err := commitWIP(ctx, r, in)
+	if err != nil {
+		return out, fmt.Errorf("committing WIP: %w", err)
+	}
+	out.CommittedWIP = committed
+
+	// Step 2: push the branch (force-with-lease tolerates a prior push).
+	if err := pushBranch(ctx, r, in.Worktree, in.Branch); err != nil {
+		return out, fmt.Errorf("pushing branch: %w", err)
+	}
+
+	// Step 3: ensure the budget-paused label exists in the repo.
+	if err := ensureLabel(ctx, r, in.Worktree, in.Repo); err != nil {
+		// Non-fatal: label creation failures shouldn't block the PR + comment.
+		// gh label create --force will fail loudly if there's an auth problem,
+		// but we still want to attempt PR creation.
+		_ = err
+	}
+
+	// Step 4: find or create the PR.
+	prNumber, prURL, created, err := ensurePR(ctx, r, in)
+	if err != nil {
+		return out, fmt.Errorf("ensuring PR: %w", err)
+	}
+	out.PRNumber = prNumber
+	out.PRURL = prURL
+	out.CreatedNewPR = created
+
+	// Step 5: apply the label.
+	if err := applyLabel(ctx, r, in.Worktree, in.Repo, prNumber); err != nil {
+		return out, fmt.Errorf("applying label: %w", err)
+	}
+
+	// Step 6: post an explanatory PR comment.
+	if err := postComment(ctx, r, in, prNumber); err != nil {
+		return out, fmt.Errorf("posting comment: %w", err)
+	}
+
+	return out, nil
+}
+
+// ClearBudgetPausedLabel removes the klaus:budget-paused label from the
+// given PR if it's present. Used by _finalize on follow-up runs against a
+// paused PR so the dashboard reflects that the pause was resolved.
+//
+// Idempotent: if the label isn't present, this is a no-op.
+func ClearBudgetPausedLabel(ctx context.Context, r Runner, workdir, repo, prNumber string) error {
+	args := []string{"pr", "edit", prNumber, "--remove-label", event.BudgetPausedLabel}
+	if repo != "" {
+		args = []string{"pr", "edit", prNumber, "--repo", repo, "--remove-label", event.BudgetPausedLabel}
+	}
+	_, err := r.GH(ctx, workdir, args...)
+	if err != nil && !strings.Contains(err.Error(), "not found") {
+		return err
+	}
+	return nil
+}
+
+// HasBudgetPausedLabel reports whether the given PR currently carries the
+// klaus:budget-paused label. Used at klaus launch --pr time to decide
+// whether to emit agent:resumed.
+func HasBudgetPausedLabel(ctx context.Context, r Runner, workdir, repo, prNumber string) (bool, error) {
+	args := []string{"pr", "view", prNumber, "--json", "labels", "-q", ".labels[].name"}
+	if repo != "" {
+		args = []string{"pr", "view", prNumber, "--repo", repo, "--json", "labels", "-q", ".labels[].name"}
+	}
+	stdout, err := r.GH(ctx, workdir, args...)
+	if err != nil {
+		return false, err
+	}
+	for _, line := range strings.Split(stdout, "\n") {
+		if strings.TrimSpace(line) == event.BudgetPausedLabel {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// ── internal helpers ────────────────────────────────────────────────────
+
+func commitWIP(ctx context.Context, r Runner, in PauseInput) (bool, error) {
+	// git status --porcelain returns empty if clean.
+	status, err := r.Git(ctx, in.Worktree, "status", "--porcelain")
+	if err != nil {
+		return false, err
+	}
+	if strings.TrimSpace(status) == "" {
+		return false, nil
+	}
+	if _, err := r.Git(ctx, in.Worktree, "add", "-A"); err != nil {
+		return false, err
+	}
+	msg := fmt.Sprintf("WIP from klaus run %s (budget paused)\n\n%s", in.RunID, summarizePrompt(in.Prompt))
+	if _, err := r.Git(ctx, in.Worktree, "commit", "-m", msg); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func pushBranch(ctx context.Context, r Runner, workdir, branch string) error {
+	// --force-with-lease is safe whether the branch was pushed before or not;
+	// for first pushes git treats absent upstream as no constraint.
+	// Use --set-upstream so subsequent pushes Just Work.
+	_, err := r.Git(ctx, workdir, "push", "--force-with-lease", "--set-upstream", "origin", branch)
+	return err
+}
+
+func ensureLabel(ctx context.Context, r Runner, workdir, repo string) error {
+	args := []string{"label", "create", event.BudgetPausedLabel,
+		"--force",
+		"--description", "Agent paused at budget cap; work-in-progress committed to this branch.",
+		"--color", "FBCA04",
+	}
+	if repo != "" {
+		args = []string{"label", "create", event.BudgetPausedLabel,
+			"--repo", repo,
+			"--force",
+			"--description", "Agent paused at budget cap; work-in-progress committed to this branch.",
+			"--color", "FBCA04",
+		}
+	}
+	_, err := r.GH(ctx, workdir, args...)
+	return err
+}
+
+func ensurePR(ctx context.Context, r Runner, in PauseInput) (prNumber, prURL string, created bool, err error) {
+	if in.ExistingPR != "" {
+		num, url, lookupErr := lookupPR(ctx, r, in.Worktree, in.Repo, in.ExistingPR)
+		if lookupErr == nil && num != "" {
+			return num, url, false, nil
+		}
+	}
+
+	// Try to find a PR for the branch.
+	num, url, err := findPRForBranch(ctx, r, in.Worktree, in.Repo, in.Branch)
+	if err == nil && num != "" {
+		return num, url, false, nil
+	}
+
+	// Create a draft PR.
+	title := titleFromPrompt(in.Prompt, in.RunID)
+	body := pauseBody(in)
+	args := []string{"pr", "create", "--draft", "--title", title, "--body", body, "--head", in.Branch}
+	if in.Repo != "" {
+		args = []string{"pr", "create", "--repo", in.Repo, "--draft", "--title", title, "--body", body, "--head", in.Branch}
+	}
+	stdout, err := r.GH(ctx, in.Worktree, args...)
+	if err != nil {
+		return "", "", false, err
+	}
+	url = strings.TrimSpace(stdout)
+	// gh pr create prints the URL on success.
+	num = extractPRNumberFromURL(url)
+	return num, url, true, nil
+}
+
+func lookupPR(ctx context.Context, r Runner, workdir, repo, prNumber string) (string, string, error) {
+	args := []string{"pr", "view", prNumber, "--json", "number,url", "-q", ".number,.url"}
+	if repo != "" {
+		args = []string{"pr", "view", prNumber, "--repo", repo, "--json", "number,url", "-q", ".number,.url"}
+	}
+	stdout, err := r.GH(ctx, workdir, args...)
+	if err != nil {
+		return "", "", err
+	}
+	parts := strings.Split(strings.TrimSpace(stdout), "\n")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("unexpected gh pr view output: %q", stdout)
+	}
+	return parts[0], parts[1], nil
+}
+
+func findPRForBranch(ctx context.Context, r Runner, workdir, repo, branch string) (string, string, error) {
+	args := []string{"pr", "list", "--head", branch, "--state", "open", "--json", "number,url", "-q", ".[0].number,.[0].url"}
+	if repo != "" {
+		args = []string{"pr", "list", "--repo", repo, "--head", branch, "--state", "open", "--json", "number,url", "-q", ".[0].number,.[0].url"}
+	}
+	stdout, err := r.GH(ctx, workdir, args...)
+	if err != nil {
+		return "", "", err
+	}
+	out := strings.TrimSpace(stdout)
+	if out == "" {
+		return "", "", nil
+	}
+	parts := strings.Split(out, "\n")
+	if len(parts) != 2 || parts[0] == "" {
+		return "", "", nil
+	}
+	return parts[0], parts[1], nil
+}
+
+func applyLabel(ctx context.Context, r Runner, workdir, repo, prNumber string) error {
+	args := []string{"pr", "edit", prNumber, "--add-label", event.BudgetPausedLabel}
+	if repo != "" {
+		args = []string{"pr", "edit", prNumber, "--repo", repo, "--add-label", event.BudgetPausedLabel}
+	}
+	_, err := r.GH(ctx, workdir, args...)
+	return err
+}
+
+func postComment(ctx context.Context, r Runner, in PauseInput, prNumber string) error {
+	body := fmt.Sprintf(
+		"Agent paused at budget cap ($%.2f of $%.2f). Label `%s` set; latest commit is WIP. Use `klaus launch --pr %s \"continue the work\"` to continue, or close to abandon.",
+		in.CostUSD, in.BudgetUSD, event.BudgetPausedLabel, prNumber,
+	)
+	args := []string{"pr", "comment", prNumber, "--body", body}
+	if in.Repo != "" {
+		args = []string{"pr", "comment", prNumber, "--repo", in.Repo, "--body", body}
+	}
+	_, err := r.GH(ctx, in.Worktree, args...)
+	return err
+}
+
+func titleFromPrompt(prompt, runID string) string {
+	first := strings.TrimSpace(prompt)
+	if idx := strings.IndexByte(first, '\n'); idx >= 0 {
+		first = first[:idx]
+	}
+	first = strings.TrimSpace(first)
+	if first == "" {
+		return fmt.Sprintf("klaus run %s (budget paused)", runID)
+	}
+	if len(first) > 72 {
+		first = strings.TrimSpace(first[:72])
+	}
+	return "[budget-paused] " + first
+}
+
+func pauseBody(in PauseInput) string {
+	return fmt.Sprintf(
+		"This PR was opened by klaus when the agent for run `%s` exhausted its budget cap.\n\n"+
+			"- **Cost so far:** $%.2f of $%.2f\n"+
+			"- **Branch:** `%s`\n"+
+			"- **Status:** draft, labeled `%s`\n\n"+
+			"## Original prompt\n\n%s\n\n"+
+			"## Continue the work\n\n"+
+			"Run `klaus launch --pr <number> \"continue the work\"` to dispatch a fresh agent against this branch. "+
+			"The new agent will see the WIP commit and pick up from there.\n\n"+
+			"To abandon, close this PR.\n",
+		in.RunID, in.CostUSD, in.BudgetUSD, in.Branch, event.BudgetPausedLabel, summarizePrompt(in.Prompt),
+	)
+}
+
+func summarizePrompt(prompt string) string {
+	s := strings.TrimSpace(prompt)
+	if s == "" {
+		return "(no prompt recorded)"
+	}
+	if len(s) > 500 {
+		return s[:500] + "…"
+	}
+	return s
+}
+
+func extractPRNumberFromURL(url string) string {
+	idx := strings.LastIndex(url, "/pull/")
+	if idx < 0 {
+		return ""
+	}
+	tail := url[idx+len("/pull/"):]
+	end := strings.IndexAny(tail, "/?# \n\t")
+	if end < 0 {
+		return strings.TrimSpace(tail)
+	}
+	return strings.TrimSpace(tail[:end])
+}
+
+// BudgetExhausted reports whether the observed cost is close enough to the
+// budget cap to treat as exhaustion. The heuristic is 95% of cap; callers
+// pair this with a check of claude's result event subtype to avoid false
+// positives (e.g. a successful completion that happened to land near cap).
+func BudgetExhausted(cost, cap float64) bool {
+	if cap <= 0 {
+		return false
+	}
+	return cost >= 0.95*cap
+}

--- a/internal/draft/draft_test.go
+++ b/internal/draft/draft_test.go
@@ -1,0 +1,327 @@
+package draft
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/patflynn/klaus/internal/event"
+)
+
+// recorderRunner is a Runner that captures every git/gh call and lets each
+// test stub specific responses by command-prefix match.
+type recorderRunner struct {
+	gitCalls  []recorded
+	ghCalls   []recorded
+	gitStubs  []stub
+	ghStubs   []stub
+}
+
+type recorded struct {
+	workdir string
+	args    []string
+}
+
+type stub struct {
+	// match: substrings that must all appear in the joined args (space-separated)
+	match []string
+	out   string
+	err   error
+}
+
+func (r *recorderRunner) addGitStub(match []string, out string, err error) {
+	r.gitStubs = append(r.gitStubs, stub{match: match, out: out, err: err})
+}
+func (r *recorderRunner) addGHStub(match []string, out string, err error) {
+	r.ghStubs = append(r.ghStubs, stub{match: match, out: out, err: err})
+}
+
+func (r *recorderRunner) Git(_ context.Context, workdir string, args ...string) (string, error) {
+	r.gitCalls = append(r.gitCalls, recorded{workdir, args})
+	joined := strings.Join(args, " ")
+	for _, s := range r.gitStubs {
+		if allContain(joined, s.match) {
+			return s.out, s.err
+		}
+	}
+	return "", nil
+}
+
+func (r *recorderRunner) GH(_ context.Context, workdir string, args ...string) (string, error) {
+	r.ghCalls = append(r.ghCalls, recorded{workdir, args})
+	joined := strings.Join(args, " ")
+	for _, s := range r.ghStubs {
+		if allContain(joined, s.match) {
+			return s.out, s.err
+		}
+	}
+	return "", nil
+}
+
+func allContain(s string, parts []string) bool {
+	for _, p := range parts {
+		if !strings.Contains(s, p) {
+			return false
+		}
+	}
+	return true
+}
+
+// argsContainAll reports whether every part appears as a standalone arg.
+// Matches by exact arg equality so "pr" doesn't fuzzy-match "progress".
+func argsContainAll(args, parts []string) bool {
+	for _, p := range parts {
+		found := false
+		for _, a := range args {
+			if a == p {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *recorderRunner) findGitCall(parts ...string) *recorded {
+	for i := range r.gitCalls {
+		if argsContainAll(r.gitCalls[i].args, parts) {
+			return &r.gitCalls[i]
+		}
+	}
+	return nil
+}
+
+func (r *recorderRunner) findGHCall(parts ...string) *recorded {
+	for i := range r.ghCalls {
+		if argsContainAll(r.ghCalls[i].args, parts) {
+			return &r.ghCalls[i]
+		}
+	}
+	return nil
+}
+
+func TestHandleBudgetPause_CreatesNewPRWithDirtyWorktree(t *testing.T) {
+	r := &recorderRunner{}
+	// Dirty worktree.
+	r.addGitStub([]string{"status", "--porcelain"}, " M foo.go\n", nil)
+	// findPRForBranch returns nothing (no existing PR).
+	r.addGHStub([]string{"pr", "list", "--head"}, "", nil)
+	// gh pr create returns the new PR URL.
+	r.addGHStub([]string{"pr", "create"}, "https://github.com/owner/repo/pull/42\n", nil)
+
+	in := PauseInput{
+		RunID:     "20260101-1200-aaaa",
+		Worktree:  "/tmp/wt",
+		Branch:    "agent/20260101-1200-aaaa",
+		Repo:      "owner/repo",
+		Prompt:    "fix the auth bug",
+		CostUSD:   4.95,
+		BudgetUSD: 5.00,
+	}
+	out, err := HandleBudgetPause(context.Background(), r, in)
+	if err != nil {
+		t.Fatalf("HandleBudgetPause error: %v", err)
+	}
+
+	if !out.CommittedWIP {
+		t.Error("expected CommittedWIP=true for dirty worktree")
+	}
+	if !out.CreatedNewPR {
+		t.Error("expected CreatedNewPR=true when no PR existed")
+	}
+	if out.PRNumber != "42" {
+		t.Errorf("expected PRNumber=42, got %q", out.PRNumber)
+	}
+	if out.PRURL != "https://github.com/owner/repo/pull/42" {
+		t.Errorf("expected PRURL set, got %q", out.PRURL)
+	}
+
+	// Verify the WIP commit happened.
+	if r.findGitCall("add", "-A") == nil {
+		t.Error("expected git add -A call")
+	}
+	if c := r.findGitCall("commit", "-m"); c == nil {
+		t.Error("expected git commit call")
+	} else {
+		// Commit message should reference the run ID.
+		if !strings.Contains(strings.Join(c.args, " "), "20260101-1200-aaaa") {
+			t.Errorf("commit message should include run ID, got %v", c.args)
+		}
+	}
+	// Verify the push.
+	if c := r.findGitCall("push", "--force-with-lease"); c == nil {
+		t.Error("expected git push --force-with-lease call")
+	}
+	// Verify label create.
+	if c := r.findGHCall("label", "create", event.BudgetPausedLabel); c == nil {
+		t.Error("expected gh label create call")
+	}
+	// Verify PR create with --draft.
+	if c := r.findGHCall("pr", "create", "--draft"); c == nil {
+		t.Error("expected gh pr create --draft call")
+	}
+	// Verify label apply.
+	if c := r.findGHCall("pr", "edit", "42", "--add-label"); c == nil {
+		t.Error("expected gh pr edit --add-label call")
+	}
+	// Verify PR comment.
+	if c := r.findGHCall("pr", "comment", "42"); c == nil {
+		t.Error("expected gh pr comment call")
+	}
+}
+
+func TestHandleBudgetPause_UsesExistingPR(t *testing.T) {
+	r := &recorderRunner{}
+	// Clean worktree.
+	r.addGitStub([]string{"status", "--porcelain"}, "", nil)
+	// lookupPR returns the existing PR.
+	r.addGHStub([]string{"pr", "view", "99", "--json"}, "99\nhttps://github.com/owner/repo/pull/99\n", nil)
+
+	in := PauseInput{
+		RunID:      "20260101-1200-bbbb",
+		Worktree:   "/tmp/wt",
+		Branch:     "agent/20260101-1200-bbbb",
+		Repo:       "owner/repo",
+		Prompt:     "do the thing",
+		CostUSD:    4.99,
+		BudgetUSD:  5.00,
+		ExistingPR: "99",
+	}
+	out, err := HandleBudgetPause(context.Background(), r, in)
+	if err != nil {
+		t.Fatalf("HandleBudgetPause error: %v", err)
+	}
+
+	if out.CommittedWIP {
+		t.Error("expected CommittedWIP=false for clean worktree")
+	}
+	if out.CreatedNewPR {
+		t.Error("expected CreatedNewPR=false when PR existed")
+	}
+	if out.PRNumber != "99" {
+		t.Errorf("expected PRNumber=99, got %q", out.PRNumber)
+	}
+
+	// Should NOT have called pr create.
+	if r.findGHCall("pr", "create") != nil {
+		t.Error("should not call gh pr create when PR already exists")
+	}
+	// Should still apply label and comment.
+	if r.findGHCall("pr", "edit", "99", "--add-label") == nil {
+		t.Error("expected label apply on existing PR")
+	}
+	if r.findGHCall("pr", "comment", "99") == nil {
+		t.Error("expected PR comment on existing PR")
+	}
+}
+
+func TestClearBudgetPausedLabel_NoOpWhenAbsent(t *testing.T) {
+	r := &recorderRunner{}
+	// gh succeeds with no output — label not present is not an error for gh
+	// pr edit --remove-label, so we treat it as success.
+	if err := ClearBudgetPausedLabel(context.Background(), r, "/tmp/wt", "owner/repo", "42"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c := r.findGHCall("pr", "edit", "42", "--remove-label"); c == nil {
+		t.Error("expected gh pr edit --remove-label call")
+	}
+}
+
+func TestClearBudgetPausedLabel_ToleratesNotFound(t *testing.T) {
+	r := &recorderRunner{}
+	r.addGHStub([]string{"--remove-label"}, "", fmt.Errorf("label not found"))
+	if err := ClearBudgetPausedLabel(context.Background(), r, "/tmp/wt", "owner/repo", "42"); err != nil {
+		t.Errorf("expected 'not found' to be tolerated, got %v", err)
+	}
+}
+
+func TestHasBudgetPausedLabel(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  string
+		want    bool
+		wantErr bool
+	}{
+		{"label present", "klaus:budget-paused\nother\n", true, false},
+		{"label absent", "other\nfoo\n", false, false},
+		{"no labels", "", false, false},
+		{"only the label", "klaus:budget-paused", true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &recorderRunner{}
+			r.addGHStub([]string{"pr", "view"}, tt.output, nil)
+			got, err := HasBudgetPausedLabel(context.Background(), r, "/tmp/wt", "owner/repo", "42")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBudgetExhausted(t *testing.T) {
+	tests := []struct {
+		cost float64
+		cap  float64
+		want bool
+	}{
+		{4.75, 5.00, true},   // at 95%
+		{4.95, 5.00, true},   // at 99%
+		{5.10, 5.00, true},   // overshoot
+		{4.00, 5.00, false},  // at 80%
+		{0.01, 5.00, false},  // tiny
+		{4.95, 0, false},     // unknown cap
+		{4.95, -1, false},    // bogus cap
+	}
+	for _, tt := range tests {
+		got := BudgetExhausted(tt.cost, tt.cap)
+		if got != tt.want {
+			t.Errorf("BudgetExhausted(%v, %v) = %v, want %v", tt.cost, tt.cap, got, tt.want)
+		}
+	}
+}
+
+func TestExtractPRNumberFromURL(t *testing.T) {
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{"https://github.com/owner/repo/pull/42", "42"},
+		{"https://github.com/owner/repo/pull/42\n", "42"},
+		{"https://github.com/owner/repo/pull/123/files", "123"},
+		{"not a url", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := extractPRNumberFromURL(tt.url)
+		if got != tt.want {
+			t.Errorf("extractPRNumberFromURL(%q) = %q, want %q", tt.url, got, tt.want)
+		}
+	}
+}
+
+func TestTitleFromPrompt(t *testing.T) {
+	tests := []struct {
+		prompt string
+		runID  string
+		want   string
+	}{
+		{"fix the auth bug", "id", "[budget-paused] fix the auth bug"},
+		{"line one\nline two", "id", "[budget-paused] line one"},
+		{"", "myid", "klaus run myid (budget paused)"},
+		{strings.Repeat("x", 100), "id", "[budget-paused] " + strings.Repeat("x", 72)},
+	}
+	for _, tt := range tests {
+		got := titleFromPrompt(tt.prompt, tt.runID)
+		if got != tt.want {
+			t.Errorf("titleFromPrompt(%q, %q) = %q, want %q", tt.prompt, tt.runID, got, tt.want)
+		}
+	}
+}

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -15,6 +15,8 @@ const (
 	AgentStarted        = "agent:started"
 	AgentCompleted      = "agent:completed"
 	AgentPRCreated      = "agent:pr-created"
+	AgentPaused         = "agent:paused"
+	AgentResumed        = "agent:resumed"
 	AgentCIPassed       = "agent:ci-passed"
 	AgentCIFailed       = "agent:ci-failed"
 	AgentNeedsAttention = "agent:needs-attention"
@@ -22,6 +24,11 @@ const (
 	PRApproved          = "pr:approved"
 	PRMerged            = "pr:merged"
 )
+
+// BudgetPausedLabel is the GitHub label applied to PRs whose agents have
+// paused due to budget exhaustion. Klaus uses the label as the persistence
+// signal for the paused state; the draft PR + label is the canonical record.
+const BudgetPausedLabel = "klaus:budget-paused"
 
 // New creates an Event with the current timestamp.
 func New(runID, eventType string, data map[string]interface{}) Event {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -13,6 +13,7 @@ type Client interface {
 	GetConflicts(ctx context.Context, prRef string) string
 	GetReviewDecision(ctx context.Context, prRef string) string
 	GetState(ctx context.Context, prRef string) string
+	GetLabels(ctx context.Context, prRef string) []string
 	GetBranch(ctx context.Context, prRef string) (string, error)
 	GetURL(ctx context.Context, prRef string) (string, error)
 	GetTitle(ctx context.Context, prRef string) string

--- a/internal/github/gh_cli_client.go
+++ b/internal/github/gh_cli_client.go
@@ -161,6 +161,32 @@ func (c *GHCLIClient) GetReviewDecision(ctx context.Context, prRef string) strin
 	return strings.TrimSpace(stdout.String())
 }
 
+// GetLabels returns the names of all labels currently applied to the PR.
+// Returns an empty slice on error (including when the PR has no labels).
+func (c *GHCLIClient) GetLabels(ctx context.Context, prRef string) []string {
+	ctx, cancel := ensureTimeout(ctx)
+	defer cancel()
+
+	args := c.ghArgs([]string{"pr", "view", "--json", "labels", "-q", ".labels[].name"}, prRef)
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return nil
+	}
+	out := strings.TrimSpace(stdout.String())
+	if out == "" {
+		return nil
+	}
+	var labels []string
+	for _, line := range strings.Split(out, "\n") {
+		if name := strings.TrimSpace(line); name != "" {
+			labels = append(labels, name)
+		}
+	}
+	return labels
+}
+
 // GetState returns the PR state (e.g. "OPEN", "MERGED", "CLOSED").
 func (c *GHCLIClient) GetState(ctx context.Context, prRef string) string {
 	ctx, cancel := ensureTimeout(ctx)

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -29,18 +29,20 @@ const (
 	StageMerging       Stage = "merging"
 	StageMerged        Stage = "merged"
 	StageStalled       Stage = "stalled"
+	StageBudgetPaused  Stage = "budget_paused"
 )
 
 // PRStatus holds the GitHub-fetched status for a single PR, passed from the dashboard.
 type PRStatus struct {
-	PRNumber               string
-	PRURL                  string
-	State                  string // OPEN, MERGED, CLOSED
-	CI                     string // passing, failing, pending, unknown
-	Conflicts              string // yes, none, unknown
-	ReviewDecision         string // APPROVED, CHANGES_REQUESTED, etc.
-	TargetRepo             string // owner/repo for dispatch context
-	HasNewTrustedComments  bool   // unaddressed comments from trusted reviewers
+	PRNumber              string
+	PRURL                 string
+	State                 string // OPEN, MERGED, CLOSED
+	CI                    string // passing, failing, pending, unknown
+	Conflicts             string // yes, none, unknown
+	ReviewDecision        string // APPROVED, CHANGES_REQUESTED, etc.
+	TargetRepo            string // owner/repo for dispatch context
+	HasNewTrustedComments bool   // unaddressed comments from trusted reviewers
+	Labels                []string // GitHub label names; klaus uses "klaus:budget-paused" as a pause signal
 }
 
 // PRPipelineState tracks per-PR pipeline state.
@@ -695,6 +697,8 @@ func StageLabel(stage Stage) string {
 		return "merged"
 	case StageStalled:
 		return "stalled"
+	case StageBudgetPaused:
+		return "budget paused, awaiting decision"
 	default:
 		return string(stage)
 	}

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -2344,3 +2344,112 @@ func TestCoordinatorLaunchedNonPRFixDoesNotSuppress(t *testing.T) {
 func strPtr(s string) *string {
 	return &s
 }
+
+func TestBudgetPausedLabelDrivesStage(t *testing.T) {
+	c, _ := newTestController(t)
+
+	launchCount := 0
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
+		launchCount++
+		return "agent-x", nil
+	})
+
+	// PR has the klaus:budget-paused label. Even though CI is failing, the
+	// pause transition should win and no fix-agent should be dispatched.
+	statuses := map[string]*PRStatus{
+		"42": {
+			PRNumber:   "42",
+			State:      "OPEN",
+			CI:         "failing",
+			TargetRepo: "owner/repo",
+			Labels:     []string{"klaus:budget-paused"},
+		},
+	}
+
+	actions := c.HandleGHStatus(context.Background(), statuses, nil)
+
+	if launchCount != 0 {
+		t.Errorf("expected no agent dispatch for paused PR, got %d launches", launchCount)
+	}
+	if len(actions) != 0 {
+		t.Errorf("expected no actions for paused PR, got %v", actions)
+	}
+	if got := c.PipelineStates()["42"].Stage; got != StageBudgetPaused {
+		t.Errorf("expected stage budget_paused, got %s", got)
+	}
+}
+
+func TestBudgetPausedTransitionsToCIFailedOnceLabelCleared(t *testing.T) {
+	c, _ := newTestController(t)
+	launchCount := 0
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
+		launchCount++
+		return "agent-fix", nil
+	})
+
+	// Step 1: paused.
+	statuses := map[string]*PRStatus{
+		"42": {
+			PRNumber:   "42",
+			State:      "OPEN",
+			CI:         "failing",
+			TargetRepo: "owner/repo",
+			Labels:     []string{"klaus:budget-paused"},
+		},
+	}
+	c.HandleGHStatus(context.Background(), statuses, nil)
+	if c.PipelineStates()["42"].Stage != StageBudgetPaused {
+		t.Fatalf("setup: expected budget_paused, got %s", c.PipelineStates()["42"].Stage)
+	}
+
+	// Step 2: label cleared → pipeline should resume normal handling
+	// (dispatch a fix agent for failing CI).
+	statuses["42"] = &PRStatus{
+		PRNumber:   "42",
+		State:      "OPEN",
+		CI:         "failing",
+		TargetRepo: "owner/repo",
+		Labels:     nil,
+	}
+	c.HandleGHStatus(context.Background(), statuses, nil)
+
+	if launchCount != 1 {
+		t.Errorf("expected fix agent dispatch after label clear, got %d launches", launchCount)
+	}
+	if got := c.PipelineStates()["42"].Stage; got != StageCIFailed {
+		t.Errorf("expected stage ci_failed after label clear, got %s", got)
+	}
+}
+
+func TestBudgetPausedEmitsEventOnTransition(t *testing.T) {
+	c, _ := newTestController(t)
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
+		return "agent-x", nil
+	})
+
+	statuses := map[string]*PRStatus{
+		"42": {
+			PRNumber:   "42",
+			State:      "OPEN",
+			CI:         "passing",
+			TargetRepo: "owner/repo",
+			Labels:     []string{"klaus:budget-paused"},
+		},
+	}
+	c.HandleGHStatus(context.Background(), statuses, nil)
+
+	// Idempotent: calling again should not double-emit (we just verify the
+	// stage stays the same — events.jsonl assertion is more fragile to set
+	// up in this test harness, so we rely on the stage as the proxy).
+	c.HandleGHStatus(context.Background(), statuses, nil)
+
+	if got := c.PipelineStates()["42"].Stage; got != StageBudgetPaused {
+		t.Errorf("expected stage budget_paused, got %s", got)
+	}
+}
+
+func TestStageLabelBudgetPaused(t *testing.T) {
+	if got := StageLabel(StageBudgetPaused); got != "budget paused, awaiting decision" {
+		t.Errorf("StageLabel(budget_paused) = %q", got)
+	}
+}

--- a/internal/pipeline/transitions.go
+++ b/internal/pipeline/transitions.go
@@ -29,6 +29,41 @@ var transitions = []transition{
 		},
 	},
 
+	// ── Budget-paused (handled before CI rules so the dashboard surfaces
+	// the pause regardless of CI state) ────────────────────────────────
+
+	{
+		Name: "budget-paused/await-decision",
+		Guard: allOf(
+			isBudgetPausedDraft,
+			agentNotRunning,
+		),
+		Apply: func(c *Controller, ps *PRPipelineState, status *PRStatus, _ []*run.State) ([]Action, []ActionDescriptor) {
+			if ps.Stage != StageBudgetPaused {
+				c.emitEvent(ps.PRNumber, event.AgentPaused, map[string]interface{}{
+					"pr_number": ps.PRNumber,
+					"pr_url":    status.PRURL,
+					"reason":    "budget_exhausted",
+				})
+			}
+			ps.Stage = StageBudgetPaused
+			return nil, nil
+		},
+	},
+	{
+		Name:  "budget-paused/noop-while-agent-running",
+		Guard: isBudgetPausedDraft,
+		Apply: func(_ *Controller, ps *PRPipelineState, _ *PRStatus, _ []*run.State) ([]Action, []ActionDescriptor) {
+			// An agent is running against the paused PR (klaus launch --pr).
+			// Hold the budget_paused stage until the agent's _finalize
+			// clears the label.
+			if ps.Stage != StageBudgetPaused {
+				ps.Stage = StageBudgetPaused
+			}
+			return nil, nil
+		},
+	},
+
 	// ── CI failing ──────────────────────────────────────────────────────
 
 	{
@@ -558,6 +593,22 @@ func changesRequested(_ *Controller, _ *PRPipelineState, status *PRStatus, _ []*
 
 func hasTrustedComments(_ *Controller, _ *PRPipelineState, status *PRStatus, _ []*run.State) bool {
 	return status.HasNewTrustedComments
+}
+
+// Label guards.
+
+// isBudgetPausedDraft reports whether the PR carries the klaus:budget-paused
+// label. We treat the label as the canonical paused-state signal: it persists
+// across klaus restarts and survives the worktree being cleaned up. Whether
+// the PR is currently draft or ready-for-review doesn't change the signal;
+// the label IS the signal.
+func isBudgetPausedDraft(_ *Controller, _ *PRPipelineState, status *PRStatus, _ []*run.State) bool {
+	for _, label := range status.Labels {
+		if label == event.BudgetPausedLabel {
+			return true
+		}
+	}
+	return false
 }
 
 // Conflict guards.


### PR DESCRIPTION
## Supersedes #258

PR #258 added a \`state.Status\` field with \`PausedAt\` / \`PauseReason\`, plus \`klaus resume\` and \`klaus finalize\` commands, to handle budget exhaustion. A review found three concrete problems:

1. **Architectural**: Klaus has no \`Status\` field today — run state is derived from field invariants (\`CostUSD\`/\`DurationMS\`/\`Approved\`). Adding a mutable Status created two sources of truth and ignored the existing pipeline FSM pattern that's designed for exactly this kind of state-transition logic.
2. **Correctness**: \`agent:pr-created\` was dropped on pause because the early-return in \`_finalize\` skipped event emission.
3. **Correctness**: \`klaus resume\` did not re-pass \`--append-system-prompt\`, diverging from session.go's resume convention.

This PR rewrites the design. **GitHub itself is the persistence layer** — the draft PR + \`klaus:budget-paused\` label IS the paused state, not an in-process field.

## The new flow

When \`_finalize\` detects budget exhaustion (claude exited with cost ≥ 95% of cap and the result event subtype is NOT \`success\`):

1. \`git add -A\` + commit any uncommitted changes with \`WIP from klaus run <id> (budget paused)\`.
2. \`git push --force-with-lease --set-upstream origin <branch>\`.
3. \`gh label create klaus:budget-paused --force\` (idempotent).
4. Find or create a draft PR via \`gh pr create --draft\` (or reuse the run's existing PR).
5. \`gh pr edit <num> --add-label klaus:budget-paused\`.
6. \`gh pr comment <num>\` with cost/budget/run-id and resume instructions.
7. Emit \`agent:paused\` (and \`agent:pr-created\` if the URL was just discovered).
8. Fall through to normal \`_finalize\` cleanup (\`syncRunToDataRef\` + \`cleanupWorktree\`). **The worktree is removed** because the work is safe on the PR branch.

When a follow-up \`klaus launch --pr <num>\` against a paused PR completes normally, \`_finalize\` clears the \`klaus:budget-paused\` label and emits \`agent:resumed\`. The dashboard is then honest about the pause being resolved.

## Pipeline FSM

A new \`StageBudgetPaused\` is added to \`internal/pipeline/pipeline.go\` and two transitions to \`transitions.go\`, guarded on \`hasLabel(klaus:budget-paused)\`. They sit at the top of the table so they win over CI/review rules. **No auto-dispatch of a continuation agent** — the user decides via \`klaus launch --pr\`.

\`PRStatus\` gets a \`Labels []string\` field, populated by a new \`GHCLIClient.GetLabels\` and propagated from \`dashboard_commands.fetchPRStatus\` → \`dashboard\` → \`pipeline.Controller\`.

## CLI surface — dropped vs kept

**Dropped from #258**: \`klaus resume\`, \`klaus finalize\`, \`internal/cmd/resume.go\`, \`internal/cmd/finalize.go\`. The draft PR + label is the persisted state; \`klaus launch --pr <num>\` IS the resume path.

**Kept**: \`agent:paused\` and \`agent:resumed\` event types in \`internal/event/event.go\`.

**Dropped**: the \`agent:finalized\` event type — \`agent:completed\` covers normal termination and \`agent:paused\` covers budget pause.

## State management — no new fields on run.State

No \`Status\`, no \`PausedAt\`, no \`PauseReason\`. The PR + label IS the state. Klaus reads it via \`gh\` when it needs to know.

## Architectural change

- **No new fields on \`run.State\`** — paused state lives on GitHub, not in process memory.
- **Pause/resume handled via the existing \`PRPipelineFSM\` transition pattern** rather than bespoke mutation across \`_finalize\` / \`cleanup\` / new commands.
- **Budget detection pairs the 95% heuristic with claude's result event subtype** — a \`success\` result is always trusted; only non-success + near-cap triggers pause.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` passes (all 16 packages)
- [x] \`klaus _pre-review\` reports no findings
- [x] Integration test in \`internal/cmd/pause_test.go\`: end-to-end pause flow against a real bare-remote + fake \`gh\` runner. Asserts WIP commit lands, branch is pushed to origin, label/PR/comment gh calls are issued, \`agent:paused\` + \`agent:pr-created\` events are written, worktree is removed.
- [x] Integration test: pause-with-existing-PR reuses the PR instead of creating a new one.
- [x] Integration test: \`_finalize\` against a paused PR with a successful follow-up clears the label and emits \`agent:resumed\`.
- [x] FSM tests: \`klaus:budget-paused\` label drives \`Stage\` to \`StageBudgetPaused\` with no auto-launch action; clearing the label transitions back to normal handling.
- [x] Unit tests in \`internal/draft/draft_test.go\` for \`BudgetExhausted\`, \`HasBudgetPausedLabel\`, \`HandleBudgetPause\` (new and existing-PR paths).
- [x] README \"Budget pause and resume\" section + coordinator system-prompt section updated.
- [x] \`launch --pr\` help text and \`Long\` description note the resume use case.

Run: 20260529-1729-7933cde0