### PR TITLE
fix: klaus approve emits an event so the FSM wakes without a follow-up webhook

### DIFF
--- a/internal/cmd/approve.go
+++ b/internal/cmd/approve.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/patflynn/klaus/internal/event"
 	"github.com/patflynn/klaus/internal/run"
 	"github.com/spf13/cobra"
 )
@@ -107,9 +108,37 @@ func markApproved(s *run.State, store run.StateStore) error {
 	now := time.Now().UTC().Format(time.RFC3339)
 	s.ApprovedAt = &now
 	if store != nil {
-		return store.Save(s)
+		if err := store.Save(s); err != nil {
+			return err
+		}
 	}
+	emitApprovalChanged(store, s)
 	return nil
+}
+
+// emitApprovalChanged writes a PRApprovalChanged event to the session event
+// log so the dashboard FSM wakes without waiting for an unrelated GitHub
+// webhook. The event is informational — failures are logged via stderr but
+// do not fail the approve command, since the state itself is already
+// persisted on disk and the dashboard's polling fallback (when enabled) will
+// pick up the change on the next tick.
+func emitApprovalChanged(store run.StateStore, s *run.State) {
+	hds, ok := store.(*run.HomeDirStore)
+	if !ok {
+		return
+	}
+	data := map[string]interface{}{}
+	if pr := extractPRNumber(s); pr != "" {
+		data["pr_number"] = pr
+	}
+	if s.PRURL != nil {
+		data["pr_url"] = *s.PRURL
+	}
+	data["approved"] = true
+	log := event.NewLog(hds.BaseDir())
+	if err := log.Emit(event.New(s.ID, event.PRApprovalChanged, data)); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to emit approval event: %v\n", err)
+	}
 }
 
 // findRunByPR finds a run state matching a PR number in the given store.

--- a/internal/cmd/approve_test.go
+++ b/internal/cmd/approve_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"testing"
 
+	"github.com/patflynn/klaus/internal/event"
 	"github.com/patflynn/klaus/internal/run"
 )
 
@@ -177,6 +178,103 @@ func TestMarkApproved(t *testing.T) {
 	reloaded, _ := store.Load("20260101-0000-aaaa")
 	if reloaded.Approved == nil || !*reloaded.Approved {
 		t.Error("approval should be persisted")
+	}
+}
+
+// TestMarkApprovedEmitsEvent verifies that approval emits a PRApprovalChanged
+// event to the session event log. This is the invalidation signal the
+// dashboard consumes to wake the pipeline FSM without waiting for a GitHub
+// webhook (see internal/cmd/dashboard.go internalEventMsg handler).
+func TestMarkApprovedEmitsEvent(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := run.NewHomeDirStoreFromPath(tmpDir)
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+
+	prURL := "https://github.com/owner/repo/pull/42"
+	s := &run.State{
+		ID:        "20260101-0000-aaaa",
+		Prompt:    "fix",
+		Branch:    "b1",
+		PRURL:     &prURL,
+		CreatedAt: "2026-01-01T00:00:00Z",
+	}
+	if err := store.Save(s); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if err := markApproved(s, store); err != nil {
+		t.Fatalf("markApproved: %v", err)
+	}
+
+	log := event.NewLog(tmpDir)
+	events, err := log.Read()
+	if err != nil {
+		t.Fatalf("reading event log: %v", err)
+	}
+
+	var approval *event.Event
+	for i := range events {
+		if events[i].Type == event.PRApprovalChanged {
+			approval = &events[i]
+			break
+		}
+	}
+	if approval == nil {
+		t.Fatalf("expected a %s event, found %d events of other types", event.PRApprovalChanged, len(events))
+	}
+	if approval.RunID != s.ID {
+		t.Errorf("event run_id = %q, want %q", approval.RunID, s.ID)
+	}
+	if approval.Data["pr_number"] != "42" {
+		t.Errorf("event pr_number = %v, want 42", approval.Data["pr_number"])
+	}
+	if approval.Data["pr_url"] != prURL {
+		t.Errorf("event pr_url = %v, want %q", approval.Data["pr_url"], prURL)
+	}
+}
+
+// TestApproveByPRNumbersEmitsEvent verifies the event is emitted from the
+// real CLI entry point, not just the lower-level helper. This is the path
+// `klaus approve <num>` actually takes.
+func TestApproveByPRNumbersEmitsEvent(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := run.NewHomeDirStoreFromPath(tmpDir)
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+
+	prURL := "https://github.com/owner/repo/pull/42"
+	s := &run.State{
+		ID:        "20260101-0000-aaaa",
+		Prompt:    "fix",
+		Branch:    "b1",
+		PRURL:     &prURL,
+		CreatedAt: "2026-01-01T00:00:00Z",
+	}
+	if err := store.Save(s); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	allStates, _ := store.List()
+	if err := approveByPRNumbers([]string{"42"}, allStates, store); err != nil {
+		t.Fatalf("approveByPRNumbers: %v", err)
+	}
+
+	log := event.NewLog(tmpDir)
+	events, err := log.Read()
+	if err != nil {
+		t.Fatalf("reading event log: %v", err)
+	}
+	found := false
+	for _, e := range events {
+		if e.Type == event.PRApprovalChanged && e.Data["pr_number"] == "42" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected %s event for PR #42, got events: %v", event.PRApprovalChanged, events)
 	}
 }
 

--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -78,6 +78,7 @@ Keyboard shortcuts:
 			internalCh := make(chan event.Event, 64)
 			model.internalEventCh = internalCh
 			go func() {
+				defer close(internalCh)
 				if err := event.Tail(ctx, model.eventsPath, internalCh); err != nil {
 					fmt.Fprintf(os.Stderr, "warning: event tail stopped: %v\n", err)
 				}

--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -70,6 +70,20 @@ Keyboard shortcuts:
 		model := newDashboardModel(store, cfg, ghClient)
 		model.shutdownCancel = cancel
 
+		// Tail the session event log so klaus-internal commands (e.g.
+		// `klaus approve`) can wake the dashboard FSM without waiting for
+		// a GitHub webhook. The tail runs even when no webhook server is
+		// configured — it is the invalidation channel for our own CLI.
+		if model.eventsPath != "" {
+			internalCh := make(chan event.Event, 64)
+			model.internalEventCh = internalCh
+			go func() {
+				if err := event.Tail(ctx, model.eventsPath, internalCh); err != nil {
+					fmt.Fprintf(os.Stderr, "warning: event tail stopped: %v\n", err)
+				}
+			}()
+		}
+
 		var webhookSrv *webhook.Server
 		if cfg.Webhook != nil {
 			ch := make(chan webhook.Event, 64)
@@ -145,20 +159,29 @@ type dashboardModel struct {
 	err            error
 	watcher        *fsnotify.Watcher
 	logFile        *os.File
-	shutdownCancel context.CancelFunc  // cancels the shared shutdown context
+	shutdownCancel context.CancelFunc   // cancels the shared shutdown context
 	webhookCh      <-chan webhook.Event // non-nil when webhook mode is active
-	webhookAddr    string              // e.g. "127.0.0.1:9800"
-	useWebhook     bool                // true when webhook server is running
-	pollEnabled    bool                // true when polling is active (default or poll_fallback)
-	reconcileEvery time.Duration       // slow reconcile heartbeat interval (webhook-only mode)
+	webhookAddr    string               // e.g. "127.0.0.1:9800"
+	useWebhook     bool                 // true when webhook server is running
+	pollEnabled    bool                 // true when polling is active (default or poll_fallback)
+	reconcileEvery time.Duration        // slow reconcile heartbeat interval (webhook-only mode)
+	// internalEventCh carries klaus-emitted invalidation events (e.g.
+	// PRApprovalChanged from `klaus approve`). It is symmetric to webhookCh
+	// but sourced from the local event log rather than an HTTP listener,
+	// so internal CLI commands can wake the FSM without waiting for a real
+	// GitHub webhook.
+	internalEventCh <-chan event.Event
+	eventsPath      string // path to events.jsonl for the tail goroutine
 }
 
 func newDashboardModel(store run.StateStore, cfg config.Config, ghClient gh.Client) dashboardModel {
 	var eventLog *event.Log
 	var logWriter io.Writer = io.Discard
 	var logFile *os.File
+	var eventsPath string
 	if hds, ok := store.(*run.HomeDirStore); ok {
 		eventLog = event.NewLog(hds.BaseDir())
+		eventsPath = eventLog.Path()
 		logPath := filepath.Join(hds.BaseDir(), "dashboard.log")
 		if f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644); err == nil {
 			logWriter = f
@@ -178,6 +201,7 @@ func newDashboardModel(store run.StateStore, cfg config.Config, ghClient gh.Clie
 		pipelineCtrl:   ctrl,
 		pipelineStates: make(map[string]*pipeline.PRPipelineState),
 		logFile:        logFile,
+		eventsPath:     eventsPath,
 	}
 }
 
@@ -192,6 +216,9 @@ func (m dashboardModel) Init() tea.Cmd {
 	}
 	if shouldScheduleReconcile(m.useWebhook, m.pollEnabled, m.reconcileEvery) {
 		cmds = append(cmds, reconcileTickAfterCmd(m.reconcileEvery))
+	}
+	if m.internalEventCh != nil {
+		cmds = append(cmds, waitForInternalEventCmd(m.internalEventCh))
 	}
 	return tea.Batch(cmds...)
 }
@@ -334,6 +361,31 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.recentErrors = m.recentErrors[len(m.recentErrors)-3:]
 		}
 		return m, nil
+
+	case internalEventMsg:
+		// Klaus-internal invalidation events are handled symmetrically to
+		// webhooks: a CLI command (e.g. `klaus approve`) signalled that the
+		// pipeline preconditions for a PR may have changed, so we trigger
+		// a targeted re-fetch of GitHub status. That re-fetch funnels into
+		// the same HandleGHStatus path that polling and webhooks use, so
+		// the FSM gets a fresh evaluation without any divergent code path.
+		ev := msg.event
+		prNum := internalEventPRNumber(ev)
+		if shouldInvalidate(ev.Type) && prNum != "" {
+			var matchedStates []*run.State
+			for _, s := range m.states {
+				if extractPRNumber(s) == prNum {
+					matchedStates = append(matchedStates, s)
+				}
+			}
+			if len(matchedStates) > 0 {
+				return m, tea.Batch(
+					fetchGHStatusCmd(m.ghClient, matchedStates),
+					waitForInternalEventCmd(m.internalEventCh),
+				)
+			}
+		}
+		return m, waitForInternalEventCmd(m.internalEventCh)
 
 	case trustedCommentsMsg:
 		existing, ok := m.ghStatus[msg.prNumber]

--- a/internal/cmd/dashboard_commands.go
+++ b/internal/cmd/dashboard_commands.go
@@ -154,9 +154,9 @@ func shouldInvalidate(eventType string) bool {
 }
 
 // internalEventPRNumber returns the PR number associated with an event,
-// or empty if none. The event Data is map[string]interface{} from JSON,
-// so PR numbers may arrive as either string or float64 depending on the
-// emitter; both forms are tolerated.
+// or empty if none. The event Data is map[string]interface{}; JSON decodes
+// numbers as float64, but events constructed in-process may carry int /
+// int64, so all common numeric forms are tolerated.
 func internalEventPRNumber(ev event.Event) string {
 	if ev.Data == nil {
 		return ""
@@ -164,6 +164,10 @@ func internalEventPRNumber(ev event.Event) string {
 	switch v := ev.Data["pr_number"].(type) {
 	case string:
 		return v
+	case int:
+		return fmt.Sprintf("%d", v)
+	case int64:
+		return fmt.Sprintf("%d", v)
 	case float64:
 		if v == float64(int64(v)) {
 			return fmt.Sprintf("%d", int64(v))

--- a/internal/cmd/dashboard_commands.go
+++ b/internal/cmd/dashboard_commands.go
@@ -11,6 +11,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/fsnotify/fsnotify"
 	"github.com/patflynn/klaus/internal/config"
+	"github.com/patflynn/klaus/internal/event"
 	gh "github.com/patflynn/klaus/internal/github"
 	"github.com/patflynn/klaus/internal/pipeline"
 	"github.com/patflynn/klaus/internal/run"
@@ -53,6 +54,14 @@ type webhookMsg struct {
 // webhookClosedMsg signals that the webhook event channel was closed, so live
 // webhook consumption has stopped. Surfaced as a non-fatal error in the TUI.
 type webhookClosedMsg struct{}
+
+// internalEventMsg delivers a klaus-emitted event (e.g. PRApprovalChanged
+// from `klaus approve`) into the dashboard's Update loop. Internal events
+// are treated as invalidation signals — the dashboard reacts by re-fetching
+// PR status, mirroring how it reacts to a real GitHub webhook.
+type internalEventMsg struct {
+	event event.Event
+}
 
 type trustedCommentsMsg struct {
 	prNumber             string
@@ -116,6 +125,51 @@ func waitForWebhookCmd(ch <-chan webhook.Event) tea.Cmd {
 		}
 		return webhookMsg{event: ev}
 	}
+}
+
+func waitForInternalEventCmd(ch <-chan event.Event) tea.Cmd {
+	if ch == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		ev, ok := <-ch
+		if !ok {
+			return nil
+		}
+		return internalEventMsg{event: ev}
+	}
+}
+
+// shouldInvalidate reports whether an event type should trigger a refetch
+// of GitHub PR status. Most klaus events (agent:started, pr:merged, …) are
+// pure notifications and either reflect state the dashboard already learned
+// from the pipeline FSM, or are observational. Only events that signal an
+// external precondition change need an active invalidation.
+func shouldInvalidate(eventType string) bool {
+	switch eventType {
+	case event.PRApprovalChanged:
+		return true
+	}
+	return false
+}
+
+// internalEventPRNumber returns the PR number associated with an event,
+// or empty if none. The event Data is map[string]interface{} from JSON,
+// so PR numbers may arrive as either string or float64 depending on the
+// emitter; both forms are tolerated.
+func internalEventPRNumber(ev event.Event) string {
+	if ev.Data == nil {
+		return ""
+	}
+	switch v := ev.Data["pr_number"].(type) {
+	case string:
+		return v
+	case float64:
+		if v == float64(int64(v)) {
+			return fmt.Sprintf("%d", int64(v))
+		}
+	}
+	return ""
 }
 
 func tickCmd() tea.Cmd {

--- a/internal/cmd/dashboard_test.go
+++ b/internal/cmd/dashboard_test.go
@@ -10,6 +10,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/patflynn/klaus/internal/config"
+	"github.com/patflynn/klaus/internal/event"
 	gh "github.com/patflynn/klaus/internal/github"
 	"github.com/patflynn/klaus/internal/pipeline"
 	"github.com/patflynn/klaus/internal/project"
@@ -961,6 +962,166 @@ func awaitGHStatusMsg(bm tea.BatchMsg, timeout time.Duration) bool {
 		case <-deadline:
 			return false
 		}
+	}
+}
+
+// TestInternalEventMsgTriggersRefetchForMatchedPR is the dashboard-side
+// counterpart to the webhook test above. When `klaus approve` emits a
+// PRApprovalChanged event and the dashboard receives it via the internal
+// event channel, the dashboard must kick a targeted GH refetch so the
+// pipeline FSM gets a fresh evaluation. Without this, an approved PR with
+// already-passing CI sits at StageCIPassed until an unrelated webhook
+// arrives (or polling tick, when poll_fallback is enabled).
+func TestInternalEventMsgTriggersRefetchForMatchedPR(t *testing.T) {
+	prURL := "https://github.com/owner/repo/pull/42"
+	states := []*run.State{
+		{
+			ID:         "20260407-0900-aaaa",
+			Prompt:     "fix bug",
+			Type:       "launch",
+			CreatedAt:  time.Now().Format(time.RFC3339),
+			TargetRepo: strPtr("owner/repo"),
+			PRURL:      &prURL,
+		},
+	}
+
+	m := newDashboardModel(run.NewGitDirStore(t.TempDir()), config.Config{}, gh.NewGHCLIClient(""))
+	m.states = states
+	ch := make(chan event.Event, 1)
+	m.internalEventCh = ch
+
+	msg := internalEventMsg{
+		event: event.New("20260407-0900-aaaa", event.PRApprovalChanged, map[string]interface{}{
+			"pr_number": "42",
+			"pr_url":    prURL,
+			"approved":  true,
+		}),
+	}
+
+	_, cmd := m.Update(msg)
+	if cmd == nil {
+		t.Fatal("expected a tea.Cmd from internal event with matching PR")
+	}
+	result := cmd()
+	bm, ok := result.(tea.BatchMsg)
+	if !ok {
+		t.Fatal("expected tea.BatchMsg from internal event handler")
+	}
+	if !awaitGHStatusMsg(bm, 15*time.Second) {
+		t.Error("expected ghStatusMsg from internal-event-triggered fetch")
+	}
+}
+
+// TestInternalEventMsgNoMatchKeepsListening ensures the handler returns a
+// new wait command even when no PR matches, so the dashboard keeps reading
+// from the channel. (Otherwise a stray event would silently kill the
+// subscription.)
+func TestInternalEventMsgNoMatchKeepsListening(t *testing.T) {
+	m := newDashboardModel(run.NewGitDirStore(t.TempDir()), config.Config{}, gh.NewGHCLIClient(""))
+	m.states = []*run.State{}
+	ch := make(chan event.Event, 1)
+	m.internalEventCh = ch
+
+	msg := internalEventMsg{
+		event: event.New("run-x", event.PRApprovalChanged, map[string]interface{}{
+			"pr_number": "999",
+		}),
+	}
+
+	_, cmd := m.Update(msg)
+	if cmd == nil {
+		t.Fatal("expected a tea.Cmd even when no PR matches (to keep listening)")
+	}
+}
+
+// TestInternalEventMsgIgnoresUnknownEventType verifies the handler only
+// reacts to invalidation-class events. A pr:merged or agent:completed event
+// arriving on the internal channel should not trigger a GH refetch (those
+// reflect state the dashboard already learned from the FSM).
+func TestInternalEventMsgIgnoresUnknownEventType(t *testing.T) {
+	prURL := "https://github.com/owner/repo/pull/42"
+	states := []*run.State{
+		{
+			ID:         "20260407-0900-aaaa",
+			Type:       "launch",
+			CreatedAt:  time.Now().Format(time.RFC3339),
+			TargetRepo: strPtr("owner/repo"),
+			PRURL:      &prURL,
+		},
+	}
+
+	m := newDashboardModel(run.NewGitDirStore(t.TempDir()), config.Config{}, gh.NewGHCLIClient(""))
+	m.states = states
+	ch := make(chan event.Event, 1)
+	m.internalEventCh = ch
+
+	msg := internalEventMsg{
+		event: event.New("20260407-0900-aaaa", event.PRMerged, map[string]interface{}{
+			"pr_number": "42",
+		}),
+	}
+
+	_, cmd := m.Update(msg)
+	if cmd == nil {
+		t.Fatal("expected a tea.Cmd (waitForInternalEventCmd) to keep listening")
+	}
+	// The returned cmd should be the single wait command, not a batch with
+	// a fetch. Block on the channel with a short timeout to confirm it is
+	// the wait command (returns no ghStatusMsg even if drained).
+	done := make(chan tea.Msg, 1)
+	go func() { done <- cmd() }()
+	select {
+	case msg := <-done:
+		// Only happens if cmd() returned (e.g. channel closed); ensure it
+		// is NOT a ghStatusMsg or BatchMsg containing a fetch.
+		if _, ok := msg.(ghStatusMsg); ok {
+			t.Errorf("non-invalidation event should not trigger a GH fetch")
+		}
+		if bm, ok := msg.(tea.BatchMsg); ok {
+			if awaitGHStatusMsg(bm, 100*time.Millisecond) {
+				t.Errorf("non-invalidation event should not trigger a GH fetch")
+			}
+		}
+	case <-time.After(200 * time.Millisecond):
+		// Expected: waitForInternalEventCmd blocks on the empty channel.
+	}
+}
+
+// TestInternalEventMsgIdempotentWithExistingFlow checks that an approval
+// event for a PR can be safely delivered after the controller has already
+// transitioned past approval — the handler does not crash, does not double
+// dispatch, and continues to listen. We exercise this by feeding the same
+// event twice and asserting both calls return non-nil commands.
+func TestInternalEventMsgIdempotent(t *testing.T) {
+	prURL := "https://github.com/owner/repo/pull/42"
+	states := []*run.State{
+		{
+			ID:         "20260407-0900-aaaa",
+			Type:       "launch",
+			CreatedAt:  time.Now().Format(time.RFC3339),
+			TargetRepo: strPtr("owner/repo"),
+			PRURL:      &prURL,
+		},
+	}
+
+	m := newDashboardModel(run.NewGitDirStore(t.TempDir()), config.Config{}, gh.NewGHCLIClient(""))
+	m.states = states
+	ch := make(chan event.Event, 1)
+	m.internalEventCh = ch
+
+	msg := internalEventMsg{
+		event: event.New("20260407-0900-aaaa", event.PRApprovalChanged, map[string]interface{}{
+			"pr_number": "42",
+		}),
+	}
+
+	_, cmd1 := m.Update(msg)
+	if cmd1 == nil {
+		t.Fatal("first delivery: expected a tea.Cmd")
+	}
+	_, cmd2 := m.Update(msg)
+	if cmd2 == nil {
+		t.Fatal("second delivery: expected a tea.Cmd")
 	}
 }
 

--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -48,6 +48,7 @@ var knownEventTypes = []eventTypeInfo{
 	{event.PRAwaitingApproval, "live", "A PR is ready for human approval"},
 	{event.PRApproved, "live", "A PR was approved"},
 	{event.PRMerged, "live", "A PR merged"},
+	{event.PRApprovalChanged, "live", "Klaus-internal approval state for a PR changed (e.g. via klaus approve)"},
 	{"agent:error", "reserved", "Reserved for unrecoverable agent failures (not currently emitted; use agent:needs-attention)"},
 	{"ci:failed", "reserved", "Reserved short name (currently emitted as agent:ci-failed)"},
 	{"ci:passed", "reserved", "Reserved short name (currently emitted as agent:ci-passed)"},

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -23,6 +23,14 @@ const (
 	PRAwaitingApproval  = "pr:awaiting-approval"
 	PRApproved          = "pr:approved"
 	PRMerged            = "pr:merged"
+	// PRApprovalChanged signals that an external decision about a PR's
+	// merge-readiness has changed (e.g. `klaus approve` flipped an internal
+	// approval flag). It is an invalidation signal — the dashboard reacts by
+	// re-fetching GitHub status and re-evaluating the pipeline FSM, just as
+	// it does for a real webhook. The name is deliberately backend-agnostic
+	// so the same signal can be reused once klaus supports non-GitHub
+	// merge-readiness sources.
+	PRApprovalChanged = "pr:approval-changed"
 )
 
 // BudgetPausedLabel is the GitHub label applied to PRs whose agents have

--- a/internal/event/tail.go
+++ b/internal/event/tail.go
@@ -1,0 +1,141 @@
+package event
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// Tail follows the events file at path, sending each newly appended Event to
+// out. It blocks until ctx is cancelled. New events are emitted starting from
+// the end of the file at the time Tail is called (it does NOT replay existing
+// history). If the file does not yet exist, Tail waits for it to appear.
+//
+// Tail is used by the dashboard to subscribe to klaus-internal invalidation
+// signals (e.g. PRApprovalChanged) written by other klaus processes such as
+// `klaus approve`. Compared with watching the run state directory, tailing
+// the event log gives a precise, intent-bearing signal rather than relying on
+// fsnotify of a JSON state file as a proxy.
+func Tail(ctx context.Context, path string, out chan<- Event) error {
+	if err := waitForFile(ctx, path); err != nil {
+		return err
+	}
+	if ctx.Err() != nil {
+		return nil
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	defer watcher.Close()
+
+	if err := watcher.Add(filepath.Dir(path)); err != nil {
+		return err
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if f != nil {
+			f.Close()
+		}
+	}()
+
+	if _, err := f.Seek(0, io.SeekEnd); err != nil {
+		return err
+	}
+
+	var pending []byte
+
+	drain := func() error {
+		buf := make([]byte, 32*1024)
+		for {
+			n, err := f.Read(buf)
+			if n > 0 {
+				pending = append(pending, buf[:n]...)
+				for {
+					idx := bytes.IndexByte(pending, '\n')
+					if idx < 0 {
+						break
+					}
+					line := pending[:idx]
+					pending = pending[idx+1:]
+					if len(line) == 0 {
+						continue
+					}
+					var evt Event
+					if err := json.Unmarshal(line, &evt); err != nil {
+						continue
+					}
+					select {
+					case out <- evt:
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+				}
+			}
+			if err == io.EOF {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := drain(); err != nil {
+		return err
+	}
+
+	const poll = 500 * time.Millisecond
+	ticker := time.NewTicker(poll)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case ev, ok := <-watcher.Events:
+			if !ok {
+				return nil
+			}
+			if filepath.Clean(ev.Name) != filepath.Clean(path) {
+				continue
+			}
+			if ev.Op&(fsnotify.Write|fsnotify.Chmod|fsnotify.Create) != 0 {
+				if err := drain(); err != nil {
+					return err
+				}
+			}
+		case <-watcher.Errors:
+			// Non-fatal — keep going.
+		case <-ticker.C:
+			// Defensive: catch missed write notifications.
+			if err := drain(); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func waitForFile(ctx context.Context, path string) error {
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+}

--- a/internal/event/tail.go
+++ b/internal/event/tail.go
@@ -96,7 +96,9 @@ func Tail(ctx context.Context, path string, out chan<- Event) error {
 		return err
 	}
 
-	const poll = 500 * time.Millisecond
+	// fsnotify is reliable on modern OSes; this fallback only exists to catch
+	// rare missed notifications, so a long interval is fine.
+	const poll = 10 * time.Second
 	ticker := time.NewTicker(poll)
 	defer ticker.Stop()
 

--- a/internal/event/tail_test.go
+++ b/internal/event/tail_test.go
@@ -1,0 +1,102 @@
+package event
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestTailDeliversAppendedEvents verifies the Tail helper picks up events
+// written after it started. This is the path the dashboard uses to wake on
+// PRApprovalChanged signals emitted by `klaus approve`.
+func TestTailDeliversAppendedEvents(t *testing.T) {
+	dir := t.TempDir()
+	log := NewLog(dir)
+	// Pre-create the file so Tail's waitForFile returns immediately.
+	if err := log.Emit(New("seed", AgentStarted, nil)); err != nil {
+		t.Fatalf("seed emit: %v", err)
+	}
+
+	out := make(chan Event, 8)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Tail(ctx, filepath.Join(dir, "events.jsonl"), out)
+	}()
+
+	// Give Tail a moment to seek to EOF before we emit.
+	time.Sleep(200 * time.Millisecond)
+
+	if err := log.Emit(New("run-1", PRApprovalChanged, map[string]interface{}{
+		"pr_number": "42",
+	})); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+
+	select {
+	case ev := <-out:
+		if ev.Type != PRApprovalChanged {
+			t.Errorf("got event type %q, want %q", ev.Type, PRApprovalChanged)
+		}
+		if ev.Data["pr_number"] != "42" {
+			t.Errorf("got pr_number %v, want 42", ev.Data["pr_number"])
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("did not receive event within 3s")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil && err != context.Canceled {
+			t.Fatalf("Tail returned error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Tail did not exit within 3s of context cancel")
+	}
+}
+
+// TestTailIgnoresPreExistingHistory verifies Tail only delivers events
+// appended after it starts. Pre-existing events should be skipped so the
+// dashboard does not re-process old approvals on every restart.
+func TestTailIgnoresPreExistingHistory(t *testing.T) {
+	dir := t.TempDir()
+	log := NewLog(dir)
+	if err := log.Emit(New("run-1", PRApprovalChanged, map[string]interface{}{
+		"pr_number": "1",
+	})); err != nil {
+		t.Fatalf("pre-emit: %v", err)
+	}
+
+	out := make(chan Event, 8)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Tail(ctx, filepath.Join(dir, "events.jsonl"), out)
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	if err := log.Emit(New("run-2", PRApprovalChanged, map[string]interface{}{
+		"pr_number": "2",
+	})); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+
+	select {
+	case ev := <-out:
+		if ev.Data["pr_number"] != "2" {
+			t.Errorf("got pre-existing event with pr_number %v; Tail should only deliver new events", ev.Data["pr_number"])
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("did not receive event within 3s")
+	}
+
+	cancel()
+	<-done
+}


### PR DESCRIPTION
Before this fix, `klaus approve` only persisted the approval flag to the run
state file. With `webhook.poll_fallback: false` (the recommended config), no
incoming GitHub events would arrive for a PR whose CI is already passing, so
the dashboard FSM never re-evaluated the PR and it stayed at StageCIPassed
indefinitely. The 30s tick is a no-op for pipeline evaluation when polling is
disabled, by design — webhooks are invalidation signals (commit f10153f), and
`klaus approve` was missing its own channel.

The fix adds a new backend-agnostic event type `pr:approval-changed`. The
approve command writes it to the session event log alongside the state save.
The dashboard tails events.jsonl in a goroutine and routes the relevant events
onto a new internal invalidation channel, symmetric to the webhook channel.
The handler shape matches `webhookMsg`: targeted refetch of GH status for the
affected PR, which funnels through the existing HandleGHStatus path so the
FSM gets a fresh evaluation. Polling-as-fallback is preserved unchanged.

Tests cover the emission, the dashboard handler (matched/unmatched/idempotent),
the tail helper, and that non-invalidation event types are ignored.

> ⚠️ The fix-agent that wrote this commit hit its $5 budget at the `git push` step, so this PR was opened manually by the coordinator. The branch and commit are the agent's; only the PR-creation step was external.