### PR TITLE
Install commit-msg hook in coordinator session worktrees

### DIFF
--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -183,6 +183,14 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 				}
 			}
 			fmt.Printf("Recreated worktree at %s\n", worktree)
+		} else if branch != "" {
+			// Worktree already exists (resuming an existing session). Reinstall
+			// the commit-msg hook so sessions created before the hook existed
+			// (or where it was removed) still strip attribution trailers.
+			// InstallCommitMsgHook is idempotent, so this is safe to rerun.
+			if err := gitClient.InstallCommitMsgHook(ctx, worktree); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: could not install commit-msg hook: %v\n", err)
+			}
 		}
 
 		// Clear stale tmux pane references from all agent runs in this session.

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -178,6 +178,9 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 				if err := gitClient.WorktreeAdd(ctx, baseRepo, worktree, branch, startPoint); err != nil {
 					return fmt.Errorf("recreating worktree: %w", err)
 				}
+				if err := gitClient.InstallCommitMsgHook(ctx, worktree); err != nil {
+					fmt.Fprintf(os.Stderr, "warning: could not install commit-msg hook: %v\n", err)
+				}
 			}
 			fmt.Printf("Recreated worktree at %s\n", worktree)
 		}
@@ -237,6 +240,10 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 
 			if err := config.WriteClaudeSettings(worktree, repoName); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: could not write .claude/settings.json: %v\n", err)
+			}
+
+			if err := gitClient.InstallCommitMsgHook(ctx, worktree); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: could not install commit-msg hook: %v\n", err)
 			}
 
 			// Set up Nix dev environment if flake.nix exists

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -534,6 +534,74 @@ func TestInstallCommitMsgHook_StripsMultiplePatterns(t *testing.T) {
 	}
 }
 
+// TestInstallCommitMsgHook_CoordinatorWorktree mirrors the coordinator session
+// worktree path (see internal/cmd/session.go): after the worktree is created the
+// commit-msg hook is installed, and a real commit with mixed trailers should have
+// the Claude/Anthropic attribution stripped while a human Co-Authored-By is kept.
+func TestInstallCommitMsgHook_CoordinatorWorktree(t *testing.T) {
+	ctx := context.Background()
+	repo := initTestRepo(t)
+	wtPath := filepath.Join(t.TempDir(), "session-wt")
+
+	if err := WorktreeAdd(ctx, repo, wtPath, "session/test", "main"); err != nil {
+		t.Fatalf("WorktreeAdd: %v", err)
+	}
+	defer WorktreeRemove(ctx, repo, wtPath)
+
+	if err := InstallCommitMsgHook(ctx, wtPath); err != nil {
+		t.Fatalf("InstallCommitMsgHook: %v", err)
+	}
+
+	// The hook must be active: core.hooksPath set and the commit-msg file present.
+	hooksPath, err := runGit(ctx, wtPath, "config", "core.hooksPath")
+	if err != nil {
+		t.Fatalf("git config core.hooksPath: %v", err)
+	}
+	if hooksPath == "" {
+		t.Fatal("core.hooksPath should be set in the coordinator worktree")
+	}
+	if _, err := os.Stat(filepath.Join(hooksPath, "commit-msg")); err != nil {
+		t.Fatalf("commit-msg hook should exist at %s: %v", hooksPath, err)
+	}
+
+	if err := os.WriteFile(filepath.Join(wtPath, "file.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	commitMsg := "coordinator change\n\n" +
+		"Co-Authored-By: Claude Opus 4 (1M context) <noreply@anthropic.com>\n" +
+		"Co-Authored-By: Bob Human <bob@example.com>\n" +
+		"🤖 Generated with Claude Code\n" +
+		"Generated with help from Anthropic"
+
+	for _, args := range [][]string{
+		{"git", "-C", wtPath, "add", "file.txt"},
+		{"git", "-C", wtPath, "commit", "-m", commitMsg},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+
+	msg, err := runGit(ctx, wtPath, "log", "-1", "--format=%B")
+	if err != nil {
+		t.Fatalf("git log: %v", err)
+	}
+	if strings.Contains(msg, "Claude") {
+		t.Errorf("should strip Claude references, got:\n%s", msg)
+	}
+	if strings.Contains(msg, "Anthropic") {
+		t.Errorf("should strip Anthropic references, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "Co-Authored-By: Bob Human") {
+		t.Errorf("should preserve human Co-Authored-By, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "coordinator change") {
+		t.Errorf("should preserve original message, got:\n%s", msg)
+	}
+}
+
 func TestWorktreeAdd_PrunesStaleAndRetries(t *testing.T) {
 	ctx := context.Background()
 	repo := initTestRepo(t)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -578,7 +578,7 @@ func TestInstallCommitMsgHook_CoordinatorWorktree(t *testing.T) {
 		{"git", "-C", wtPath, "add", "file.txt"},
 		{"git", "-C", wtPath, "commit", "-m", commitMsg},
 	} {
-		cmd := exec.Command(args[0], args[1:]...)
+		cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 		if out, err := cmd.CombinedOutput(); err != nil {
 			t.Fatalf("%v: %v\n%s", args, err, out)
 		}


### PR DESCRIPTION
## Problem

The `commit-msg` hook that strips Claude/Anthropic co-author trailers was installed only for **agent** worktrees (`internal/cmd/launch.go`), never for the **coordinator session** worktree (`internal/cmd/session.go`). As a result, coordinator commits leaked `Co-Authored-By: Claude...` trailers.

`InstallCommitMsgHook` (`internal/git/git.go`) had exactly one non-test caller — the agent launch path.

## Fix

Mirror the launch path in `session.go`: call `gitClient.InstallCommitMsgHook(ctx, worktree)` after the worktree is created, in both git-backed paths:

- **Fresh session** — after `WorktreeAdd`, alongside the existing `WriteClaudeSettings` call.
- **Recreate-on-resume** — after the `WorktreeAdd` that recreates a cleaned-up worktree.

The scratch-workspace path (plain directory, no git repo) is left untouched. The same warning-on-error pattern as `launch.go` is used so a hook-install failure does not abort session startup. The hook install is idempotent (writes the file and sets `core.hooksPath`), so running it on every fresh/recreate path is safe.

## Tests

Added `TestInstallCommitMsgHook_CoordinatorWorktree` to `internal/git/git_test.go`. It exercises the coordinator path against a real git repo: installs the hook in a worktree, asserts `core.hooksPath` is set and `hooks/commit-msg` exists, then makes a real commit with mixed trailers and verifies Claude/Anthropic attribution is stripped while a human `Co-Authored-By` line is preserved.

`go build ./...` passes and the git package tests pass. (The pre-existing `TestLoadNoFile` failure in `internal/config` is environment-dependent and fails identically on unmodified `main` — unrelated to this change.)

Run: 20260606-0732-8fc2f19a
Fixes #265