### PR TITLE
Add trajectory replay for budget-paused PR continuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,34 @@ klaus launch --pr <num> "continue the work"
 
 The new agent sees the WIP commit and picks up from there. When the follow-up agent's `_finalize` runs, the `klaus:budget-paused` label is automatically removed and an `agent:resumed` event is emitted. If the follow-up agent *also* exhausts its budget, the cycle repeats (a new WIP commit, label re-applied).
 
+### Trajectory replay
+
+By default, `klaus launch --pr` against a budget-paused PR does more than pick up the WIP commit: it **continues the previous agent's Claude conversation** instead of starting one cold. At finalize time klaus stores the resume-able conversation trajectory (the JSONL `claude` itself writes under `~/.claude/projects/…`) on `refs/klaus/data` at `sessions/<run-id>.jsonl`. On resume it fetches that blob, restores it into the new worktree's project dir, and invokes `claude --resume <uuid>`. The conversation continues from the exact point of pause — no re-grepping or re-orienting — which is faster and cheaper than a fresh agent.
+
+Replay is best-effort and **falls back to a fresh agent** when any of these hold:
+
+- The trajectory was never pushed (skipped because `klaus` detected potentially sensitive content), or the PR pre-dates this feature.
+- The trajectory is larger than the size threshold (default 300KB; replaying a very large trajectory can cost more than re-exploration). Configure with `replay_threshold_kb` in `~/.klaus/config.json` or `--replay-threshold-kb`.
+- No Claude session UUID could be determined for the paused run.
+- You pass `--no-replay`.
+
+Flags:
+
+```bash
+klaus launch --pr 42 "continue"                       # replay if eligible (default)
+klaus launch --pr 42 --no-replay "continue"           # force a fresh agent
+klaus launch --pr 42 --replay "continue"              # force replay, bypassing the size threshold
+klaus launch --pr 42 --replay-threshold-kb 500 "..."  # raise the per-launch threshold
+```
+
+**Staleness semantics — what you opt into with replay.** The restored conversation is a snapshot from when the previous agent paused, replayed into a *new* worktree at a *different* path:
+
+- **`cwd` / path mismatch.** The trajectory's tool calls reference the original (now-deleted) worktree path; the resumed agent runs in a fresh worktree. `claude` re-anchors to its current working directory, so new file operations are correct, but the conversation history still mentions the old path.
+- **Tool-result staleness.** Cached `Read`/grep results in the history reflect the files *as they were at pause time*. The branch head carries the WIP commit, so current contents may differ. This is the same staleness any long-lived `claude --resume` has; the agent is expected to re-read before relying on stale output. klaus adds no special mitigation beyond restoring the trajectory faithfully.
+- **No prompt-cache benefit.** Resumes happen long after the 5-minute cache TTL, so the replayed history is re-read as fresh input tokens. The size threshold exists precisely to keep that cost below the cost of a fresh re-exploration.
+
+> Note: replay relies on the conversation file being available where finalize runs. For agents executed on a remote `sandbox_host`, the conversation file lives on the sandbox and is not synced back, so those runs fall back to a fresh agent.
+
 To abandon the work, close the draft PR. To redirect, push manual commits to its branch.
 
 There is no separate `klaus resume` or `klaus finalize` command — `klaus launch --pr` is the only resume path, and `_finalize` handles the WIP commit automatically.

--- a/internal/cmd/hidden.go
+++ b/internal/cmd/hidden.go
@@ -379,6 +379,7 @@ func finalizeFromLog(store run.StateStore, state *run.State) (string, error) {
 		var ev struct {
 			Type         string  `json:"type"`
 			Subtype      string  `json:"subtype"`
+			SessionID    string  `json:"session_id"`
 			TotalCostUSD float64 `json:"total_cost_usd"`
 			DurationMS   int64   `json:"duration_ms"`
 			Message      *struct {
@@ -405,6 +406,12 @@ func finalizeFromLog(store run.StateStore, state *run.State) (string, error) {
 			}
 			if ev.Subtype != "" {
 				resultSubtype = ev.Subtype
+			}
+			// Record the Claude conversation UUID so a later budget-paused
+			// resume can restore the trajectory and run claude --resume.
+			if ev.SessionID != "" {
+				sid := ev.SessionID
+				state.ClaudeSessionID = &sid
 			}
 		case "assistant":
 			if ev.Message != nil {
@@ -549,6 +556,22 @@ func syncRunToDataRef(ctx context.Context, root string, store run.StateStore, gi
 					fmt.Fprintf(os.Stderr, "  - %s\n", f.Category)
 				}
 				fmt.Fprintf(os.Stderr, "  Use 'klaus push-log %s' to push manually.\n", state.ID)
+			}
+		}
+	}
+
+	// Also capture the resume-able Claude conversation file. This is distinct
+	// from the stream-json log above: claude --resume reads this file (under
+	// ~/.claude/projects/...), not the stdout stream we tee into logs/. Storing
+	// it lets 'klaus launch --pr' continue a budget-paused conversation.
+	if convPath := findResumeConversation(state); convPath != "" {
+		if cf, err := os.Open(convPath); err == nil {
+			findings := scan.CheckSensitivity(cf)
+			cf.Close()
+			if len(findings) == 0 {
+				files["sessions/"+state.ID+".jsonl"] = convPath
+			} else {
+				fmt.Fprintf(os.Stderr, "warning: skipping conversation push for %s: potentially sensitive data detected\n", state.ID)
 			}
 		}
 	}

--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -38,6 +38,14 @@ PR and it picks up from the WIP commit klaus left on the branch. When the
 follow-up agent's _finalize runs, the 'klaus:budget-paused' label is cleared
 automatically.
 
+For a budget-paused PR, klaus continues the previous agent's Claude
+conversation by default (trajectory replay): it restores the stored
+conversation and runs 'claude --resume', avoiding a cold re-exploration of
+the repo. It falls back to a fresh agent when the trajectory is missing,
+oversized, sensitive-skipped, or its session UUID is unknown. Use --no-replay
+to force a fresh agent, --replay to force replay (bypassing the size
+threshold), and --replay-threshold-kb to tune the per-launch size cap.
+
 When sandbox_host is configured in ~/.klaus/config.json, agents run remotely
 via SSH on the sandbox host. The worktree is synced before launch and results
 are synced back after completion. Use --local to force local execution, or
@@ -52,11 +60,18 @@ are synced back after completion. Use --local to force local execution, or
 		forceLocal, _ := cmd.Flags().GetBool("local")
 		hostOverride, _ := cmd.Flags().GetString("host")
 		resumeFrom, _ := cmd.Flags().GetString("resume-from")
+		replayFlag, _ := cmd.Flags().GetBool("replay")
+		noReplay, _ := cmd.Flags().GetBool("no-replay")
+		replayThresholdKB, _ := cmd.Flags().GetInt("replay-threshold-kb")
 		ctx := cmd.Context()
 		tmuxClient := tmux.NewExecClient()
 
 		if !tmux.InSession() {
 			return fmt.Errorf("klaus launch must be run inside a tmux session")
+		}
+
+		if replayFlag && noReplay {
+			return fmt.Errorf("--replay and --no-replay are mutually exclusive")
 		}
 
 		// Host repo — optional when --repo is specified or session target is set
@@ -108,7 +123,7 @@ are synced back after completion. Use --local to force local execution, or
 		// When --repo matches a registered project, use the local path directly.
 		// State is always tracked in the host repo.
 		var (
-			repoRoot      string  // repo dir for git ops (clone or host)
+			repoRoot      string // repo dir for git ops (clone or host)
 			repoName      string
 			defaultBranch string
 			targetRepo    *string
@@ -297,6 +312,44 @@ are synced back after completion. Use --local to force local execution, or
 			// up, skip --resume entirely and let claude start fresh.
 		}
 
+		// Budget-paused PR continuation (issue #261): when launching against a
+		// paused PR with no explicit --resume-from, try to continue the prior
+		// agent's Claude conversation via trajectory replay. The stored
+		// conversation is restored into this worktree's project dir and
+		// claude --resume picks up where the pause happened, avoiding a costly
+		// re-exploration of the repo. Falls back to a fresh agent on any miss.
+		// Replay restores the trajectory onto the local machine, so it only
+		// applies to local execution. When the run is destined for a sandbox
+		// host, claude runs remotely and would not find the restored file —
+		// skip replay and let it start fresh there.
+		intendsSandbox := !forceLocal && (hostOverride != "" || hostCfg.SandboxHost != "")
+		var replayedFromRunID string
+		if resolvedResume == "" && isPRFix && prNumber != "" && !noReplay && !intendsSandbox {
+			threshold := replayThresholdKB
+			if threshold == 0 {
+				threshold = hostCfg.ReplayThresholdKB
+			}
+			decision := resolveBudgetPausedReplay(ctx, replayParams{
+				GitClient:   gitClient,
+				Store:       store,
+				RepoRoot:    repoRoot,
+				DataRef:     hostCfg.DataRef,
+				Worktree:    worktree,
+				PRBranch:    branch,
+				PRNumber:    prNumber,
+				GHRepo:      resolveGHRepo(repoRef, repoRoot),
+				ForceReplay: replayFlag,
+				ThresholdKB: threshold,
+			})
+			if decision.SessionUUID != "" {
+				resolvedResume = decision.SessionUUID
+				replayedFromRunID = decision.SourceRunID
+				fmt.Printf("  replay:   %s\n", decision.Reason)
+			} else {
+				fmt.Printf("  replay:   fresh agent (%s)\n", decision.Reason)
+			}
+		}
+
 		// Build the claude command
 		claudeCmd := buildClaudeCommand(sysPrompt, budget, prompt, id, resolvedResume)
 
@@ -398,6 +451,8 @@ are synced back after completion. Use --local to force local execution, or
 		}
 		if resumeFrom != "" {
 			state.OriginalRunID = &resumeFrom
+		} else if replayedFromRunID != "" {
+			state.OriginalRunID = &replayedFromRunID
 		}
 		if isPRFix {
 			state.Type = "pr-fix"
@@ -710,5 +765,8 @@ func init() {
 	launchCmd.Flags().Bool("local", false, "Force local execution even when sandbox is configured")
 	launchCmd.Flags().String("host", "", "Override sandbox host (ignores config sandbox_host)")
 	launchCmd.Flags().String("resume-from", "", "Resume from a previous agent's session (run ID)")
+	launchCmd.Flags().Bool("replay", false, "Force trajectory replay for a budget-paused --pr (continue the prior conversation, bypassing the size threshold)")
+	launchCmd.Flags().Bool("no-replay", false, "Disable trajectory replay for a budget-paused --pr; dispatch a fresh agent instead")
+	launchCmd.Flags().Int("replay-threshold-kb", 0, "Max stored trajectory size (KB) eligible for replay; 0 uses config replay_threshold_kb (default 300)")
 	rootCmd.AddCommand(launchCmd)
 }

--- a/internal/cmd/replay.go
+++ b/internal/cmd/replay.go
@@ -33,6 +33,9 @@ import (
 // segment Claude Code uses under ~/.claude/projects. Claude replaces both '/'
 // and '.' with '-'. Verified empirically against Claude Code 2.1.x.
 func encodeProjectPath(cwd string) string {
+	if abs, err := filepath.Abs(cwd); err == nil {
+		cwd = abs
+	}
 	return strings.NewReplacer("/", "-", ".", "-").Replace(cwd)
 }
 
@@ -92,6 +95,9 @@ func findClaudeConversationFile(sessionUUID string) string {
 // back to globbing all project dirs. Returns "" if the UUID is unknown or no
 // file exists.
 func findResumeConversation(state *run.State) string {
+	if state == nil {
+		return ""
+	}
 	uuid := ""
 	if state.ClaudeSessionID != nil {
 		uuid = *state.ClaudeSessionID
@@ -115,21 +121,22 @@ func findResumeConversation(state *run.State) string {
 // extractConversationSessionID reads the sessionId (camelCase) from a
 // conversation-format JSONL blob. Returns "" if none is found.
 func extractConversationSessionID(data []byte) string {
-	sc := bufio.NewScanner(bytes.NewReader(data))
-	sc.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
+	// bufio.Reader.ReadBytes avoids the fixed buffer cap of bufio.Scanner,
+	// which would silently stop (bufio.ErrTooLong) on a single line larger
+	// than the cap — tool outputs and system prompts can exceed many MB.
+	r := bufio.NewReader(bytes.NewReader(data))
 	var ev struct {
 		SessionID string `json:"sessionId"`
 	}
-	for sc.Scan() {
-		line := sc.Bytes()
-		if len(line) == 0 {
-			continue
+	for {
+		line, err := r.ReadBytes('\n')
+		if len(line) > 0 {
+			if uerr := json.Unmarshal(line, &ev); uerr == nil && ev.SessionID != "" {
+				return ev.SessionID
+			}
 		}
-		if err := json.Unmarshal(line, &ev); err != nil {
-			continue
-		}
-		if ev.SessionID != "" {
-			return ev.SessionID
+		if err != nil {
+			break
 		}
 	}
 	return ""

--- a/internal/cmd/replay.go
+++ b/internal/cmd/replay.go
@@ -1,0 +1,236 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/patflynn/klaus/internal/draft"
+	"github.com/patflynn/klaus/internal/git"
+	"github.com/patflynn/klaus/internal/run"
+)
+
+// Trajectory replay continues a budget-paused PR's prior Claude conversation
+// instead of dispatching a fresh agent that must re-explore the repo.
+//
+// Mechanism: klaus stores the resume-able conversation JSONL (the file
+// claude itself writes under ~/.claude/projects/<encoded-cwd>/<uuid>.jsonl)
+// on refs/klaus/data at sessions/<run-id>.jsonl. On 'klaus launch --pr'
+// against a paused PR, we fetch that blob and restore it into the *new*
+// worktree's project dir, then invoke 'claude --resume <uuid>'. claude
+// re-anchors to the new cwd; the conversation picks up where it paused.
+//
+// IMPORTANT: this is NOT the stream-json log at logs/<run-id>.jsonl —
+// claude --resume rejects that format ("No conversation found"). The two
+// are different schemas; see findResumeConversation.
+
+// encodeProjectPath converts an absolute working directory into the directory
+// segment Claude Code uses under ~/.claude/projects. Claude replaces both '/'
+// and '.' with '-'. Verified empirically against Claude Code 2.1.x.
+func encodeProjectPath(cwd string) string {
+	return strings.NewReplacer("/", "-", ".", "-").Replace(cwd)
+}
+
+// claudeProjectsDir returns ~/.claude/projects, or "" if the home dir is
+// unknown.
+func claudeProjectsDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".claude", "projects")
+}
+
+// claudeConversationPath returns the path claude --resume reads for a session
+// whose conversation runs in worktree cwd.
+func claudeConversationPath(cwd, sessionUUID string) string {
+	base := claudeProjectsDir()
+	if base == "" {
+		return ""
+	}
+	return filepath.Join(base, encodeProjectPath(cwd), sessionUUID+".jsonl")
+}
+
+// validSessionUUID reports whether s is safe to interpolate into a filepath
+// glob/join (UUID-shaped: alphanumerics and hyphens only).
+func validSessionUUID(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-') {
+			return false
+		}
+	}
+	return true
+}
+
+// findClaudeConversationFile globs every project dir for a session UUID's
+// conversation file, returning the first match or "".
+func findClaudeConversationFile(sessionUUID string) string {
+	if !validSessionUUID(sessionUUID) {
+		return ""
+	}
+	base := claudeProjectsDir()
+	if base == "" {
+		return ""
+	}
+	matches, err := filepath.Glob(filepath.Join(base, "*", sessionUUID+".jsonl"))
+	if err != nil || len(matches) == 0 {
+		return ""
+	}
+	return matches[0]
+}
+
+// findResumeConversation locates the resume-able Claude conversation file for
+// a finalized run. It prefers the run's own worktree project dir, then falls
+// back to globbing all project dirs. Returns "" if the UUID is unknown or no
+// file exists.
+func findResumeConversation(state *run.State) string {
+	uuid := ""
+	if state.ClaudeSessionID != nil {
+		uuid = *state.ClaudeSessionID
+	}
+	if uuid == "" && state.LogFile != nil {
+		uuid = ExtractClaudeSessionID(*state.LogFile)
+	}
+	if !validSessionUUID(uuid) {
+		return ""
+	}
+	if state.Worktree != "" {
+		if p := claudeConversationPath(state.Worktree, uuid); p != "" {
+			if fi, err := os.Stat(p); err == nil && !fi.IsDir() {
+				return p
+			}
+		}
+	}
+	return findClaudeConversationFile(uuid)
+}
+
+// extractConversationSessionID reads the sessionId (camelCase) from a
+// conversation-format JSONL blob. Returns "" if none is found.
+func extractConversationSessionID(data []byte) string {
+	sc := bufio.NewScanner(bytes.NewReader(data))
+	sc.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
+	var ev struct {
+		SessionID string `json:"sessionId"`
+	}
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		if err := json.Unmarshal(line, &ev); err != nil {
+			continue
+		}
+		if ev.SessionID != "" {
+			return ev.SessionID
+		}
+	}
+	return ""
+}
+
+// replayParams carries everything resolveBudgetPausedReplay needs.
+type replayParams struct {
+	GitClient   git.Client
+	Store       run.StateStore
+	RepoRoot    string // repo dir holding refs/klaus/data (clone dir or host repo)
+	DataRef     string
+	Worktree    string // the fresh worktree the resumed agent will run in
+	PRBranch    string
+	PRNumber    string
+	GHRepo      string // owner/repo for gh calls (may be "")
+	ForceReplay bool   // --replay: skip the size threshold and the paused gate
+	ThresholdKB int    // max trajectory size in KB (0 disables the size check)
+}
+
+// replayDecision is the outcome of attempting trajectory replay.
+type replayDecision struct {
+	// SessionUUID is non-empty when the caller should run claude --resume
+	// against it; empty means fall back to the fresh-agent flow.
+	SessionUUID string
+	// SourceRunID is the run whose trajectory was restored (for logging).
+	SourceRunID string
+	// Reason explains the decision (always set, for user-facing logging).
+	Reason string
+}
+
+// resolveBudgetPausedReplay decides whether to continue a budget-paused PR's
+// prior Claude conversation. On success it restores the stored trajectory into
+// the new worktree's project dir and returns the session UUID to resume. On
+// any miss it returns an empty SessionUUID with a Reason, signalling the caller
+// to fall back to the fresh-agent flow.
+func resolveBudgetPausedReplay(ctx context.Context, p replayParams) replayDecision {
+	// Replay only targets budget-paused PRs unless the user forces it.
+	if !p.ForceReplay {
+		paused, err := draft.HasBudgetPausedLabel(ctx, budgetPauseRunner, p.Worktree, p.GHRepo, p.PRNumber)
+		if err != nil {
+			return replayDecision{Reason: fmt.Sprintf("could not check budget-paused label: %v", err)}
+		}
+		if !paused {
+			return replayDecision{Reason: "PR is not budget-paused"}
+		}
+	}
+
+	// Find candidate runs on this branch, newest first (List() is sorted by
+	// CreatedAt descending).
+	states, err := p.Store.List()
+	if err != nil {
+		return replayDecision{Reason: fmt.Sprintf("listing runs: %v", err)}
+	}
+	var candidates []*run.State
+	for _, s := range states {
+		if s.Branch == p.PRBranch {
+			candidates = append(candidates, s)
+		}
+	}
+	if len(candidates) == 0 {
+		return replayDecision{Reason: "no prior run recorded for this branch"}
+	}
+
+	// Best-effort: pull the latest data ref so the trajectory blob is present
+	// even on a fresh machine. Errors are expected (no remote, ref absent).
+	_ = p.GitClient.FetchDataRef(ctx, p.RepoRoot, p.DataRef)
+
+	// Use the most recent candidate that actually has a stored trajectory.
+	for _, s := range candidates {
+		treePath := "sessions/" + s.ID + ".jsonl"
+		blob, err := p.GitClient.ReadDataRefFile(ctx, p.RepoRoot, p.DataRef, treePath)
+		if err != nil {
+			// Sensitive-skipped, never pushed, or pre-dates this feature.
+			continue
+		}
+
+		if !p.ForceReplay && p.ThresholdKB > 0 && len(blob) > p.ThresholdKB*1024 {
+			return replayDecision{Reason: fmt.Sprintf("trajectory for %s is %dKB, over the %dKB threshold (use --replay to force)", s.ID, len(blob)/1024, p.ThresholdKB)}
+		}
+
+		uuid := extractConversationSessionID(blob)
+		if !validSessionUUID(uuid) {
+			return replayDecision{Reason: fmt.Sprintf("stored trajectory for %s has no usable session UUID", s.ID)}
+		}
+
+		dest := claudeConversationPath(p.Worktree, uuid)
+		if dest == "" {
+			return replayDecision{Reason: "could not resolve Claude projects dir"}
+		}
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return replayDecision{Reason: fmt.Sprintf("creating project dir: %v", err)}
+		}
+		if err := os.WriteFile(dest, blob, 0o600); err != nil {
+			return replayDecision{Reason: fmt.Sprintf("restoring trajectory: %v", err)}
+		}
+		return replayDecision{
+			SessionUUID: uuid,
+			SourceRunID: s.ID,
+			Reason:      fmt.Sprintf("resuming conversation from run %s (%dKB)", s.ID, len(blob)/1024),
+		}
+	}
+
+	return replayDecision{Reason: "no stored trajectory found on the data ref (sensitive-skipped or pre-dates replay)"}
+}

--- a/internal/cmd/replay_test.go
+++ b/internal/cmd/replay_test.go
@@ -69,6 +69,7 @@ func storeTrajectoryOnDataRef(t *testing.T, repo, dataRef, runID, content string
 func TestReplayRoundTripEndToEnd(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // os.UserHomeDir checks USERPROFILE first on Windows
 
 	repo := initReplayTestRepo(t)
 	const dataRef = "refs/klaus/data"
@@ -146,6 +147,7 @@ func TestReplayRoundTripEndToEnd(t *testing.T) {
 func TestReplayFallbacks(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // os.UserHomeDir checks USERPROFILE first on Windows
 	repo := initReplayTestRepo(t)
 	const dataRef = "refs/klaus/data"
 	const branch = "feature-x"

--- a/internal/cmd/replay_test.go
+++ b/internal/cmd/replay_test.go
@@ -1,0 +1,282 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/patflynn/klaus/internal/draft"
+	"github.com/patflynn/klaus/internal/git"
+	"github.com/patflynn/klaus/internal/run"
+)
+
+// initReplayTestRepo creates a real git repo with an initial commit.
+func initReplayTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	steps := [][]string{
+		{"git", "init", "--initial-branch=main", dir},
+		{"git", "-C", dir, "config", "user.email", "test@test.com"},
+		{"git", "-C", dir, "config", "user.name", "Test"},
+	}
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	steps = append(steps,
+		[]string{"git", "-C", dir, "add", "README.md"},
+		[]string{"git", "-C", dir, "commit", "-m", "initial"},
+	)
+	for _, args := range steps {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("setup %v: %v\n%s", args, err, out)
+		}
+	}
+	return dir
+}
+
+// makeConversationJSONL builds a small conversation-format trajectory (the
+// schema claude --resume reads) carrying the given sessionId and cwd.
+func makeConversationJSONL(sessionID, cwd string) string {
+	lines := []string{
+		fmt.Sprintf(`{"type":"user","cwd":%q,"sessionId":%q,"version":"2.1.158","gitBranch":"feature-x","uuid":"11111111-1111-1111-1111-111111111111","parentUuid":null,"isSidechain":false,"message":{"role":"user","content":"do the thing"}}`, cwd, sessionID),
+		fmt.Sprintf(`{"type":"assistant","cwd":%q,"sessionId":%q,"version":"2.1.158","uuid":"22222222-2222-2222-2222-222222222222","parentUuid":"11111111-1111-1111-1111-111111111111","message":{"role":"assistant","content":[{"type":"text","text":"working on it"}]}}`, cwd, sessionID),
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+// storeTrajectoryOnDataRef writes a conversation trajectory onto refs/klaus/data
+// at sessions/<runID>.jsonl using the real data-ref machinery.
+func storeTrajectoryOnDataRef(t *testing.T, repo, dataRef, runID, content string) {
+	t.Helper()
+	tmp := filepath.Join(t.TempDir(), "traj.jsonl")
+	if err := os.WriteFile(tmp, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	files := map[string]string{"sessions/" + runID + ".jsonl": tmp}
+	if err := git.SyncToDataRef(context.Background(), repo, dataRef, "Run "+runID, files); err != nil {
+		t.Fatalf("SyncToDataRef: %v", err)
+	}
+}
+
+// TestReplayRoundTripEndToEnd exercises the full replay path against a REAL
+// refs/klaus/data blob: store a conversation trajectory, then resolve a
+// budget-paused replay and assert klaus restores the JSONL into the new
+// worktree's project dir and that the downstream claude command resumes it.
+func TestReplayRoundTripEndToEnd(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repo := initReplayTestRepo(t)
+	const dataRef = "refs/klaus/data"
+	const runID = "20260601-1000-aaaa"
+	const branch = "feature-x"
+	const sessionID = "6623bdcf-1dce-4da0-86b3-a46743d208e8"
+
+	// New worktree the resumed agent will run in. The trajectory's original
+	// cwd is intentionally different to mimic the cross-worktree handoff.
+	worktree := filepath.Join(home, "worktrees", runID+"-resume")
+	origCwd := filepath.Join(home, "worktrees", runID)
+	traj := makeConversationJSONL(sessionID, origCwd)
+	storeTrajectoryOnDataRef(t, repo, dataRef, runID, traj)
+
+	// Record the paused run in the store, keyed to the PR branch.
+	baseDir := filepath.Join(home, ".klaus", "sessions", "session-test")
+	store := run.NewHomeDirStoreFromPath(baseDir)
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+	sid := sessionID
+	if err := store.Save(&run.State{
+		ID:              runID,
+		Branch:          branch,
+		Prompt:          "do the thing",
+		CreatedAt:       "2026-06-01T10:00:00Z",
+		ClaudeSessionID: &sid,
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	decision := resolveBudgetPausedReplay(context.Background(), replayParams{
+		GitClient:   git.NewExecClient(),
+		Store:       store,
+		RepoRoot:    repo,
+		DataRef:     dataRef,
+		Worktree:    worktree,
+		PRBranch:    branch,
+		PRNumber:    "42",
+		ForceReplay: true, // skip the gh paused-label check in this unit
+		ThresholdKB: 300,
+	})
+
+	if decision.SessionUUID != sessionID {
+		t.Fatalf("SessionUUID = %q, want %q (reason: %s)", decision.SessionUUID, sessionID, decision.Reason)
+	}
+	if decision.SourceRunID != runID {
+		t.Errorf("SourceRunID = %q, want %q", decision.SourceRunID, runID)
+	}
+
+	// The trajectory must be restored into the NEW worktree's project dir,
+	// byte-for-byte, under <sessionID>.jsonl — exactly where claude --resume
+	// looks when invoked from that worktree.
+	dest := claudeConversationPath(worktree, sessionID)
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("restored trajectory not found at %s: %v", dest, err)
+	}
+	if string(got) != traj {
+		t.Errorf("restored trajectory mismatch:\n got %q\nwant %q", got, traj)
+	}
+
+	// The downstream claude command resumes the restored session.
+	cmd := buildClaudeCommand("sys", "5", "continue", "20260601-1100-bbbb", decision.SessionUUID)
+	if !strings.Contains(cmd, "--resume '"+sessionID+"'") {
+		t.Errorf("claude command missing --resume %s: %s", sessionID, cmd)
+	}
+	if !strings.Contains(cmd, "--fork-session") {
+		t.Errorf("claude command missing --fork-session: %s", cmd)
+	}
+}
+
+// TestReplayFallbacks covers the miss paths that must drop back to a fresh
+// agent (empty SessionUUID with an explanatory reason).
+func TestReplayFallbacks(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	repo := initReplayTestRepo(t)
+	const dataRef = "refs/klaus/data"
+	const branch = "feature-x"
+	worktree := filepath.Join(home, "wt")
+
+	newStore := func() run.StateStore {
+		baseDir := filepath.Join(t.TempDir(), "session")
+		s := run.NewHomeDirStoreFromPath(baseDir)
+		if err := s.EnsureDirs(); err != nil {
+			t.Fatalf("EnsureDirs: %v", err)
+		}
+		return s
+	}
+
+	t.Run("no prior run for branch", func(t *testing.T) {
+		d := resolveBudgetPausedReplay(context.Background(), replayParams{
+			GitClient: git.NewExecClient(), Store: newStore(), RepoRoot: repo,
+			DataRef: dataRef, Worktree: worktree, PRBranch: branch, PRNumber: "1",
+			ForceReplay: true, ThresholdKB: 300,
+		})
+		if d.SessionUUID != "" {
+			t.Errorf("expected fresh fallback, got resume %q", d.SessionUUID)
+		}
+	})
+
+	t.Run("trajectory missing from data ref", func(t *testing.T) {
+		store := newStore()
+		_ = store.Save(&run.State{ID: "20260601-1000-cccc", Branch: branch, CreatedAt: "2026-06-01T10:00:00Z"})
+		d := resolveBudgetPausedReplay(context.Background(), replayParams{
+			GitClient: git.NewExecClient(), Store: store, RepoRoot: repo,
+			DataRef: dataRef, Worktree: worktree, PRBranch: branch, PRNumber: "1",
+			ForceReplay: true, ThresholdKB: 300,
+		})
+		if d.SessionUUID != "" {
+			t.Errorf("expected fresh fallback when blob absent, got %q (%s)", d.SessionUUID, d.Reason)
+		}
+	})
+
+	t.Run("oversized trajectory falls back unless forced", func(t *testing.T) {
+		const runID = "20260601-1000-dddd"
+		const sessionID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+		store := newStore()
+		_ = store.Save(&run.State{ID: runID, Branch: branch, CreatedAt: "2026-06-01T10:00:00Z"})
+
+		// Build a trajectory larger than a 1KB threshold.
+		big := makeConversationJSONL(sessionID, filepath.Join(home, "orig")) + strings.Repeat("x", 4096) + "\n"
+		storeTrajectoryOnDataRef(t, repo, dataRef, runID, big)
+
+		// Paused PR confirmed via a fake runner so the gate passes; threshold
+		// then forces the fallback because --replay is not set.
+		orig := budgetPauseRunner
+		budgetPauseRunner = fakeLabelRunner{labels: "klaus:budget-paused\n"}
+		defer func() { budgetPauseRunner = orig }()
+
+		d := resolveBudgetPausedReplay(context.Background(), replayParams{
+			GitClient: git.NewExecClient(), Store: store, RepoRoot: repo,
+			DataRef: dataRef, Worktree: worktree, PRBranch: branch, PRNumber: "1",
+			ForceReplay: false, ThresholdKB: 1,
+		})
+		if d.SessionUUID != "" {
+			t.Errorf("expected fresh fallback for oversized trajectory, got %q", d.SessionUUID)
+		}
+		if !strings.Contains(d.Reason, "threshold") {
+			t.Errorf("reason should mention threshold, got %q", d.Reason)
+		}
+
+		// --replay (ForceReplay) bypasses the size threshold.
+		d2 := resolveBudgetPausedReplay(context.Background(), replayParams{
+			GitClient: git.NewExecClient(), Store: store, RepoRoot: repo,
+			DataRef: dataRef, Worktree: worktree, PRBranch: branch, PRNumber: "1",
+			ForceReplay: true, ThresholdKB: 1,
+		})
+		if d2.SessionUUID != sessionID {
+			t.Errorf("--replay should bypass threshold and resume, got %q (%s)", d2.SessionUUID, d2.Reason)
+		}
+	})
+
+	t.Run("not paused falls back without forcing", func(t *testing.T) {
+		const runID = "20260601-1000-eeee"
+		const sessionID = "ffffffff-0000-1111-2222-333333333333"
+		store := newStore()
+		_ = store.Save(&run.State{ID: runID, Branch: branch, CreatedAt: "2026-06-01T10:00:00Z"})
+		storeTrajectoryOnDataRef(t, repo, dataRef, runID, makeConversationJSONL(sessionID, home))
+
+		orig := budgetPauseRunner
+		budgetPauseRunner = fakeLabelRunner{labels: "some-other-label\n"} // not paused
+		defer func() { budgetPauseRunner = orig }()
+
+		d := resolveBudgetPausedReplay(context.Background(), replayParams{
+			GitClient: git.NewExecClient(), Store: store, RepoRoot: repo,
+			DataRef: dataRef, Worktree: worktree, PRBranch: branch, PRNumber: "1",
+			ForceReplay: false, ThresholdKB: 300,
+		})
+		if d.SessionUUID != "" {
+			t.Errorf("expected fresh fallback when PR not paused, got %q", d.SessionUUID)
+		}
+	})
+}
+
+func TestEncodeProjectPath(t *testing.T) {
+	// Claude replaces both '/' and '.' with '-'.
+	got := encodeProjectPath("/tmp/klaus-sessions/k/2026.06")
+	want := "-tmp-klaus-sessions-k-2026-06"
+	if got != want {
+		t.Errorf("encodeProjectPath = %q, want %q", got, want)
+	}
+}
+
+func TestExtractConversationSessionID(t *testing.T) {
+	blob := makeConversationJSONL("9a9a9a9a-0000-0000-0000-000000000000", "/x")
+	if got := extractConversationSessionID([]byte(blob)); got != "9a9a9a9a-0000-0000-0000-000000000000" {
+		t.Errorf("extractConversationSessionID = %q", got)
+	}
+	if got := extractConversationSessionID([]byte("not json\n{}\n")); got != "" {
+		t.Errorf("expected empty for blob without sessionId, got %q", got)
+	}
+}
+
+// fakeLabelRunner is a draft.Runner that returns canned gh output for the
+// label lookup and is a no-op for git.
+type fakeLabelRunner struct {
+	labels string
+	err    error
+}
+
+func (f fakeLabelRunner) Git(ctx context.Context, workdir string, args ...string) (string, error) {
+	return "", nil
+}
+
+func (f fakeLabelRunner) GH(ctx context.Context, workdir string, args ...string) (string, error) {
+	return f.labels, f.err
+}
+
+var _ draft.Runner = fakeLabelRunner{}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,11 @@ type Config struct {
 	SandboxHost         string           `json:"sandbox_host,omitempty"`
 	PRReviewer          string           `json:"pr_reviewer,omitempty"`
 	Webhook             *WebhookConfig   `json:"webhook,omitempty"`
+	// ReplayThresholdKB caps the stored Claude trajectory size (in KB) that
+	// 'klaus launch --pr' will restore for claude --resume when continuing a
+	// budget-paused PR. Trajectories above this fall back to a fresh agent
+	// unless --replay is passed. Default 300.
+	ReplayThresholdKB int `json:"replay_threshold_kb,omitempty"`
 }
 
 // WebhookConfig configures the GitHub webhook receiver. When present, the
@@ -40,11 +45,11 @@ type WebhookConfig struct {
 
 // PreReviewConfig configures the pre-PR review checks.
 type PreReviewConfig struct {
-	Enabled      *bool    `json:"enabled,omitempty"`         // default: true
-	Linters      []string `json:"linters,omitempty"`         // default: auto-detect from project
-	ReviewModel  string   `json:"review_model,omitempty"`    // default: "haiku"
-	MaxFixRounds int      `json:"max_fix_rounds,omitempty"`  // default: 2
-	BlockOn      string   `json:"block_on,omitempty"`        // default: "high" (block PR on high+ findings)
+	Enabled      *bool    `json:"enabled,omitempty"`        // default: true
+	Linters      []string `json:"linters,omitempty"`        // default: auto-detect from project
+	ReviewModel  string   `json:"review_model,omitempty"`   // default: "haiku"
+	MaxFixRounds int      `json:"max_fix_rounds,omitempty"` // default: 2
+	BlockOn      string   `json:"block_on,omitempty"`       // default: "high" (block PR on high+ findings)
 }
 
 // RequiresApproval returns true if approval is required before merging.
@@ -131,11 +136,12 @@ func (c *Config) PRReviewerOrDefault() string {
 // Defaults returns a Config with default values.
 func Defaults() Config {
 	return Config{
-		WorktreeBase:     filepath.Join(os.TempDir(), "klaus-sessions"),
-		DefaultBudget:    "5.00",
-		DataRef:          "refs/klaus/data",
-		DefaultBranch:    "main",
-		TrustedReviewers: []string{"gemini-code-assist[bot]"},
+		WorktreeBase:      filepath.Join(os.TempDir(), "klaus-sessions"),
+		DefaultBudget:     "5.00",
+		DataRef:           "refs/klaus/data",
+		DefaultBranch:     "main",
+		TrustedReviewers:  []string{"gemini-code-assist[bot]"},
+		ReplayThresholdKB: 300,
 	}
 }
 
@@ -541,7 +547,6 @@ func sortStrings(s []string) {
 		}
 	}
 }
-
 
 // WriteClaudeSettings writes a .claude/settings.json into the given worktree
 // directory with a statusLine that displays the repo name and current branch.

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -64,6 +64,13 @@ type Client interface {
 	// PushDataRef pushes the data ref to origin.
 	PushDataRef(ctx context.Context, repoDir, dataRef string) error
 
+	// FetchDataRef updates the local data ref from origin. Best-effort: the
+	// returned error can be ignored when there is no remote or no such ref.
+	FetchDataRef(ctx context.Context, repoDir, dataRef string) error
+
+	// ReadDataRefFile returns the raw bytes of a file stored in the data ref tree.
+	ReadDataRefFile(ctx context.Context, repoDir, dataRef, treePath string) ([]byte, error)
+
 	// InstallCommitMsgHook installs a commit-msg hook in the given worktree that
 	// strips Claude/Anthropic attribution from commit messages.
 	InstallCommitMsgHook(ctx context.Context, worktreeDir string) error

--- a/internal/git/exec_client.go
+++ b/internal/git/exec_client.go
@@ -78,6 +78,14 @@ func (c *ExecClient) PushDataRef(ctx context.Context, repoDir, dataRef string) e
 	return PushDataRef(ctx, repoDir, dataRef)
 }
 
+func (c *ExecClient) FetchDataRef(ctx context.Context, repoDir, dataRef string) error {
+	return FetchDataRef(ctx, repoDir, dataRef)
+}
+
+func (c *ExecClient) ReadDataRefFile(ctx context.Context, repoDir, dataRef, treePath string) ([]byte, error) {
+	return ReadDataRefFile(ctx, repoDir, dataRef, treePath)
+}
+
 func (c *ExecClient) InstallCommitMsgHook(ctx context.Context, worktreeDir string) error {
 	return InstallCommitMsgHook(ctx, worktreeDir)
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -53,6 +53,39 @@ func FetchBranch(ctx context.Context, repoDir, branch string) error {
 	return err
 }
 
+// FetchDataRef updates the local data ref from origin. It is best-effort:
+// callers should ignore the error (there may be no remote, the ref may not
+// exist remotely, or the local ref may already be current). When the local
+// ref is missing and the remote has it, the ref is created locally.
+func FetchDataRef(ctx context.Context, repoDir, dataRef string) error {
+	_, err := runGitNetwork(ctx, repoDir, "fetch", "origin", dataRef+":"+dataRef, "--quiet")
+	return err
+}
+
+// ReadDataRefFile returns the raw bytes of a file stored in the data ref tree.
+// treePath is the path within the ref's tree (e.g. "sessions/<run-id>.jsonl").
+// It returns an error if the ref or path does not exist. Output is not trimmed,
+// so JSONL content (including trailing newlines) is preserved verbatim.
+func ReadDataRefFile(ctx context.Context, repoDir, dataRef, treePath string) ([]byte, error) {
+	ctx, cancel := ensureTimeout(ctx, localTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "cat-file", "blob", dataRef+":"+treePath)
+	if repoDir != "" {
+		cmd.Dir = repoDir
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("git cat-file timed out after %s", localTimeout)
+		}
+		return nil, fmt.Errorf("reading %s from %s: %w: %s", treePath, dataRef, err, stderr.String())
+	}
+	return stdout.Bytes(), nil
+}
+
 // WorktreeAdd creates a new worktree at path on a new branch based on startPoint.
 // If the branch is already checked out in a stale worktree, it prunes and retries once.
 func WorktreeAdd(ctx context.Context, repoDir, path, branch, startPoint string) error {


### PR DESCRIPTION
## Summary

`klaus launch --pr <num>` against a budget-paused PR now **continues the previous agent's Claude conversation** via `claude --resume` instead of dispatching a fresh agent that must re-explore the repo. This saves tokens and preserves the prior reasoning.

## STEP 0 — gating investigation (the design hinge)

The issue assumed the JSONL already on `refs/klaus/data` (`logs/<run-id>.jsonl`) is the resume-able trajectory. **It is not.** Empirically verified against Claude Code 2.1.158:

- `claude --resume <uuid>` reads `~/.claude/projects/<encoded-cwd>/<uuid>.jsonl`, where the dir encodes the cwd with **both `/` and `.` replaced by `-`**. Restoring a **conversation-format** JSONL there — even one captured in a *different* original cwd — successfully resumes; claude re-anchors to the new cwd. (Confirmed by resuming a conversation whose only record of a secret value lived in the restored file, after deleting the original project dir.)
- klaus's stored `logs/<run-id>.jsonl` is the tee'd **stream-json stdout** — a different schema (snake_case `session_id`, `system`/`result` event types, no `parentUuid`/`cwd`/`gitBranch`). `claude --resume` rejects it: *"No conversation found with session ID."*

**Conclusion:** native `--resume` replay IS viable, but only against the real conversation file — not the stream-json log. Rather than reverse-engineer a fragile stream-json→conversation conversion, this PR captures and stores the *actual* conversation file (which claude already writes, even in `-p` mode) and restores it verbatim. This is the robust path and degrades gracefully to fresh-agent for anything it can't serve.

## Design decision (documented per issue guidance)

Because the premise changed, the storage side is new: at finalize, `syncRunToDataRef` now also stores the resume-able conversation file at `sessions/<run-id>.jsonl` on `refs/klaus/data` (subject to the same `scan.CheckSensitivity` gate as the log). Replay restores **that** blob. Trajectories produced before this change (or sensitive-skipped) simply aren't present, so those PRs fall back to a fresh agent — exactly the intended fallback behavior.

## Changes

- `finalizeFromLog`: record the Claude session UUID into `state.ClaudeSessionID`.
- `syncRunToDataRef`: capture + store the conversation trajectory (`findResumeConversation`), with a sensitivity check.
- `internal/git`: `FetchDataRef` (best-effort) + `ReadDataRefFile` (raw `git cat-file blob`) to read blobs off the data ref; added to the `Client` interface.
- `internal/cmd/replay.go`: `resolveBudgetPausedReplay` orchestrates lookup → fetch → size-threshold → restore, plus path-encoding helpers.
- `launch.go`: replay wired into the `--pr` path; flags `--replay`, `--no-replay`, `--replay-threshold-kb`; config `replay_threshold_kb` (default 300).
- README: replay flags + staleness semantics (cwd mismatch, tool-result staleness, no prompt-cache benefit, sandbox limitation).

## Acceptance criteria

- [x] `--pr` against a budget-paused PR attempts replay by default
- [x] Fallback to fresh when trajectory missing / oversized / sensitive-skipped / UUID absent (and for sandbox-destined runs)
- [x] `--no-replay` forces fresh; `--replay` forces replay (bypasses size threshold)
- [x] Worktree handoff: new worktree off PR branch head; `claude --resume` invoked there with the restored JSONL
- [x] Integration test covers the replay path end-to-end against a **real** `refs/klaus/data` blob (`internal/cmd/replay_test.go`) — exercises the real data-ref machinery; asserts klaus restores the JSONL into the new worktree's project dir byte-for-byte and builds the correct `claude --resume … --fork-session` command
- [x] Docs explain staleness semantics

## Testing

- `go build ./...` clean; `go vet` clean on touched packages.
- New tests pass: `TestReplayRoundTripEndToEnd`, `TestReplayFallbacks` (no-run / missing-blob / oversized±force / not-paused), `TestEncodeProjectPath`, `TestExtractConversationSessionID`.
- `klaus _pre-review`: all checks passed (no critical/high findings).
- Full suite green **except** a pre-existing, environment-specific failure: `internal/config TestLoadNoFile` asserts `WorktreeBase` against `os.TempDir()` but the test does not isolate `HOME`, so it reads this machine's real `~/.klaus/config.json` (`worktree_base`). Fails identically on a clean checkout of `main` in this environment; unrelated to this change.

## Notes / limitations

- Sandbox (`sandbox_host`) runs: the conversation file lives on the sandbox and isn't synced back, so those runs neither store a trajectory nor replay one — they fall back to fresh (guarded explicitly in `launch.go`).
- The Claude projects path encoding (`/` and `.` → `-`) is an undocumented internal detail; verified against 2.1.158 and noted in code comments.

Run: 20260606-0733-6af729c6
Fixes #261