### PR TITLE
Fix 404 in review-fix prompt by using {owner}/{repo} placeholder

### DIFF
--- a/internal/cmd/dashboard_commands.go
+++ b/internal/cmd/dashboard_commands.go
@@ -190,7 +190,7 @@ func fetchPRStatus(client gh.Client, prNumber, prRef string) *prStatus {
 	// trusted reviewer comments that GitHub doesn't reflect in reviewDecision.
 	if !strings.EqualFold(ps.ReviewDecision, "CHANGES_REQUESTED") &&
 		!strings.EqualFold(ps.ReviewDecision, "APPROVED") {
-		ownerRepo := ownerRepoFromPRURL(prRef)
+		ownerRepo := gh.OwnerRepoFromPRURL(prRef)
 		if ownerRepo != "" {
 			ps.HasNewTrustedComments = hasUnaddressedTrustedComments(ownerRepo, prNumber)
 		}

--- a/internal/cmd/dashboard_pipeline.go
+++ b/internal/cmd/dashboard_pipeline.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"log/slog"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/patflynn/klaus/internal/git"
+	"github.com/patflynn/klaus/internal/github"
 	"github.com/patflynn/klaus/internal/project"
 	"github.com/patflynn/klaus/internal/run"
 )
@@ -94,14 +94,12 @@ func repoFromState(s *run.State, reg *project.Registry) string {
 	return "(local)"
 }
 
-// repoFromPRURL extracts "owner/repo" from a GitHub PR URL.
+// repoFromPRURL extracts "owner/repo" from a GitHub PR URL, returning the
+// "(unknown)" sentinel when the URL can't be parsed. The parsing itself lives
+// in github.OwnerRepoFromPRURL so there's a single source of truth.
 func repoFromPRURL(prURL string) string {
-	// https://github.com/owner/repo/pull/123
-	prURL = strings.TrimPrefix(prURL, "https://github.com/")
-	prURL = strings.TrimPrefix(prURL, "http://github.com/")
-	parts := strings.Split(prURL, "/")
-	if len(parts) >= 2 {
-		return parts[0] + "/" + parts[1]
+	if slug := github.OwnerRepoFromPRURL(prURL); slug != "" {
+		return slug
 	}
 	return "(unknown)"
 }

--- a/internal/cmd/review_check.go
+++ b/internal/cmd/review_check.go
@@ -10,17 +10,6 @@ import (
 	"github.com/patflynn/klaus/internal/github"
 )
 
-// ownerRepoFromPRURL extracts "owner/repo" from a full GitHub PR URL.
-func ownerRepoFromPRURL(prURL string) string {
-	prURL = strings.TrimPrefix(prURL, "https://github.com/")
-	prURL = strings.TrimPrefix(prURL, "http://github.com/")
-	parts := strings.Split(prURL, "/")
-	if len(parts) >= 2 {
-		return parts[0] + "/" + parts[1]
-	}
-	return ""
-}
-
 // ghReview represents a single review from the GitHub API.
 type ghReview struct {
 	User        ghUser `json:"user"`

--- a/internal/github/prurl.go
+++ b/internal/github/prurl.go
@@ -1,0 +1,21 @@
+package github
+
+import "strings"
+
+// OwnerRepoFromPRURL extracts the "owner/repo" slug from a full GitHub PR URL
+// such as "https://github.com/owner/repo/pull/123". It tolerates a trailing
+// slash and returns "" when the URL does not contain a non-empty owner and
+// repo segment (e.g. a bare short name like "klaus" or a malformed URL).
+//
+// This is the single source of truth for PR-URL slug parsing; callers in
+// internal/cmd and internal/pipeline both delegate here rather than reimplementing
+// the split.
+func OwnerRepoFromPRURL(prURL string) string {
+	s := strings.TrimPrefix(prURL, "https://github.com/")
+	s = strings.TrimPrefix(s, "http://github.com/")
+	parts := strings.Split(s, "/")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return ""
+	}
+	return parts[0] + "/" + parts[1]
+}

--- a/internal/github/prurl_test.go
+++ b/internal/github/prurl_test.go
@@ -1,0 +1,28 @@
+package github
+
+import "testing"
+
+func TestOwnerRepoFromPRURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"standard PR URL", "https://github.com/patflynn/klaus/pull/270", "patflynn/klaus"},
+		{"http scheme", "http://github.com/owner/repo/pull/1", "owner/repo"},
+		{"trailing slash after repo", "https://github.com/owner/repo/", "owner/repo"},
+		{"owner/repo only", "https://github.com/owner/repo", "owner/repo"},
+		{"bare short name returns empty", "klaus", ""},
+		{"malformed URL returns empty", "not-a-url", ""},
+		{"owner only returns empty", "https://github.com/owner", ""},
+		{"empty string returns empty", "", ""},
+		{"empty repo segment returns empty", "https://github.com/owner//pull/1", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := OwnerRepoFromPRURL(tt.url); got != tt.want {
+				t.Errorf("OwnerRepoFromPRURL(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -40,7 +40,7 @@ type PRStatus struct {
 	CI                    string // passing, failing, pending, unknown
 	Conflicts             string // yes, none, unknown
 	ReviewDecision        string // APPROVED, CHANGES_REQUESTED, etc.
-	TargetRepo            string // owner/repo for dispatch context
+	TargetRepo            string // canonical project short name (e.g. "klaus") for registered projects, else an owner/repo slug; NOT guaranteed to be a GitHub owner/repo slug — do not use in gh api paths
 	HasNewTrustedComments bool   // unaddressed comments from trusted reviewers
 	Labels                []string // GitHub label names; klaus uses "klaus:budget-paused" as a pause signal
 }

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -1327,6 +1327,111 @@ func TestReviewThreadsResolvedAfterAgentCompletion(t *testing.T) {
 	}
 }
 
+// TestSnapshotThreadsUsesOwnerRepoSlugFromPRURL guards against issue where
+// ActionSnapshotThreads was given PRStatus.TargetRepo, which is a canonical
+// project short name (e.g. "klaus") for registered projects, not an owner/repo
+// slug. defaultSnapshotThreads splits the value on "/" and would fail, silently
+// breaking thread resolution. The descriptor must instead carry the owner/repo
+// slug extracted from PRURL.
+func TestSnapshotThreadsUsesOwnerRepoSlugFromPRURL(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		reviewDecision string
+		trusted        bool
+	}{
+		{"changes-requested", "CHANGES_REQUESTED", false},
+		{"trusted-comments", "", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _ := newTestController(t)
+
+			var gotRepo string
+			c.SetSnapshotThreads(func(repo, prNumber string) ([]string, error) {
+				gotRepo = repo
+				return nil, nil
+			})
+			c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
+				return "agent-fix", nil
+			})
+
+			statuses := map[string]*PRStatus{
+				"42": {
+					PRNumber:              "42",
+					State:                 "OPEN",
+					CI:                    "passing",
+					ReviewDecision:        tc.reviewDecision,
+					HasNewTrustedComments: tc.trusted,
+					// TargetRepo is a project short name, NOT an owner/repo slug.
+					TargetRepo: "klaus",
+					PRURL:      "https://github.com/patflynn/klaus/pull/42",
+				},
+			}
+			c.HandleGHStatus(context.Background(), statuses, nil)
+
+			if gotRepo != "patflynn/klaus" {
+				t.Errorf("snapshotThreads got repo %q, want owner/repo slug from PRURL %q", gotRepo, "patflynn/klaus")
+			}
+			if strings.Count(gotRepo, "/") != 1 {
+				t.Errorf("snapshot repo %q is not a valid owner/repo slug (need exactly one '/')", gotRepo)
+			}
+		})
+	}
+}
+
+// TestDispatchRepoDerivesSlugFromPRURL covers the slug-extraction helper used to
+// attach a real owner/repo to descriptors whose handlers treat Repo as a GitHub
+// slug. status.TargetRepo may be a bare project short name (e.g. "klaus"), so the
+// slug must come from the PR URL, falling back to TargetRepo only when the URL is
+// unparseable. The parsing itself lives in github.OwnerRepoFromPRURL (the single
+// source of truth, unit-tested in internal/github).
+func TestDispatchRepoDerivesSlugFromPRURL(t *testing.T) {
+	c, _ := newTestController(t)
+	for _, tt := range []struct {
+		name   string
+		status *PRStatus
+		want   string
+	}{
+		{"valid URL overrides bare short name", &PRStatus{PRURL: "https://github.com/patflynn/klaus/pull/270", TargetRepo: "klaus"}, "patflynn/klaus"},
+		{"trailing slash", &PRStatus{PRURL: "https://github.com/patflynn/klaus/", TargetRepo: "klaus"}, "patflynn/klaus"},
+		{"malformed URL falls back to TargetRepo", &PRStatus{PRURL: "not-a-url", TargetRepo: "owner/repo"}, "owner/repo"},
+		{"empty URL falls back to TargetRepo", &PRStatus{PRURL: "", TargetRepo: "owner/repo"}, "owner/repo"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dispatchRepo(c, tt.status); got != tt.want {
+				t.Errorf("dispatchRepo() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMergeDescriptorUsesOwnerRepoSlug locks the audit fix: the ActionMergePR
+// descriptor must carry the owner/repo slug derived from the PR URL, not the bare
+// project short name in TargetRepo.
+func TestMergeDescriptorUsesOwnerRepoSlug(t *testing.T) {
+	c, _ := newTestController(t)
+	c.SetAutoMergeOnApproval(true)
+
+	var mergeRepo string
+	c.SetMergePRs(func(ctx context.Context, repo string, prNumbers []string) error {
+		mergeRepo = repo
+		return nil
+	})
+
+	statuses := map[string]*PRStatus{
+		"270": {
+			PRNumber: "270", State: "OPEN", CI: "passing",
+			ReviewDecision: "APPROVED", Conflicts: "none", TargetRepo: "klaus",
+			PRURL: "https://github.com/patflynn/klaus/pull/270",
+		},
+	}
+
+	c.HandleGHStatus(context.Background(), statuses, nil)
+
+	if mergeRepo != "patflynn/klaus" {
+		t.Errorf("merge repo = %q, want patflynn/klaus", mergeRepo)
+	}
+}
+
 func TestReviewThreadResolutionFailureDoesNotBlock(t *testing.T) {
 	c, _ := newTestController(t)
 	c.SetAutoMergeOnApproval(true)

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -260,9 +260,15 @@ func TestReviewFixPromptsInstructAgentToReplyToComments(t *testing.T) {
 			if !strings.Contains(launchedPrompt, tc.wantLeadIn) {
 				t.Errorf("prompt missing lead-in %q: %q", tc.wantLeadIn, launchedPrompt)
 			}
-			// Must instruct fetching the comments.
-			if !strings.Contains(launchedPrompt, "gh api repos/owner/repo/pulls/42/comments") {
-				t.Errorf("prompt missing fetch instruction: %q", launchedPrompt)
+			// Must instruct fetching the comments using the literal
+			// {owner}/{repo} placeholder, which gh expands from the worktree's
+			// git remote. It must NOT substitute TargetRepo, which is a project
+			// short name and would yield a 404 path (issue #269).
+			if !strings.Contains(launchedPrompt, "gh api repos/{owner}/{repo}/pulls/42/comments") {
+				t.Errorf("prompt missing placeholder fetch instruction: %q", launchedPrompt)
+			}
+			if strings.Contains(launchedPrompt, "repos/"+tc.status.TargetRepo+"/pulls") {
+				t.Errorf("prompt substitutes TargetRepo into API path (404 risk): %q", launchedPrompt)
 			}
 			// Must instruct replying to each comment.
 			if !strings.Contains(launchedPrompt, "reply to EACH") {

--- a/internal/pipeline/transitions.go
+++ b/internal/pipeline/transitions.go
@@ -337,7 +337,7 @@ var transitions = []transition{
 
 			prompt := reviewFixPrompt(
 				fmt.Sprintf("PR #%s in %s has changes requested by reviewers.", ps.PRNumber, status.TargetRepo),
-				status.TargetRepo, ps.PRNumber,
+				ps.PRNumber,
 			)
 			ps.pendingLaunchDetail = fmt.Sprintf("Review fix agent for PR #%s", ps.PRNumber)
 			ps.Stage = StageReviewPending
@@ -389,7 +389,7 @@ var transitions = []transition{
 
 			prompt := reviewFixPrompt(
 				fmt.Sprintf("PR #%s in %s has review comments from a trusted reviewer that need to be addressed.", ps.PRNumber, status.TargetRepo),
-				status.TargetRepo, ps.PRNumber,
+				ps.PRNumber,
 			)
 			ps.pendingLaunchDetail = fmt.Sprintf("Review fix agent for PR #%s (trusted reviewer)", ps.PRNumber)
 			ps.Stage = StageReviewPending
@@ -649,16 +649,22 @@ func emitCIPassedIfNeeded(c *Controller, ps *PRPipelineState, status *PRStatus) 
 // The "(that you haven't already replied to)" qualifier matters because a fix
 // agent may be re-dispatched (e.g. after CI fails on its first push). Without
 // it the agent may post duplicate replies on threads it already answered.
-func reviewFixPrompt(leadIn, repo, prNumber string) string {
+func reviewFixPrompt(leadIn, prNumber string) string {
+	// The API paths use the literal {owner}/{repo} placeholder, which gh expands
+	// from the worktree's git remote at runtime. We must NOT substitute the
+	// dispatch repo here: PRStatus.TargetRepo is the canonical project short name
+	// (e.g. "klaus") for registered projects, not an owner/repo slug, so it would
+	// produce a 404 path like repos/klaus/pulls/267/comments. The fix agent always
+	// runs inside the PR's worktree, so {owner}/{repo} resolves correctly.
 	return fmt.Sprintf(
 		"%s "+
-			"Fetch the review comments with: gh api repos/%s/pulls/%s/comments\n"+
+			"Fetch the review comments with: gh api repos/{owner}/{repo}/pulls/%s/comments\n"+
 			"Address each comment in the code, then push your fixes.\n"+
 			"After pushing, reply to EACH review comment that you haven't already replied to with a concise (1-2 sentence) explanation of what you changed. "+
 			"If a comment was intentionally not addressed, reply explaining why it was discounted.\n"+
 			"Use this exact command to reply, substituting the comment id and your explanation:\n"+
-			"  gh api repos/%s/pulls/%s/comments/{commentId}/replies -f body='<explanation>'",
-		leadIn, repo, prNumber, repo, prNumber,
+			"  gh api repos/{owner}/{repo}/pulls/%s/comments/{commentId}/replies -f body='<explanation>'",
+		leadIn, prNumber, prNumber,
 	)
 }
 

--- a/internal/pipeline/transitions.go
+++ b/internal/pipeline/transitions.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/patflynn/klaus/internal/event"
+	ghutil "github.com/patflynn/klaus/internal/github"
 	"github.com/patflynn/klaus/internal/run"
 )
 
@@ -287,7 +288,7 @@ var transitions = []transition{
 			return nil, []ActionDescriptor{{
 				Type:      ActionMergePR,
 				PRNumber:  ps.PRNumber,
-				Repo:      status.TargetRepo,
+				Repo:      dispatchRepo(c, status),
 				PRNumbers: []string{ps.PRNumber},
 			}}
 		},
@@ -332,7 +333,7 @@ var transitions = []transition{
 			descs = append(descs, ActionDescriptor{
 				Type:     ActionSnapshotThreads,
 				PRNumber: ps.PRNumber,
-				Repo:     status.TargetRepo,
+				Repo:     dispatchRepo(c, status),
 			})
 
 			prompt := reviewFixPrompt(
@@ -384,7 +385,7 @@ var transitions = []transition{
 			descs = append(descs, ActionDescriptor{
 				Type:     ActionSnapshotThreads,
 				PRNumber: ps.PRNumber,
-				Repo:     status.TargetRepo,
+				Repo:     dispatchRepo(c, status),
 			})
 
 			prompt := reviewFixPrompt(
@@ -639,6 +640,26 @@ func emitCIPassedIfNeeded(c *Controller, ps *PRPipelineState, status *PRStatus) 
 			"pr_url":    status.PRURL,
 		})
 	}
+}
+
+// dispatchRepo returns the owner/repo slug to attach to ActionDescriptors whose
+// handlers treat Repo as a real GitHub slug (ActionSnapshotThreads, ActionMergePR).
+// It derives the slug from status.PRURL (always a full GitHub PR URL) because
+// status.TargetRepo holds the canonical project SHORT name (e.g. "klaus") for
+// registered projects, which is NOT a valid owner/repo slug. If the URL can't be
+// parsed it falls back to status.TargetRepo to preserve prior behavior.
+//
+// Note: ActionLaunchAgent intentionally does NOT use this — its handler runs the
+// value through normalizeTargetRepo, which expects the short name.
+func dispatchRepo(c *Controller, status *PRStatus) string {
+	if slug := ghutil.OwnerRepoFromPRURL(status.PRURL); slug != "" {
+		return slug
+	}
+	c.logger.Warn("could not derive owner/repo from PR URL; falling back to TargetRepo",
+		"pr", status.PRURL,
+		"target_repo", status.TargetRepo,
+	)
+	return status.TargetRepo
 }
 
 // reviewFixPrompt builds the prompt sent to a review-fix agent. The leadIn is


### PR DESCRIPTION
## Problem

The pipeline's trusted-reviewer fix-agent prompt (and the sibling changes-requested prompt, since both share `reviewFixPrompt`) built a `gh api` path by substituting `PRStatus.TargetRepo` into `repos/%s/pulls/...`.

`TargetRepo` is the canonical project **short name** (e.g. `klaus`) for registered projects — produced by `project.NormalizeRepoName` via `normalizeTargetRepo` — not an `owner/repo` slug. So the generated path resolved to `repos/klaus/pulls/267/comments`, which 404s.

## Fix

Switch the API paths in `reviewFixPrompt` to the literal `{owner}/{repo}` placeholder, which `gh` expands from the worktree's git remote at runtime. The fix agent always runs inside the PR's worktree, so this resolves correctly with zero substitution. `TargetRepo` is retained only in the human-readable "in %s" prose.

Both the comments-fetch path and the replies path get the same treatment.

Also corrected the `PRStatus.TargetRepo` doc comment, which inaccurately claimed the value was always `owner/repo`. `NormalizeRepoName` returns a bare project name for registered projects and an `owner/repo` slug otherwise.

## Tests

Extended `TestReviewFixPromptsInstructAgentToReplyToComments` to assert the generated prompt:
- DOES contain `repos/{owner}/{repo}/pulls`
- does NOT substitute `TargetRepo` into the API path

The assertion runs against the real generated prompt from the transition (no mocking of internals). Full `go test ./...` passes except the pre-existing, unrelated `TestLoadNoFile` (HOME isolation) failure.

Run: 20260606-0940-61af8c42
Fixes #269