### PR TITLE
webhook: stop dropping commented reviews; add reconcile heartbeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,22 @@ Both commands require `webhook.relay_url` in your config. `setup` also requires 
 
 The created webhooks subscribe to `push`, `check_run`, `check_suite`, `pull_request`, and `pull_request_review` events.
 
+Additional webhook config knobs:
+
+- `poll_fallback` (bool, default `false`): when `true`, the dashboard polls GitHub every 30s *in addition* to receiving webhooks.
+- `reconcile_interval_seconds` (int, default `300`): in webhook-only mode (`poll_fallback: false`), a slow reconcile heartbeat runs a full PR status re-fetch on this interval. This bounds worst-case staleness if a webhook is ever dropped or missed — without reverting to full 30s polling. Set to a negative value to disable. Ignored when `poll_fallback` is `true` (polling already re-fetches every 30s).
+
+```json
+{
+  "webhook": {
+    "relay_url": "https://your-relay.example.com",
+    "secret_file": "/path/to/webhook-secret",
+    "poll_fallback": false,
+    "reconcile_interval_seconds": 300
+  }
+}
+```
+
 ### `klaus new`
 
 Creates a new GitHub repo and launches a Claude agent to scaffold it. Reads principles from `.klaus/principles.md` (or built-in defaults). The agent makes all scaffolding decisions based on those principles — no templates. The new project is automatically registered in the project registry.

--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -43,6 +43,10 @@ When webhook config is present in .klaus/config.json, the dashboard starts
 an HTTP server to receive push events from github-relay instead of polling.
 Set "webhook": {"port": 9800} in config to enable.
 
+In webhook-only mode (poll_fallback false), a slow reconcile heartbeat runs
+a full status re-fetch every 5 minutes by default (configurable via
+"reconcile_interval_seconds") so a dropped webhook can't strand a PR forever.
+
 Keyboard shortcuts:
   q  quit
   r  force refresh`,
@@ -83,6 +87,7 @@ Keyboard shortcuts:
 			model.useWebhook = true
 			model.pollEnabled = cfg.Webhook.PollFallback
 			model.webhookAddr = webhookSrv.Addr()
+			model.reconcileEvery = reconcileInterval(cfg.Webhook)
 
 			go func() {
 				if err := webhookSrv.Serve(); err != nil && err != http.ErrServerClosed {
@@ -145,6 +150,7 @@ type dashboardModel struct {
 	webhookAddr    string              // e.g. "127.0.0.1:9800"
 	useWebhook     bool                // true when webhook server is running
 	pollEnabled    bool                // true when polling is active (default or poll_fallback)
+	reconcileEvery time.Duration       // slow reconcile heartbeat interval (webhook-only mode)
 }
 
 func newDashboardModel(store run.StateStore, cfg config.Config, ghClient gh.Client) dashboardModel {
@@ -183,6 +189,9 @@ func (m dashboardModel) Init() tea.Cmd {
 	}
 	if m.webhookCh != nil {
 		cmds = append(cmds, waitForWebhookCmd(m.webhookCh))
+	}
+	if shouldScheduleReconcile(m.useWebhook, m.pollEnabled, m.reconcileEvery) {
+		cmds = append(cmds, reconcileTickAfterCmd(m.reconcileEvery))
 	}
 	return tea.Batch(cmds...)
 }
@@ -313,11 +322,36 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, waitForWebhookCmd(m.webhookCh)
 
+	case webhookClosedMsg:
+		// Live webhook consumption has stopped. Do not re-arm (re-reading a
+		// closed channel busy-loops). Surface it non-fatally; the reconcile
+		// heartbeat, if active, still bounds staleness.
+		m.recentErrors = append(m.recentErrors, dashboardError{
+			Time:    time.Now(),
+			Message: "webhook event channel closed; live webhook updates stopped (reconcile heartbeat still active)",
+		})
+		if len(m.recentErrors) > 3 {
+			m.recentErrors = m.recentErrors[len(m.recentErrors)-3:]
+		}
+		return m, nil
+
 	case trustedCommentsMsg:
 		existing, ok := m.ghStatus[msg.prNumber]
 		if ok {
 			existing.HasNewTrustedComments = msg.hasNewTrustedComments
 		}
+
+	case reconcileTickMsg:
+		// Slow reconcile heartbeat (webhook-only mode). Webhooks are the only
+		// reconcile trigger when poll_fallback is false, so a single dropped
+		// or missed event would strand a PR forever. This periodic full
+		// re-fetch bounds worst-case staleness (see issue #271). It re-arms
+		// itself; it is never scheduled when polling is active (which already
+		// re-fetches every 30s), so there is no double-fetch.
+		return m, tea.Batch(
+			fetchGHStatusCmd(m.ghClient, m.states),
+			reconcileTickAfterCmd(m.reconcileEvery),
+		)
 
 	case tickMsg:
 		// Expire errors older than 3 minutes.
@@ -396,6 +430,8 @@ func (m dashboardModel) View() string {
 		tag := fmt.Sprintf("  webhook: listening on %s", addr)
 		if m.pollEnabled {
 			tag += " + polling: 30s"
+		} else if m.reconcileEvery > 0 {
+			tag += fmt.Sprintf(" + reconcile: %s", formatDuration(m.reconcileEvery))
 		}
 		b.WriteString(dimStyle.Render(tag))
 		b.WriteString("\n")

--- a/internal/cmd/dashboard_commands.go
+++ b/internal/cmd/dashboard_commands.go
@@ -155,6 +155,13 @@ func reconcileInterval(cfg *config.WebhookConfig) time.Duration {
 }
 
 func reconcileTickAfterCmd(interval time.Duration) tea.Cmd {
+	// Defensive guard: tea.Tick fires immediately for a non-positive duration,
+	// so re-arming with interval <= 0 (the disabled-heartbeat sentinel) would
+	// spin an infinite loop of reconcileTickMsg messages and peg the CPU.
+	// Returning nil cleanly disables the heartbeat (bubbletea ignores nil cmds).
+	if interval <= 0 {
+		return nil
+	}
 	return tea.Tick(interval, func(time.Time) tea.Msg {
 		return reconcileTickMsg{}
 	})

--- a/internal/cmd/dashboard_commands.go
+++ b/internal/cmd/dashboard_commands.go
@@ -10,6 +10,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/fsnotify/fsnotify"
+	"github.com/patflynn/klaus/internal/config"
 	gh "github.com/patflynn/klaus/internal/github"
 	"github.com/patflynn/klaus/internal/pipeline"
 	"github.com/patflynn/klaus/internal/run"
@@ -30,6 +31,9 @@ type fsEventMsg struct{}
 
 type tickMsg struct{}
 
+// reconcileTickMsg fires the slow reconcile heartbeat in webhook-only mode.
+type reconcileTickMsg struct{}
+
 type sandboxStatusMsg struct {
 	hosts map[string]bool // host -> reachable
 }
@@ -45,6 +49,10 @@ type errMsg struct {
 type webhookMsg struct {
 	event webhook.Event
 }
+
+// webhookClosedMsg signals that the webhook event channel was closed, so live
+// webhook consumption has stopped. Surfaced as a non-fatal error in the TUI.
+type webhookClosedMsg struct{}
 
 type trustedCommentsMsg struct {
 	prNumber             string
@@ -98,7 +106,13 @@ func waitForWebhookCmd(ch <-chan webhook.Event) tea.Cmd {
 	return func() tea.Msg {
 		ev, ok := <-ch
 		if !ok {
-			return nil
+			// The webhook channel was closed. Re-reading it would return
+			// immediately forever (a busy-loop), so we do NOT re-arm.
+			// Surface a visible (non-fatal) error instead of going silently
+			// dark — in webhook-only mode this would otherwise permanently
+			// kill all reconcile triggers except the slow heartbeat (see
+			// issue #271).
+			return webhookClosedMsg{}
 		}
 		return webhookMsg{event: ev}
 	}
@@ -113,6 +127,36 @@ func tickCmd() tea.Cmd {
 func tickAfterCmd() tea.Cmd {
 	return tea.Tick(30*time.Second, func(time.Time) tea.Msg {
 		return tickMsg{}
+	})
+}
+
+// defaultReconcileInterval is the slow reconcile heartbeat interval used in
+// webhook-only mode when no override is configured.
+const defaultReconcileInterval = 5 * time.Minute
+
+// shouldScheduleReconcile reports whether the slow reconcile heartbeat should
+// run. It runs only in webhook mode when polling is NOT active: poll mode
+// already re-fetches every 30s (tickMsg), so the heartbeat would be redundant.
+// A non-positive interval disables the heartbeat entirely.
+func shouldScheduleReconcile(useWebhook, pollEnabled bool, interval time.Duration) bool {
+	return useWebhook && !pollEnabled && interval > 0
+}
+
+// reconcileInterval resolves the heartbeat interval from config. A zero value
+// means "use the default"; a negative value disables the heartbeat.
+func reconcileInterval(cfg *config.WebhookConfig) time.Duration {
+	if cfg == nil || cfg.ReconcileIntervalSeconds == 0 {
+		return defaultReconcileInterval
+	}
+	if cfg.ReconcileIntervalSeconds < 0 {
+		return 0 // disabled
+	}
+	return time.Duration(cfg.ReconcileIntervalSeconds) * time.Second
+}
+
+func reconcileTickAfterCmd(interval time.Duration) tea.Cmd {
+	return tea.Tick(interval, func(time.Time) tea.Msg {
+		return reconcileTickMsg{}
 	})
 }
 

--- a/internal/cmd/dashboard_reconcile_test.go
+++ b/internal/cmd/dashboard_reconcile_test.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/patflynn/klaus/internal/config"
+)
+
+// TestShouldScheduleReconcile verifies the heartbeat scheduling decision:
+// the slow reconcile sweep runs only in webhook-only mode (webhook on,
+// polling off) with a positive interval. It must NOT run when polling is
+// active (polling already re-fetches every 30s) or in plain poll mode.
+func TestShouldScheduleReconcile(t *testing.T) {
+	const iv = 5 * time.Minute
+	tests := []struct {
+		name        string
+		useWebhook  bool
+		pollEnabled bool
+		interval    time.Duration
+		want        bool
+	}{
+		{"webhook only", true, false, iv, true},
+		{"webhook plus polling (poll_fallback)", true, true, iv, false},
+		{"poll only (no webhook)", false, true, iv, false},
+		{"neither", false, false, iv, false},
+		{"webhook only but disabled interval", true, false, 0, false},
+		{"webhook only but negative interval", true, false, -1, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldScheduleReconcile(tt.useWebhook, tt.pollEnabled, tt.interval)
+			if got != tt.want {
+				t.Errorf("shouldScheduleReconcile(%v, %v, %v) = %v, want %v",
+					tt.useWebhook, tt.pollEnabled, tt.interval, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestReconcileInterval verifies config resolution: zero/nil → default,
+// negative → disabled (0), positive → that many seconds.
+func TestReconcileInterval(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.WebhookConfig
+		want time.Duration
+	}{
+		{"nil config uses default", nil, defaultReconcileInterval},
+		{"zero uses default", &config.WebhookConfig{ReconcileIntervalSeconds: 0}, defaultReconcileInterval},
+		{"negative disables", &config.WebhookConfig{ReconcileIntervalSeconds: -1}, 0},
+		{"positive override", &config.WebhookConfig{ReconcileIntervalSeconds: 120}, 120 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := reconcileInterval(tt.cfg); got != tt.want {
+				t.Errorf("reconcileInterval(%+v) = %v, want %v", tt.cfg, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/dashboard_reconcile_test.go
+++ b/internal/cmd/dashboard_reconcile_test.go
@@ -38,6 +38,22 @@ func TestShouldScheduleReconcile(t *testing.T) {
 	}
 }
 
+// TestReconcileTickAfterCmd verifies the defensive guard: a non-positive
+// interval returns a nil command (heartbeat disabled), so the re-arm path can
+// never spin tea.Tick into an immediate-fire infinite loop. A positive interval
+// returns a real command.
+func TestReconcileTickAfterCmd(t *testing.T) {
+	if cmd := reconcileTickAfterCmd(0); cmd != nil {
+		t.Errorf("reconcileTickAfterCmd(0) = non-nil, want nil")
+	}
+	if cmd := reconcileTickAfterCmd(-1 * time.Second); cmd != nil {
+		t.Errorf("reconcileTickAfterCmd(-1s) = non-nil, want nil")
+	}
+	if cmd := reconcileTickAfterCmd(5 * time.Minute); cmd == nil {
+		t.Errorf("reconcileTickAfterCmd(5m) = nil, want non-nil")
+	}
+}
+
 // TestReconcileInterval verifies config resolution: zero/nil → default,
 // negative → disabled (0), positive → that many seconds.
 func TestReconcileInterval(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,14 @@ type WebhookConfig struct {
 	PollFallback bool   `json:"poll_fallback"` // if true, poll even when webhook is active
 	RelayURL     string `json:"relay_url"`     // public URL of github-relay (e.g. https://example.ts.net)
 	SecretFile   string `json:"secret_file"`   // path to file containing the webhook secret
+
+	// ReconcileIntervalSeconds is the interval for the slow reconcile
+	// heartbeat in webhook-only mode (PollFallback false). A full status
+	// re-fetch runs on this interval to bound worst-case staleness if a
+	// webhook is ever dropped or missed. Default 300 (5 minutes). Ignored
+	// when polling is active (PollFallback true), since polling already
+	// re-fetches every 30s. Set to a negative value to disable entirely.
+	ReconcileIntervalSeconds int `json:"reconcile_interval_seconds"`
 }
 
 // PreReviewConfig configures the pre-PR review checks.

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"strings"
 )
 
 // Event is an invalidation signal from a GitHub webhook. It carries just
@@ -269,13 +268,13 @@ func parsePullRequestReview(payload json.RawMessage) []Event {
 		return nil
 	}
 
-	// Only signal for meaningful review states.
-	switch strings.ToLower(p.Review.State) {
-	case "approved", "changes_requested":
-		// valid
-	default:
-		return nil
-	}
+	// Emit for any submitted review regardless of state (approved,
+	// changes_requested, commented). Webhooks are invalidation signals; the
+	// trusted-reviewer + review-time/commit-time filtering lives in the
+	// detection layer (hasUnaddressedTrustedComments), not here. Dropping
+	// "commented" reviews stranded trusted-reviewer comments on quiescent
+	// PRs (see issue #271). We only ignore non-"submitted" actions
+	// (e.g. "edited", "dismissed").
 
 	return []Event{{
 		PRNumber:  fmt.Sprintf("%d", p.PullRequest.Number),

--- a/internal/webhook/server_test.go
+++ b/internal/webhook/server_test.go
@@ -159,13 +159,18 @@ func TestParsePullRequest(t *testing.T) {
 }
 
 func TestParsePullRequestReview(t *testing.T) {
+	// Any submitted review must produce an invalidation event regardless of
+	// state — including "commented" (gemini-code-assist submits its review
+	// bundles as state=commented). The trusted-reviewer/timing filtering
+	// lives in the detection layer, not the webhook parser (see issue #271).
+	// Non-"submitted" actions (edited, dismissed) produce no event.
 	tests := []struct {
 		name    string
 		payload string
 		wantLen int
 	}{
 		{
-			name: "approved",
+			name: "submitted approved",
 			payload: `{
 				"action": "submitted",
 				"review": {"state": "approved"},
@@ -175,7 +180,7 @@ func TestParsePullRequestReview(t *testing.T) {
 			wantLen: 1,
 		},
 		{
-			name: "changes requested",
+			name: "submitted changes_requested",
 			payload: `{
 				"action": "submitted",
 				"review": {"state": "changes_requested"},
@@ -185,10 +190,40 @@ func TestParsePullRequestReview(t *testing.T) {
 			wantLen: 1,
 		},
 		{
-			name: "commented (ignored)",
+			name: "submitted commented (now emits)",
 			payload: `{
 				"action": "submitted",
 				"review": {"state": "commented"},
+				"pull_request": {"number": 7},
+				"repository": {"full_name": "owner/repo"}
+			}`,
+			wantLen: 1,
+		},
+		{
+			name: "submitted commented uppercase COMMENTED",
+			payload: `{
+				"action": "submitted",
+				"review": {"state": "COMMENTED"},
+				"pull_request": {"number": 7},
+				"repository": {"full_name": "owner/repo"}
+			}`,
+			wantLen: 1,
+		},
+		{
+			name: "edited (ignored)",
+			payload: `{
+				"action": "edited",
+				"review": {"state": "commented"},
+				"pull_request": {"number": 7},
+				"repository": {"full_name": "owner/repo"}
+			}`,
+			wantLen: 0,
+		},
+		{
+			name: "dismissed (ignored)",
+			payload: `{
+				"action": "dismissed",
+				"review": {"state": "changes_requested"},
 				"pull_request": {"number": 7},
 				"repository": {"full_name": "owner/repo"}
 			}`,
@@ -205,6 +240,12 @@ func TestParsePullRequestReview(t *testing.T) {
 			if tt.wantLen > 0 {
 				if events[0].EventType != "pull_request_review" {
 					t.Errorf("expected EventType=pull_request_review, got %q", events[0].EventType)
+				}
+				if events[0].PRNumber != "7" {
+					t.Errorf("expected PRNumber=7, got %q", events[0].PRNumber)
+				}
+				if events[0].Repo != "owner/repo" {
+					t.Errorf("expected Repo=owner/repo, got %q", events[0].Repo)
 				}
 			}
 		})


### PR DESCRIPTION
## Summary

In webhook-driven mode (`poll_fallback: false`), a trusted reviewer's comment-only review never triggered a pipeline reconcile, so review comments stalled indefinitely on quiescent PRs (no CI/push churn to incidentally force a re-fetch). gemini-code-assist submits its review bundles as state `commented`, which the webhook parser silently dropped. Observed: a review sat ~23h with no dispatch. Fixes #271.

## Changes

### 1. Primary: stop dropping `commented` reviews (`internal/webhook/server.go`)
`parsePullRequestReview` previously emitted an invalidation `Event` only for review states `approved`/`changes_requested` and dropped everything else. It now emits for **any** `submitted` review regardless of state. Webhooks are pure invalidation signals; the trusted-reviewer + review-time/commit-time filtering already lives in the detection layer (`hasUnaddressedTrustedComments`), not the parser, so the parser should not second-guess which states matter. Non-`submitted` actions (`edited`, `dismissed`) are still ignored. Extra `commented` events only cause an idempotent re-fetch — they cannot cause spurious dispatches.

### 2. Defense in depth: slow reconcile heartbeat (`internal/cmd/dashboard.go`, `dashboard_commands.go`, `internal/config/config.go`)
With `poll_fallback: false`, webhooks are the only reconcile trigger, so a single dropped/missed event strands a PR forever. Added a low-frequency reconcile sweep that runs a full `fetchGHStatusCmd` re-fetch on an interval **even in webhook-only mode**. Reuses the existing `fetchGHStatusCmd` → `ghStatusMsg` → `pipelineCtrl.HandleGHStatus` path — no parallel reconcile path.

- Default interval **5 minutes**, configurable via `webhook.reconcile_interval_seconds` (negative disables).
- Never scheduled when polling is already active (poll mode re-fetches every 30s), so there is no double-fetch. The scheduling decision is factored into a testable `shouldScheduleReconcile` helper.

### 3. Related: `waitForWebhookCmd` re-arm
Previously returned `nil` and never re-armed when the event channel closed — silent permanent death of webhook consumption. It now surfaces a visible non-fatal error in the TUI instead of going dark (it does not re-read the closed channel, which would busy-loop).

## Worst-case staleness
- **Before:** unbounded on a quiescent PR — a dropped `commented` review could sit until some unrelated event (CI/push) happened to force a recompute.
- **After:** bounded by the heartbeat interval (default 5 minutes) even with zero webhook traffic, and the `commented` review now invalidates immediately when its webhook is delivered.

## Tests
- `internal/webhook`: table test for `parsePullRequestReview` — `action=submitted` with state in {commented, COMMENTED, approved, changes_requested} all produce an `Event` with the correct PRNumber/Repo/EventType; `edited`/`dismissed` produce none. Fed real JSON payloads.
- `internal/cmd`: focused tests for `shouldScheduleReconcile` (the scheduling decision) and `reconcileInterval` (config resolution).
- Full `go test ./...` green except the known pre-existing, unrelated `internal/config TestLoadNoFile` failure (doesn't isolate `HOME`; fails on clean main too).

## Notes
- No github-relay config change — `pull_request_review` is already forwarded; the fix is purely klaus-side parsing + reconcile.
- `klaus _pre-review` flagged a HIGH finding in `.github/workflows/nightly-release.yml`, but that file is not part of this changeset — it surfaced only because the local `main` ref is stale relative to the branch base (#262); the finding originates from already-merged PR #254.

Run: 20260607-0906-1d6e5b51
Fixes #271
