### PR TITLE
Add e2e test harness driving the real klaus binary via real tmux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,20 @@ jobs:
       - run: go test ./...
       - run: go vet ./...
 
+  e2e:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: '1.24'
+      - run: sudo apt-get update && sudo apt-get install -y tmux
+      - run: go test -tags e2e ./e2e/...
+
   zizmor:
     runs-on: ubuntu-latest
     permissions:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint vet clean install
+.PHONY: build test test-e2e lint vet clean install
 
 BINARY := klaus
 BUILD_DIR := bin
@@ -11,6 +11,11 @@ build:
 
 test:
 	go test ./...
+
+# End-to-end tests drive the real binary against an isolated tmux server.
+# Kept separate from `test` so the default suite needs no tmux.
+test-e2e:
+	go test -tags e2e ./e2e/...
 
 vet:
 	go vet ./...

--- a/README.md
+++ b/README.md
@@ -149,6 +149,19 @@ cd klaus
 go build -o ~/.local/bin/klaus ./cmd/klaus/
 ```
 
+## Development
+
+```bash
+make test       # unit tests (go test ./...)
+make test-e2e   # end-to-end tests against a real, isolated tmux server
+make vet        # go vet ./...
+```
+
+The e2e suite (`e2e/`, guarded by the `e2e` build tag so `go test ./...` is
+unaffected) drives the real `klaus` binary against a private tmux server and
+real git repositories, faking only `claude`/`gh`. It requires `tmux` on PATH.
+See [`e2e/README.md`](e2e/README.md) for the design and how to add scenarios.
+
 ## Commands
 
 The coordinator session uses these — you generally don't run them directly:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,82 @@
+# klaus end-to-end tests
+
+These tests drive the **real `klaus` binary** against a **real but fully
+isolated** tmux server and real git repositories. They exercise behavior the
+unit tests can't: actual pane creation, the `claude | tee | _format-stream;
+_finalize` pipeline, worktree lifecycle, and run-state persistence.
+
+## Running
+
+```bash
+make test-e2e
+# or
+go test -tags e2e ./e2e/...
+```
+
+The suite is guarded by the `e2e` build tag, so the default `go test ./...`
+(and the `build-and-test` CI job) never compile or run it. Requirements:
+
+- `tmux` and `git` on `PATH` (real, used as-is)
+- `go` (the binary is built once per run by `TestMain`)
+
+A dedicated `e2e` CI job runs the suite on `ubuntu-latest`.
+
+## Isolation
+
+Every test gets its own throwaway world; nothing touches your real tmux server
+or `~/.klaus`:
+
+| Concern   | How it's isolated |
+|-----------|-------------------|
+| tmux      | A private server on a per-test unix socket (`tmux -S <tmpdir>/tmux.sock`). klaus' own tmux calls are aimed at it via the `$TMUX` env var; the test's control queries use `tmux -S <sock>`. Killed in `t.Cleanup`. |
+| state     | `HOME` is a per-test temp dir, so all `~/.klaus/sessions/...` state lands under it. |
+| externals | A per-test bin dir is prepended to `PATH` and holds the klaus binary plus fake `claude`/`gh` stubs. **git and tmux stay real.** |
+| git       | A sandbox repo with a **bare local `origin`**, so worktrees, branches, and pushes work with no network. |
+
+Unique socket name + temp `HOME` per test ⇒ the tests run in parallel safely.
+
+### The one tmux subtlety
+
+tmux runs pane commands through the configured *default-shell*. A login shell
+can rewrite `PATH` (e.g. via the Nix profile), which would hide our stubs. The
+harness starts the server with `-f /dev/null` (ignore user config) and points
+`default-shell` at a tiny no-profile wrapper that forces a deterministic
+`PATH`/`HOME`. That makes the stubs/binary resolvable in panes on any host.
+
+## The fake `claude` contract
+
+After `claude` exits, `klaus _finalize <run-id>` parses the run's captured
+JSONL log. The stub emits stream-json containing:
+
+- an `assistant` event whose text holds a PR URL matching
+  `https?://github\.com/[^\s"<>\]]+/pull/\d+`, and
+- a `result` event with `total_cost_usd`, `duration_ms`, and `session_id`.
+
+`_finalize` turns those into the run's `CostUSD`, `DurationMS`, and `PRURL`.
+The stub also **blocks until released** (`Harness.ReleaseClaude`) so a test can
+deterministically observe the live pane (title, existence, argv) before
+`_finalize` tears it down. Override the emitted JSONL with
+`WriteDefaultClaudeOutput`, or replace either stub entirely with `WriteStub`.
+
+## Adding a scenario
+
+```go
+//go:build e2e
+
+func TestSomething(t *testing.T) {
+    t.Parallel()
+    h := NewHarness(t)
+
+    res := h.RunKlaus("launch", "do the thing")
+    // ... assert on res, h.ReadState(id), h.ListPanes(), h.PaneTitle(id), etc.
+}
+```
+
+Key `Harness` helpers (see `harness_test.go`):
+
+- `RunKlaus(args...)` — run the real binary with the isolated env, return stdout/stderr/exit
+- `ReadState(id)` / `WaitForState(id, pred, timeout)` / `RunIDs()` — inspect run state
+- `ListPanes()` / `PaneExists(id)` / `PaneTitle(id)` — query the isolated tmux server
+- `WaitForClaudeStart` / `ReleaseClaude` / `ClaudeArgv` / `GHArgv` — coordinate the stubs
+- `SeedState(state)` — pre-seed state for read-path tests (e.g. `status`)
+- `WriteStub(name, script)` / `WriteDefaultClaudeOutput(jsonl)` — customize externals

--- a/e2e/cleanup_test.go
+++ b/e2e/cleanup_test.go
@@ -1,0 +1,68 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// TestCleanupRemovesPaneAndWorktree launches an agent and then cleans it up
+// while it is still live, asserting that `klaus cleanup` kills the real pane,
+// removes the real worktree, and deletes the state file. The fake claude is
+// left blocked so the run is genuinely active (exercising --force).
+func TestCleanupRemovesPaneAndWorktree(t *testing.T) {
+	t.Parallel()
+	h := NewHarness(t)
+
+	res := h.RunKlaus("launch", "do some work")
+	if res.ExitCode != 0 {
+		t.Fatalf("launch exited %d\nstdout:\n%s\nstderr:\n%s", res.ExitCode, res.Stdout, res.Stderr)
+	}
+	ids := h.RunIDs()
+	if len(ids) != 1 {
+		t.Fatalf("expected 1 run, got %d: %v", len(ids), ids)
+	}
+	runID := ids[0]
+
+	st, err := h.ReadState(runID)
+	if err != nil {
+		t.Fatalf("reading state: %v", err)
+	}
+	if st.TmuxPane == nil {
+		t.Fatal("launch wrote no TmuxPane")
+	}
+	pane := *st.TmuxPane
+	worktree := st.Worktree
+
+	// Make sure the agent is genuinely running in its pane before cleanup.
+	h.WaitForClaudeStart(30 * time.Second)
+	if !h.PaneExists(pane) {
+		t.Fatalf("pane %s should exist before cleanup", pane)
+	}
+	if _, err := os.Stat(worktree); err != nil {
+		t.Fatalf("worktree should exist before cleanup: %v", err)
+	}
+
+	// --force because the blocked stub keeps the run "active".
+	res = h.RunKlaus("cleanup", "--force", runID)
+	if res.ExitCode != 0 {
+		t.Fatalf("cleanup exited %d\nstdout:\n%s\nstderr:\n%s", res.ExitCode, res.Stdout, res.Stderr)
+	}
+
+	// Pane killed.
+	waitPaneGone(t, h, pane, 30*time.Second)
+
+	// Worktree removed.
+	if _, err := os.Stat(worktree); !os.IsNotExist(err) {
+		t.Errorf("worktree should be removed, stat err: %v", err)
+	}
+
+	// State file deleted.
+	for _, id := range h.RunIDs() {
+		if id == runID {
+			t.Errorf("state for %s should be deleted after cleanup", runID)
+		}
+	}
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,0 +1,67 @@
+//go:build e2e
+
+// Package e2e contains end-to-end tests that drive the real klaus binary
+// against a real (but fully isolated) tmux server and real git repositories.
+//
+// These tests are guarded by the `e2e` build tag so the default
+// `go test ./...` is unaffected. Run them with:
+//
+//	go test -tags e2e ./e2e/...
+//
+// See e2e/README.md for the design and how to add new scenarios.
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// klausBinary is the path to the klaus binary built once for the whole test
+// binary by TestMain. Every Harness shells out to this exact binary.
+var klausBinary string
+
+// TestMain builds the klaus binary a single time before running the e2e
+// suite, then removes it afterwards. Building once keeps the suite fast even
+// though each test spins up its own isolated environment.
+func TestMain(m *testing.M) {
+	code, err := runMain(m)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "e2e setup:", err)
+		os.Exit(1)
+	}
+	os.Exit(code)
+}
+
+func runMain(m *testing.M) (int, error) {
+	// Ensure tmux exists — the whole suite is meaningless without it.
+	if _, err := exec.LookPath("tmux"); err != nil {
+		return 0, fmt.Errorf("tmux not found in PATH: %w", err)
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return 0, err
+	}
+	// The e2e package lives directly under the module root.
+	repoRoot := filepath.Dir(wd)
+
+	binDir, err := os.MkdirTemp("", "klaus-e2e-bin-")
+	if err != nil {
+		return 0, err
+	}
+	defer os.RemoveAll(binDir)
+
+	klausBinary = filepath.Join(binDir, "klaus")
+	build := exec.Command("go", "build", "-o", klausBinary, "./cmd/klaus/")
+	build.Dir = repoRoot
+	build.Stdout = os.Stderr
+	build.Stderr = os.Stderr
+	if err := build.Run(); err != nil {
+		return 0, fmt.Errorf("building klaus binary: %w", err)
+	}
+
+	return m.Run(), nil
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -36,9 +36,12 @@ func TestMain(m *testing.M) {
 }
 
 func runMain(m *testing.M) (int, error) {
-	// Ensure tmux exists — the whole suite is meaningless without it.
+	// Ensure tmux and git exist — the whole suite is meaningless without them.
 	if _, err := exec.LookPath("tmux"); err != nil {
 		return 0, fmt.Errorf("tmux not found in PATH: %w", err)
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		return 0, fmt.Errorf("git not found in PATH: %w", err)
 	}
 
 	wd, err := os.Getwd()

--- a/e2e/harness_test.go
+++ b/e2e/harness_test.go
@@ -154,7 +154,7 @@ dir=%q
 { for a in "$@"; do printf '%%s\n' "$a"; done; } > "$dir/claude.argv"
 printf '%%s' "$PWD" > "$dir/claude.cwd"
 : > "$dir/claude.started"
-for _ in $(seq 1 600); do
+for _ in {1..600}; do
   [ -f "$dir/claude.release" ] && break
   sleep 0.1
 done
@@ -216,7 +216,7 @@ func (h *Harness) GHArgv() string {
 // user config.
 func (h *Harness) setupGitConfig() {
 	h.t.Helper()
-	cfg := "[user]\n\tname = klaus-e2e\n\temail = klaus-e2e@example.com\n[init]\n\tdefaultBranch = main\n[protocol \"file\"]\n\tallow = always\n"
+	cfg := "[user]\n\tname = klaus-e2e\n\temail = klaus-e2e@example.com\n[init]\n\tdefaultBranch = main\n[protocol \"file\"]\n\tallow = always\n[safe]\n\tdirectory = *\n"
 	if err := os.WriteFile(filepath.Join(h.Home, ".gitconfig"), []byte(cfg), 0o644); err != nil {
 		h.t.Fatalf("writing gitconfig: %v", err)
 	}
@@ -281,12 +281,19 @@ func (h *Harness) startTmuxServer() {
 		h.t.Fatalf("writing shell wrapper: %v", err)
 	}
 
-	// -f /dev/null ignores any user/system tmux.conf for full isolation.
+	// Start the server and set the global default-shell *before* creating the
+	// session, so even the session's initial pane uses the no-profile wrapper
+	// rather than the system default shell (which could source login profiles).
+	// h.tmux passes -f /dev/null, so the server starts ignoring any
+	// user/system tmux.conf for full isolation. exit-empty must be turned off
+	// in the same command that starts the server, otherwise the freshly started
+	// (session-less) server exits before we can set default-shell.
+	h.tmux("start-server", ";", "set-option", "-g", "exit-empty", "off")
+	h.tmux("set-option", "-g", "default-shell", h.shellWrap)
 	h.tmux("new-session", "-d", "-s", "main", "-x", "200", "-y", "50")
 	h.t.Cleanup(func() {
-		_ = exec.Command("tmux", "-S", h.Sock, "kill-server").Run()
+		_ = exec.Command("tmux", "-S", h.Sock, "-f", "/dev/null", "kill-server").Run()
 	})
-	h.tmux("set-option", "-g", "default-shell", h.shellWrap)
 
 	h.ServerPID = strings.TrimSpace(h.tmux("display-message", "-p", "#{pid}"))
 	panes := h.ListPanes()
@@ -334,7 +341,7 @@ func (h *Harness) RunKlaus(args ...string) RunResult {
 // returns trimmed stdout, failing the test on error.
 func (h *Harness) tmux(args ...string) string {
 	h.t.Helper()
-	full := append([]string{"-S", h.Sock}, args...)
+	full := append([]string{"-S", h.Sock, "-f", "/dev/null"}, args...)
 	out, err := exec.Command("tmux", full...).CombinedOutput()
 	if err != nil {
 		h.t.Fatalf("tmux %v: %v: %s", args, err, out)

--- a/e2e/harness_test.go
+++ b/e2e/harness_test.go
@@ -1,0 +1,462 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/patflynn/klaus/internal/run"
+)
+
+// Harness is a fully isolated environment for driving the real klaus binary.
+//
+// Isolation guarantees (so tests never touch the developer's real tmux server
+// or ~/.klaus state):
+//   - tmux: a private server on a per-test unix socket (Sock). klaus' own tmux
+//     calls are pointed at it via the $TMUX env var; the test's control-plane
+//     queries use `tmux -S <Sock>`.
+//   - state: HOME is a per-test temp dir, so all ~/.klaus/sessions state lands
+//     under Home.
+//   - externals: a per-test bin dir (BinDir) is prepended to PATH and holds the
+//     klaus binary plus fake `claude`/`gh` stubs. git and tmux stay real.
+//
+// A unique socket name + temp HOME per test keeps tests parallel-safe.
+type Harness struct {
+	t *testing.T
+
+	Home      string // temp HOME ($HOME for all klaus invocations)
+	BinDir    string // dir prepended to PATH; holds klaus + stubs
+	E2EDir    string // scratch dir for stub coordination/log files
+	RepoDir   string // sandbox repo working tree (CWD for klaus)
+	OriginDir string // bare "origin" remote backing RepoDir
+
+	Sock        string // tmux server socket path (isolated server)
+	ServerPID   string // isolated tmux server pid (for the $TMUX value)
+	InitialPane string // the session's first pane id (klaus splits from here)
+
+	SessionID string // KLAUS_SESSION_ID for all invocations
+	shellWrap string // path to the no-profile shell wrapper for tmux panes
+}
+
+// RunResult is the outcome of a klaus invocation.
+type RunResult struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+// NewHarness builds nothing (the binary is built once in TestMain) but wires up
+// a complete isolated environment: temp HOME, a bin dir with the klaus binary
+// and fake claude/gh stubs, a sandbox git repo with a bare origin, and an
+// isolated tmux server. It registers cleanup to kill the tmux server; temp dirs
+// are removed automatically by t.TempDir.
+func NewHarness(t *testing.T) *Harness {
+	t.Helper()
+
+	if klausBinary == "" {
+		t.Fatal("klaus binary not built (TestMain did not run)")
+	}
+
+	root := t.TempDir()
+	h := &Harness{
+		t:         t,
+		Home:      filepath.Join(root, "home"),
+		BinDir:    filepath.Join(root, "bin"),
+		E2EDir:    filepath.Join(root, "e2e"),
+		RepoDir:   filepath.Join(root, "repo"),
+		OriginDir: filepath.Join(root, "origin.git"),
+		Sock:      filepath.Join(root, "tmux.sock"),
+		SessionID: "session-e2e-" + filepath.Base(root),
+	}
+
+	for _, d := range []string{h.Home, h.BinDir, h.E2EDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	h.installKlausBinary()
+	h.installDefaultStubs()
+	h.setupGitConfig()
+	h.setupSandboxRepo()
+	h.writeRepoConfig()
+	h.startTmuxServer()
+
+	return h
+}
+
+// installKlausBinary copies the prebuilt klaus binary into BinDir as "klaus"
+// so the pane pipeline (which runs `klaus _format-stream`/`klaus _finalize`)
+// resolves it from PATH.
+func (h *Harness) installKlausBinary() {
+	h.t.Helper()
+	data, err := os.ReadFile(klausBinary)
+	if err != nil {
+		h.t.Fatalf("reading klaus binary: %v", err)
+	}
+	dst := filepath.Join(h.BinDir, "klaus")
+	if err := os.WriteFile(dst, data, 0o755); err != nil {
+		h.t.Fatalf("installing klaus binary: %v", err)
+	}
+}
+
+// WriteStub writes an executable script into BinDir, shadowing any real binary
+// of the same name for klaus invocations in this harness.
+func (h *Harness) WriteStub(name, script string) {
+	h.t.Helper()
+	p := filepath.Join(h.BinDir, name)
+	if err := os.WriteFile(p, []byte(script), 0o755); err != nil {
+		h.t.Fatalf("writing stub %s: %v", name, err)
+	}
+}
+
+// installDefaultStubs writes the fake claude and gh binaries. The claude stub
+// blocks until released (see ReleaseClaude) so tests can deterministically
+// observe the live pane before _finalize tears it down. Tests may override
+// either stub with WriteStub before launching.
+func (h *Harness) installDefaultStubs() {
+	h.t.Helper()
+	h.WriteDefaultClaudeOutput(defaultClaudeOutput)
+	h.WriteStub("claude", h.claudeStubScript())
+	h.WriteStub("gh", h.ghStubScript())
+}
+
+// defaultClaudeOutput is the stream-json the fake agent emits. It contains a PR
+// URL (matched by hidden.go's prURLExtractRegex) and a result event carrying
+// cost/duration/session_id so _finalize can populate run state.
+const defaultClaudeOutput = `{"type":"system","subtype":"init","model":"claude-e2e"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Opened PR: https://github.com/acme/widget/pull/4242"}]}}
+{"type":"result","subtype":"success","total_cost_usd":0.1234,"duration_ms":4242,"session_id":"11111111-2222-4333-8444-555555555555"}
+`
+
+// WriteDefaultClaudeOutput sets the JSONL the fake claude prints once released.
+func (h *Harness) WriteDefaultClaudeOutput(jsonl string) {
+	h.t.Helper()
+	if err := os.WriteFile(filepath.Join(h.E2EDir, "claude.output.jsonl"), []byte(jsonl), 0o644); err != nil {
+		h.t.Fatalf("writing claude output: %v", err)
+	}
+}
+
+func (h *Harness) claudeStubScript() string {
+	// Records argv + cwd, signals start, blocks until a release file appears
+	// (max ~60s), then emits the canned stream-json. Paths are baked in so the
+	// stub is independent of the pane's environment.
+	return fmt.Sprintf(`#!/usr/bin/env bash
+dir=%q
+{ for a in "$@"; do printf '%%s\n' "$a"; done; } > "$dir/claude.argv"
+printf '%%s' "$PWD" > "$dir/claude.cwd"
+: > "$dir/claude.started"
+for _ in $(seq 1 600); do
+  [ -f "$dir/claude.release" ] && break
+  sleep 0.1
+done
+cat "$dir/claude.output.jsonl"
+`, h.E2EDir)
+}
+
+func (h *Harness) ghStubScript() string {
+	// Logs every invocation so tests can prove how (or whether) gh was called,
+	// and returns benign output. The launch path avoids gh entirely (pr_reviewer
+	// is configured), so this is mostly a safety net against hitting real gh.
+	return fmt.Sprintf(`#!/usr/bin/env bash
+dir=%q
+{ printf 'gh'; for a in "$@"; do printf ' %%q' "$a"; done; printf '\n'; } >> "$dir/gh.argv"
+exit 0
+`, h.E2EDir)
+}
+
+// ReleaseClaude unblocks the fake claude so the pane pipeline proceeds to
+// _format-stream and _finalize.
+func (h *Harness) ReleaseClaude() {
+	h.t.Helper()
+	if err := os.WriteFile(filepath.Join(h.E2EDir, "claude.release"), nil, 0o644); err != nil {
+		h.t.Fatalf("releasing claude: %v", err)
+	}
+}
+
+// WaitForClaudeStart blocks until the fake claude has started running in the
+// pane (or the timeout elapses).
+func (h *Harness) WaitForClaudeStart(timeout time.Duration) {
+	h.t.Helper()
+	started := filepath.Join(h.E2EDir, "claude.started")
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(started); err == nil {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	h.t.Fatalf("fake claude did not start within %s", timeout)
+}
+
+// ClaudeArgv returns the argv the fake claude was invoked with (one entry per
+// line as recorded), or "" if it has not run yet.
+func (h *Harness) ClaudeArgv() string {
+	b, _ := os.ReadFile(filepath.Join(h.E2EDir, "claude.argv"))
+	return string(b)
+}
+
+// GHArgv returns the logged gh invocations (one per line), or "" if gh was
+// never called.
+func (h *Harness) GHArgv() string {
+	b, _ := os.ReadFile(filepath.Join(h.E2EDir, "gh.argv"))
+	return string(b)
+}
+
+// setupGitConfig writes a global gitconfig under the temp HOME so git has a
+// committer identity (needed by data-ref commits) without touching the real
+// user config.
+func (h *Harness) setupGitConfig() {
+	h.t.Helper()
+	cfg := "[user]\n\tname = klaus-e2e\n\temail = klaus-e2e@example.com\n[init]\n\tdefaultBranch = main\n[protocol \"file\"]\n\tallow = always\n"
+	if err := os.WriteFile(filepath.Join(h.Home, ".gitconfig"), []byte(cfg), 0o644); err != nil {
+		h.t.Fatalf("writing gitconfig: %v", err)
+	}
+}
+
+// setupSandboxRepo creates a bare origin and a working clone with one commit on
+// main, pushed to origin. klaus' worktree/branch/push operations run against
+// these real repos with no network.
+func (h *Harness) setupSandboxRepo() {
+	h.t.Helper()
+	h.git("", "init", "-q", "--bare", "-b", "main", h.OriginDir)
+	h.git("", "init", "-q", "-b", "main", h.RepoDir)
+	if err := os.WriteFile(filepath.Join(h.RepoDir, "README.md"), []byte("# widget\n"), 0o644); err != nil {
+		h.t.Fatalf("seeding repo: %v", err)
+	}
+	h.git(h.RepoDir, "add", "-A")
+	h.git(h.RepoDir, "commit", "-qm", "init")
+	h.git(h.RepoDir, "remote", "add", "origin", h.OriginDir)
+	h.git(h.RepoDir, "push", "-q", "origin", "main")
+}
+
+// writeRepoConfig writes .klaus/config.json pointing WorktreeBase at the temp
+// root and setting pr_reviewer (so launch's prompt render does not shell out to
+// gh). It is committed so worktrees see the same config.
+func (h *Harness) writeRepoConfig() {
+	h.t.Helper()
+	cfgDir := filepath.Join(h.RepoDir, ".klaus")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		h.t.Fatalf("mkdir .klaus: %v", err)
+	}
+	cfg := map[string]any{
+		"worktree_base":  filepath.Join(filepath.Dir(h.RepoDir), "worktrees"),
+		"default_budget": "5.00",
+		"default_branch": "main",
+		"data_ref":       "refs/klaus/data",
+		"pr_reviewer":    "acme-bot",
+	}
+	data, _ := json.MarshalIndent(cfg, "", "  ")
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), append(data, '\n'), 0o644); err != nil {
+		h.t.Fatalf("writing repo config: %v", err)
+	}
+	h.git(h.RepoDir, "add", "-A")
+	h.git(h.RepoDir, "commit", "-qm", "add klaus config")
+	h.git(h.RepoDir, "push", "-q", "origin", "main")
+}
+
+// startTmuxServer launches an isolated tmux server on h.Sock and points its
+// panes at a no-profile shell wrapper so they inherit BinDir-first PATH and the
+// temp HOME (the user's login shell would otherwise reset PATH via the Nix
+// profile). Registers cleanup to kill the server.
+func (h *Harness) startTmuxServer() {
+	h.t.Helper()
+
+	// A wrapper shell that forces a deterministic PATH/HOME and refuses to
+	// source the user's profile. tmux runs pane commands via the default-shell;
+	// without this, a login shell would reset PATH and our stubs/binary would
+	// not be found.
+	h.shellWrap = filepath.Join(filepath.Dir(h.BinDir), "shellwrap")
+	wrap := fmt.Sprintf("#!/bin/sh\nexport HOME=%q\nexport PATH=%q\nexec %q --noprofile --norc \"$@\"\n",
+		h.Home, h.BinDir+":"+os.Getenv("PATH"), mustBash(h.t))
+	if err := os.WriteFile(h.shellWrap, []byte(wrap), 0o755); err != nil {
+		h.t.Fatalf("writing shell wrapper: %v", err)
+	}
+
+	// -f /dev/null ignores any user/system tmux.conf for full isolation.
+	h.tmux("new-session", "-d", "-s", "main", "-x", "200", "-y", "50")
+	h.t.Cleanup(func() {
+		_ = exec.Command("tmux", "-S", h.Sock, "kill-server").Run()
+	})
+	h.tmux("set-option", "-g", "default-shell", h.shellWrap)
+
+	h.ServerPID = strings.TrimSpace(h.tmux("display-message", "-p", "#{pid}"))
+	panes := h.ListPanes()
+	if len(panes) == 0 {
+		h.t.Fatal("isolated tmux server has no panes")
+	}
+	h.InitialPane = panes[0]
+}
+
+// env returns the environment for a klaus invocation: isolated HOME, BinDir-first
+// PATH, the session id, and $TMUX/$TMUX_PANE pointing at the isolated server.
+func (h *Harness) env() []string {
+	return []string{
+		"HOME=" + h.Home,
+		"PATH=" + h.BinDir + ":" + os.Getenv("PATH"),
+		"KLAUS_SESSION_ID=" + h.SessionID,
+		"TMUX=" + h.Sock + "," + h.ServerPID + ",0",
+		"TMUX_PANE=" + h.InitialPane,
+		"TERM=xterm",
+	}
+}
+
+// RunKlaus runs the real klaus binary with the isolated environment, with CWD
+// set to the sandbox repo. It returns stdout/stderr/exit and never fails the
+// test on a non-zero exit (callers assert as needed).
+func (h *Harness) RunKlaus(args ...string) RunResult {
+	h.t.Helper()
+	cmd := exec.Command(klausBinary, args...)
+	cmd.Dir = h.RepoDir
+	cmd.Env = h.env()
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	res := RunResult{Stdout: stdout.String(), Stderr: stderr.String()}
+	if ee, ok := err.(*exec.ExitError); ok {
+		res.ExitCode = ee.ExitCode()
+	} else if err != nil {
+		h.t.Fatalf("running klaus %v: %v", args, err)
+	}
+	return res
+}
+
+// tmux runs a control-plane tmux command against the isolated server and
+// returns trimmed stdout, failing the test on error.
+func (h *Harness) tmux(args ...string) string {
+	h.t.Helper()
+	full := append([]string{"-S", h.Sock}, args...)
+	out, err := exec.Command("tmux", full...).CombinedOutput()
+	if err != nil {
+		h.t.Fatalf("tmux %v: %v: %s", args, err, out)
+	}
+	return string(out)
+}
+
+// ListPanes returns all pane ids on the isolated server.
+func (h *Harness) ListPanes() []string {
+	h.t.Helper()
+	out := h.tmux("list-panes", "-a", "-F", "#{pane_id}")
+	var panes []string
+	for _, line := range strings.Split(out, "\n") {
+		if s := strings.TrimSpace(line); s != "" {
+			panes = append(panes, s)
+		}
+	}
+	return panes
+}
+
+// PaneExists reports whether the given pane id is alive on the isolated server.
+func (h *Harness) PaneExists(paneID string) bool {
+	for _, p := range h.ListPanes() {
+		if p == paneID {
+			return true
+		}
+	}
+	return false
+}
+
+// PaneTitle returns the title of the given pane.
+func (h *Harness) PaneTitle(paneID string) string {
+	h.t.Helper()
+	return strings.TrimSpace(h.tmux("display-message", "-p", "-t", paneID, "#{pane_title}"))
+}
+
+// RunsDir is the directory holding this session's run-state JSON files.
+func (h *Harness) RunsDir() string {
+	return filepath.Join(h.Home, ".klaus", "sessions", h.SessionID, "runs")
+}
+
+// RunIDs returns the run ids (state file basenames) currently on disk.
+func (h *Harness) RunIDs() []string {
+	entries, err := os.ReadDir(h.RunsDir())
+	if err != nil {
+		return nil
+	}
+	var ids []string
+	for _, e := range entries {
+		if name := e.Name(); strings.HasSuffix(name, ".json") {
+			ids = append(ids, strings.TrimSuffix(name, ".json"))
+		}
+	}
+	return ids
+}
+
+// ReadState reads and decodes a run's state JSON from the isolated HOME.
+func (h *Harness) ReadState(runID string) (*run.State, error) {
+	data, err := os.ReadFile(filepath.Join(h.RunsDir(), runID+".json"))
+	if err != nil {
+		return nil, err
+	}
+	var st run.State
+	if err := json.Unmarshal(data, &st); err != nil {
+		return nil, err
+	}
+	return &st, nil
+}
+
+// WaitForState polls a run's state until pred is satisfied or the timeout
+// elapses, returning the final state. It fails the test on timeout.
+func (h *Harness) WaitForState(runID string, pred func(*run.State) bool, timeout time.Duration) *run.State {
+	h.t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last *run.State
+	for time.Now().Before(deadline) {
+		st, err := h.ReadState(runID)
+		if err == nil {
+			last = st
+			if pred(st) {
+				return st
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	h.t.Fatalf("state predicate not satisfied for %s within %s (last: %+v)", runID, timeout, last)
+	return last
+}
+
+// SeedState writes a run-state JSON directly into the session store, for tests
+// that exercise read paths (e.g. status) without launching an agent.
+func (h *Harness) SeedState(st *run.State) {
+	h.t.Helper()
+	if err := os.MkdirAll(h.RunsDir(), 0o755); err != nil {
+		h.t.Fatalf("mkdir runs: %v", err)
+	}
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		h.t.Fatalf("marshal state: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(h.RunsDir(), st.ID+".json"), data, 0o644); err != nil {
+		h.t.Fatalf("writing seeded state: %v", err)
+	}
+}
+
+func (h *Harness) git(dir string, args ...string) {
+	h.t.Helper()
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	cmd.Env = append(os.Environ(), "HOME="+h.Home, "GIT_CONFIG_GLOBAL="+filepath.Join(h.Home, ".gitconfig"), "GIT_CONFIG_NOSYSTEM=1")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		h.t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+}
+
+func mustBash(t *testing.T) string {
+	t.Helper()
+	p, err := exec.LookPath("bash")
+	if err != nil {
+		t.Fatalf("bash not found: %v", err)
+	}
+	return p
+}

--- a/e2e/launch_test.go
+++ b/e2e/launch_test.go
@@ -1,0 +1,123 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/patflynn/klaus/internal/cmd"
+	"github.com/patflynn/klaus/internal/run"
+)
+
+// TestLaunchLifecycle is the headline scenario. With a fake claude, a real git
+// worktree, and a fake gh, it drives `klaus launch` end-to-end and asserts the
+// full lifecycle:
+//
+//	(a) a real pane is created in the isolated tmux server with the agent title,
+//	(b) run state is written with a branch, worktree, and pane,
+//	(c) the fake claude was invoked with the expected args,
+//	(d) after the agent completes, _finalize populates cost/duration/PR URL from
+//	    the stub's emitted stream-json, and
+//	(e) the worktree is removed and the pane is killed.
+func TestLaunchLifecycle(t *testing.T) {
+	t.Parallel()
+	h := NewHarness(t)
+
+	const prompt = "add a health check endpoint"
+	res := h.RunKlaus("launch", prompt)
+	if res.ExitCode != 0 {
+		t.Fatalf("launch exited %d\nstdout:\n%s\nstderr:\n%s", res.ExitCode, res.Stdout, res.Stderr)
+	}
+
+	// Exactly one run should have been recorded.
+	ids := h.RunIDs()
+	if len(ids) != 1 {
+		t.Fatalf("expected 1 run, got %d: %v", len(ids), ids)
+	}
+	runID := ids[0]
+
+	// (b) State is written with branch/worktree/pane while the agent runs.
+	st, err := h.ReadState(runID)
+	if err != nil {
+		t.Fatalf("reading state: %v", err)
+	}
+	if st.Branch == "" {
+		t.Error("state has empty Branch")
+	}
+	if st.Worktree == "" {
+		t.Error("state has empty Worktree")
+	}
+	if st.TmuxPane == nil || *st.TmuxPane == "" {
+		t.Fatal("state has no TmuxPane")
+	}
+	pane := *st.TmuxPane
+
+	// The worktree should actually exist on disk during the run.
+	if _, err := os.Stat(st.Worktree); err != nil {
+		t.Errorf("worktree should exist during run: %v", err)
+	}
+
+	// Wait until the fake claude is actually running in the pane before we
+	// assert on the live pane (the stub blocks until released).
+	h.WaitForClaudeStart(30 * time.Second)
+
+	// (a) The pane exists in the isolated server with the expected title.
+	if !h.PaneExists(pane) {
+		t.Fatalf("expected pane %s to exist; panes: %v", pane, h.ListPanes())
+	}
+	wantTitle := cmd.FormatPaneTitle(runID, "", prompt)
+	if got := h.PaneTitle(pane); got != wantTitle {
+		t.Errorf("pane title = %q, want %q", got, wantTitle)
+	}
+
+	// (c) claude was invoked with the expected args.
+	argv := h.ClaudeArgv()
+	for _, want := range []string{prompt, "-p", "--output-format", "stream-json", "--max-budget-usd"} {
+		if !strings.Contains(argv, want) {
+			t.Errorf("claude argv missing %q\n--- argv ---\n%s", want, argv)
+		}
+	}
+
+	// Let the agent finish; the pipeline runs _format-stream then _finalize.
+	h.ReleaseClaude()
+
+	// (d) _finalize populates cost/duration/PR URL from the emitted log.
+	final := h.WaitForState(runID, func(s *run.State) bool {
+		return s.CostUSD != nil && s.TmuxPane == nil
+	}, 30*time.Second)
+
+	if final.CostUSD == nil || *final.CostUSD != 0.1234 {
+		t.Errorf("CostUSD = %v, want 0.1234", final.CostUSD)
+	}
+	if final.DurationMS == nil || *final.DurationMS != 4242 {
+		t.Errorf("DurationMS = %v, want 4242", final.DurationMS)
+	}
+	if final.PRURL == nil || *final.PRURL != "https://github.com/acme/widget/pull/4242" {
+		t.Errorf("PRURL = %v, want the PR URL from the stub log", final.PRURL)
+	}
+
+	// (e) The worktree is removed and the pane is killed.
+	if final.Worktree != "" {
+		t.Errorf("Worktree should be cleared after cleanup, got %q", final.Worktree)
+	}
+	if _, err := os.Stat(st.Worktree); !os.IsNotExist(err) {
+		t.Errorf("worktree dir should be removed, stat err: %v", err)
+	}
+	waitPaneGone(t, h, pane, 30*time.Second)
+}
+
+// waitPaneGone polls until the pane disappears from the isolated server.
+func waitPaneGone(t *testing.T, h *Harness, pane string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !h.PaneExists(pane) {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Errorf("pane %s still alive after %s; panes: %v", pane, timeout, h.ListPanes())
+}

--- a/e2e/status_test.go
+++ b/e2e/status_test.go
@@ -1,0 +1,40 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/patflynn/klaus/internal/run"
+)
+
+// TestStatusRendersSeededRun is the warm-up scenario: it proves the harness
+// can build + run the real binary, that HOME isolation routes state reads to
+// the temp store, and that the rendered table reflects seeded state — all
+// without touching tmux (the seeded run has no pane).
+func TestStatusRendersSeededRun(t *testing.T) {
+	t.Parallel()
+	h := NewHarness(t)
+
+	budget := "5.00"
+	h.SeedState(&run.State{
+		ID:        "20260608-0101-deadbeef",
+		Prompt:    "implement the frobnicator",
+		Branch:    "agent/20260608-0101-deadbeef",
+		Budget:    &budget,
+		CreatedAt: "2026-06-08T01:01:00Z",
+		// No TmuxPane and no PRURL: determineStatus -> "exited" with no tmux/gh calls.
+	})
+
+	res := h.RunKlaus("status")
+	if res.ExitCode != 0 {
+		t.Fatalf("status exited %d; stderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	for _, want := range []string{"20260608-0101-deadbeef", "implement the frobnicator", "exited"} {
+		if !strings.Contains(res.Stdout, want) {
+			t.Errorf("status output missing %q\n--- stdout ---\n%s", want, res.Stdout)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

klaus had 35 unit tests but **zero** end-to-end coverage. This adds an e2e foundation that drives the **real klaus binary** against a **real but fully isolated** tmux server and real git repositories, faking only the non-deterministic externals (`claude`, `gh`). Per the project's testing guidance, these are "tests that run the real binary."

No production code is changed — the harness black-box drives the existing binary.

## Isolation (the #1 requirement)

Each test gets a throwaway world; nothing touches the developer's real tmux server or `~/.klaus`:

- **tmux** — a private server on a per-test unix socket. klaus' own tmux calls land on it via `$TMUX`; control queries use `tmux -S <sock>`. Killed in `t.Cleanup`.
- **state** — `HOME` is a per-test temp dir, so all `~/.klaus/sessions` state is isolated.
- **externals** — a per-test bin dir is prepended to `PATH` with the klaus binary + fake `claude`/`gh` stubs. **git and tmux stay real.**
- **git** — a sandbox repo with a bare local `origin`, so worktrees/branches/pushes work with no network.

Unique socket + temp HOME per test ⇒ parallel-safe.

One subtlety handled by the harness: tmux runs pane commands through the default-shell, and a login shell can rewrite `PATH` (e.g. via a Nix profile) and hide the stubs. The server starts with `-f /dev/null` and points `default-shell` at a tiny no-profile wrapper that forces a deterministic `PATH`/`HOME`, so panes resolve the stubs on any host.

## Scenarios

1. **`klaus status`** — renders a pre-seeded run (proves binary build + HOME isolation, no tmux).
2. **`klaus launch` full lifecycle** — asserts a real pane is created with the expected title, run state has branch/worktree/pane, claude was invoked with the expected args, `_finalize` populates `CostUSD`/`DurationMS`/`PRURL` from the stub's emitted stream-json, and the worktree + pane are torn down. The fake claude blocks until released so the live pane can be observed deterministically before finalize.
3. **`klaus cleanup`** — kills the live pane, removes the worktree, deletes state.

## How to run

```bash
make test-e2e            # go test -tags e2e ./e2e/...
```

The `e2e` build tag keeps the default `go test ./...` and the existing `build-and-test` CI job unaffected. A new `e2e` CI job runs the suite on `ubuntu-latest` (installs tmux), mirroring the repo's pinned-action / least-privilege hygiene. See `e2e/README.md` for design and how to add scenarios.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` (default, no tags) unchanged in scope and pass.
- `go test -tags e2e ./e2e/...` passes locally, including `-count=3` for flakiness and parallel execution; leaves no panes/worktrees/state behind.
- A pre-existing, environment-specific fsnotify flake in `internal/event` (`tail_test.go`) is unrelated — it fails identically on a pristine tree without these changes.

Run: 20260608-0555-a96aa863