### PR TITLE
feat(dashboard): make PR number a clickable hyperlink

### DIFF
--- a/internal/cmd/dashboard_render.go
+++ b/internal/cmd/dashboard_render.go
@@ -204,7 +204,19 @@ func renderSandboxStatus(hosts map[string]bool) string {
 // hyperlink wraps text in an OSC 8 terminal hyperlink escape sequence.
 // The escape bytes are invisible and stripped by lipgloss.Width(), so the
 // visible width of the returned string equals that of text.
+//
+// If url is empty or contains any byte outside printable ASCII (32–126), the
+// plain text is returned unwrapped. This guards against terminal escape
+// sequence injection when the URL originates from untrusted input.
 func hyperlink(url, text string) string {
+	if url == "" {
+		return text
+	}
+	for i := 0; i < len(url); i++ {
+		if url[i] < 32 || url[i] > 126 {
+			return text
+		}
+	}
 	return "\x1b]8;;" + url + "\x1b\\" + text + "\x1b]8;;\x1b\\"
 }
 

--- a/internal/cmd/dashboard_render.go
+++ b/internal/cmd/dashboard_render.go
@@ -100,7 +100,14 @@ func (m dashboardModel) renderGroup(g repoGroup) string {
 
 func (m dashboardModel) renderPRLine(prNum string, agents []*run.State, ps *prStatus) string {
 	s := agents[0]
-	prLabel := fmt.Sprintf("  #%-5s", prNum)
+	// Build the visible PR label first (visible width 6), then wrap only the
+	// visible text in a hyperlink so the OSC 8 escape bytes are not counted in
+	// the %-5s padding and column alignment is preserved.
+	prText := fmt.Sprintf("#%-5s", prNum)
+	if s.PRURL != nil && *s.PRURL != "" {
+		prText = hyperlink(*s.PRURL, prText)
+	}
+	prLabel := "  " + prText
 	prompt := truncate(s.Prompt, 20)
 
 	state := "OPEN"
@@ -192,6 +199,13 @@ func renderSandboxStatus(hosts map[string]bool) string {
 	}
 	sort.Strings(parts)
 	return strings.Join(parts, "  ") + "\n"
+}
+
+// hyperlink wraps text in an OSC 8 terminal hyperlink escape sequence.
+// The escape bytes are invisible and stripped by lipgloss.Width(), so the
+// visible width of the returned string equals that of text.
+func hyperlink(url, text string) string {
+	return "\x1b]8;;" + url + "\x1b\\" + text + "\x1b]8;;\x1b\\"
 }
 
 func stateLabel(state string) string {

--- a/internal/cmd/dashboard_test.go
+++ b/internal/cmd/dashboard_test.go
@@ -596,6 +596,27 @@ func TestRenderPRLineHyperlink(t *testing.T) {
 	}
 }
 
+func TestHyperlinkSanitizesURL(t *testing.T) {
+	// A clean URL is wrapped in the OSC 8 escape sequence.
+	if got := hyperlink("https://example.com/pull/1", "#1"); !strings.Contains(got, "\x1b]8;;") {
+		t.Errorf("clean URL should be wrapped, got %q", got)
+	}
+
+	// URLs with control characters must not be embedded; the plain text is
+	// returned to prevent terminal escape sequence injection.
+	for _, bad := range []string{
+		"https://x\x1b]8;;evil\x1b\\.com",
+		"https://x\nfoo.com",
+		"https://x\rfoo.com",
+		"https://x\x07.com",
+		"", // empty URL
+	} {
+		if got := hyperlink(bad, "#1"); got != "#1" {
+			t.Errorf("hyperlink(%q) = %q, want plain text %q", bad, got, "#1")
+		}
+	}
+}
+
 func TestRenderPRLineApproval(t *testing.T) {
 	m := dashboardModel{
 		width:          80,

--- a/internal/cmd/dashboard_test.go
+++ b/internal/cmd/dashboard_test.go
@@ -569,6 +569,33 @@ func TestRenderPRLine(t *testing.T) {
 	}
 }
 
+func TestRenderPRLineHyperlink(t *testing.T) {
+	m := dashboardModel{width: 80, tmuxDeps: testDashboardTmuxDeps(), ghStatus: map[string]*prStatus{}}
+
+	// With a PR URL, the PR number is wrapped in an OSC 8 hyperlink.
+	withURL := &run.State{
+		ID:     "20260307-0900-aaaa",
+		Prompt: "fix bug",
+		Type:   "launch",
+		PRURL:  strPtr("https://github.com/o/r/pull/42"),
+	}
+	line := m.renderPRLine("42", []*run.State{withURL}, nil)
+	want := hyperlink("https://github.com/o/r/pull/42", "#42   ")
+	if !strings.Contains(line, want) {
+		t.Errorf("expected OSC 8 hyperlink %q in line %q", want, line)
+	}
+
+	// Without a PR URL, there is no escape sequence and the number is plain.
+	noURL := &run.State{ID: "id", Prompt: "fix bug", Type: "launch"}
+	line = m.renderPRLine("42", []*run.State{noURL}, nil)
+	if strings.Contains(line, "\x1b]8;;") {
+		t.Errorf("expected no OSC 8 hyperlink when PRURL is nil, got %q", line)
+	}
+	if !strings.Contains(line, "#42") {
+		t.Errorf("expected plain PR number when PRURL is nil, got %q", line)
+	}
+}
+
 func TestRenderPRLineApproval(t *testing.T) {
 	m := dashboardModel{
 		width:          80,


### PR DESCRIPTION
## Summary
Makes the PR number in the dashboard a clickable hyperlink using an OSC 8 terminal escape sequence, so terminals that support OSC 8 (iTerm2, WezTerm, recent VTE, etc.) let you click straight through to the PR on GitHub.

## Changes
- Add a small `hyperlink(url, text)` helper in `dashboard_render.go` that wraps text in an OSC 8 escape sequence.
- In `renderPRLine`, wrap only the visible `#NNN` PR-number label in the hyperlink, and only when `s.PRURL` is set.

## Alignment
The visible `#%-5s` label (width 6) is built and padded *before* wrapping, so the OSC 8 escape bytes sit outside the padded field. `lipgloss.Width()` strips ANSI/OSC escapes, so the measured column width is identical to before — alignment is unchanged.

## Fallback
When `PRURL` is nil/empty the rendering is byte-for-byte unchanged (plain text, no escape codes).

## Tests
Added `TestRenderPRLineHyperlink` asserting the OSC 8 sequence appears when `PRURL` is set and is absent when it is nil. Full suite (`go test ./...`), `go build ./...`, and `go vet` pass.

Run: 20260627-1645-e5d352c0