### PR TITLE
feat(dashboard): keyboard nav to select, approve, and discuss PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ The status dashboard shows these columns for each run:
 
 ### `klaus dashboard`
 
-Live TUI view of the PR pipeline. Groups runs by repository, auto-refreshes via filesystem watching and GitHub polling every 30s. Keyboard shortcuts: `q` quit, `r` force refresh.
+Live TUI view of the PR pipeline. Groups runs by repository, auto-refreshes via filesystem watching and GitHub polling every 30s. Keyboard shortcuts: `j`/`k` (or `↑`/`↓`) move the PR selection, `a` approve the selected PR, `d` discuss the selected PR with the coordinator (pre-fills `WRT PR#<num>:` in the session pane and switches focus there), `r` force refresh, `q` quit.
 
 ### `klaus approve`
 

--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -19,6 +19,7 @@ import (
 	gh "github.com/patflynn/klaus/internal/github"
 	"github.com/patflynn/klaus/internal/pipeline"
 	"github.com/patflynn/klaus/internal/run"
+	"github.com/patflynn/klaus/internal/tmux"
 	"github.com/patflynn/klaus/internal/webhook"
 	"github.com/spf13/cobra"
 )
@@ -48,8 +49,11 @@ a full status re-fetch every 5 minutes by default (configurable via
 "reconcile_interval_seconds") so a dropped webhook can't strand a PR forever.
 
 Keyboard shortcuts:
-  q  quit
-  r  force refresh`,
+  j / k or ↑ / ↓  move the PR selection
+  a               approve the selected PR
+  d               discuss the selected PR with the coordinator
+  r               force refresh
+  q               quit`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		store, err := sessionStore()
 		if err != nil {
@@ -149,6 +153,8 @@ type dashboardModel struct {
 	store          run.StateStore
 	ghClient       gh.Client
 	tmuxDeps       run.TmuxDeps
+	tmux           tmux.Client // for keyboard-driven actions (discuss)
+	cursor         int         // index into selectablePRs(states) for keyboard selection
 	states         []*run.State
 	ghStatus       map[string]*prStatus // keyed by PR number
 	sandboxHosts   map[string]bool      // host -> reachable
@@ -197,6 +203,7 @@ func newDashboardModel(store run.StateStore, cfg config.Config, ghClient gh.Clie
 		store:          store,
 		ghClient:       ghClient,
 		tmuxDeps:       run.DefaultTmuxDeps(),
+		tmux:           tmux.NewExecClient(),
 		ghStatus:       make(map[string]*prStatus),
 		sandboxHosts:   make(map[string]bool),
 		pipelineCtrl:   ctrl,
@@ -239,6 +246,45 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				loadStatesCmd(m.store),
 				fetchGHStatusCmd(m.ghClient, m.states),
 			)
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case "down", "j":
+			if n := len(selectablePRs(m.states)); m.cursor < n-1 {
+				m.cursor++
+			}
+		case "a":
+			// Approve the selected PR immediately (no confirmation).
+			entries := selectablePRs(m.states)
+			if len(entries) == 0 {
+				break
+			}
+			e := entries[clampCursor(m.cursor, len(entries))]
+			if e.state != nil {
+				if err := markApproved(e.state, m.store); err != nil {
+					m.noteError(fmt.Sprintf("approve PR #%s: %v", e.prNum, err))
+				}
+			}
+			// Reload so the row reflects approval immediately; the fsnotify
+			// watcher also catches the save, but this avoids the round-trip lag.
+			return m, loadStatesCmd(m.store)
+		case "d":
+			// Discuss the selected PR with the coordinator: pre-fill a prompt
+			// in the coordinator pane and switch focus there.
+			entries := selectablePRs(m.states)
+			if len(entries) == 0 {
+				break
+			}
+			e := entries[clampCursor(m.cursor, len(entries))]
+			pane := m.coordinatorPane()
+			if pane == "" {
+				m.noteError("coordinator pane unknown (older session; relaunch to enable discuss)")
+				break
+			}
+			if err := m.discussPR(e.prNum, pane); err != nil {
+				m.noteError(fmt.Sprintf("discuss PR #%s: %v", e.prNum, err))
+			}
 		}
 
 	case tea.WindowSizeMsg:
@@ -246,7 +292,9 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = msg.Height
 
 	case statesLoadedMsg:
+		prevEntries := selectablePRs(m.states)
 		m.states = msg.states
+		m.reconcileSelection(prevEntries)
 		// Detect and finalize stale (orphaned) runs so they stop appearing as active.
 		for _, s := range m.states {
 			if s.IsStaleWith(m.tmuxDeps) {
@@ -522,7 +570,7 @@ func (m dashboardModel) View() string {
 
 	// Footer
 	footer := dimStyle.Render(fmt.Sprintf(
-		"  %d/%d agents running | q quit | r refresh",
+		"  %d/%d agents running | j/k move · a approve · d discuss | r refresh · q quit",
 		runningCount, totalCount,
 	))
 	b.WriteString(footer)

--- a/internal/cmd/dashboard_render.go
+++ b/internal/cmd/dashboard_render.go
@@ -14,15 +14,16 @@ import (
 // Styling.
 
 var (
-	headerStyle  = lipgloss.NewStyle().Bold(true)
-	repoStyle    = lipgloss.NewStyle().Bold(true)
-	greenStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
-	redStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
-	yellowStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
-	dimStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
-	cyanStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
-	sandboxStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
-	dimRedStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("9")).Faint(true)
+	headerStyle   = lipgloss.NewStyle().Bold(true)
+	repoStyle     = lipgloss.NewStyle().Bold(true)
+	greenStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+	redStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
+	yellowStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+	dimStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	cyanStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
+	sandboxStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
+	dimRedStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("9")).Faint(true)
+	selectedStyle = lipgloss.NewStyle().Bold(true).Background(lipgloss.Color("237"))
 )
 
 func (m dashboardModel) renderGroup(g repoGroup) string {
@@ -73,13 +74,18 @@ func (m dashboardModel) renderGroup(g repoGroup) string {
 		}
 	}
 
+	// Determine which PR row (if any) is currently selected so it can be
+	// rendered with the highlight gutter.
+	selRepo, selPR, hasSel := m.selectedPR()
+
 	// Render PRs and their agents
 	for _, prNum := range prOrder {
 		agents := prToAgents[prNum]
 		if len(agents) == 0 {
 			continue
 		}
-		b.WriteString(m.renderPRLine(prNum, agents, g.PRMap[prNum]))
+		selected := hasSel && selRepo == g.Repo && selPR == prNum
+		b.WriteString(m.renderPRLine(prNum, agents, g.PRMap[prNum], selected))
 		b.WriteString("\n")
 		for _, s := range agents {
 			if m.isAgentRunning(s) {
@@ -98,8 +104,13 @@ func (m dashboardModel) renderGroup(g repoGroup) string {
 	return b.String()
 }
 
-func (m dashboardModel) renderPRLine(prNum string, agents []*run.State, ps *prStatus) string {
+func (m dashboardModel) renderPRLine(prNum string, agents []*run.State, ps *prStatus, selected bool) string {
 	s := agents[0]
+	// Gutter marker for the cursor-selected row.
+	gutter := "  "
+	if selected {
+		gutter = "> "
+	}
 	// Build the visible PR label first (visible width 6), then wrap only the
 	// visible text in a hyperlink so the OSC 8 escape bytes are not counted in
 	// the %-5s padding and column alignment is preserved.
@@ -107,7 +118,7 @@ func (m dashboardModel) renderPRLine(prNum string, agents []*run.State, ps *prSt
 	if s.PRURL != nil && *s.PRURL != "" {
 		prText = hyperlink(*s.PRURL, prText)
 	}
-	prLabel := "  " + prText
+	prLabel := gutter + prText
 	prompt := truncate(s.Prompt, 20)
 
 	state := "OPEN"
@@ -143,7 +154,11 @@ func (m dashboardModel) renderPRLine(prNum string, agents []*run.State, ps *prSt
 		parts = append(parts, dimStyle.Render(pipeline.StageLabel(pps.Stage)))
 	}
 
-	return fmt.Sprintf("%s  %-20s  %s", prLabel, prompt, strings.Join(parts, "  "))
+	prefix := fmt.Sprintf("%s  %-20s", prLabel, prompt)
+	if selected {
+		prefix = selectedStyle.Render(prefix)
+	}
+	return fmt.Sprintf("%s  %s", prefix, strings.Join(parts, "  "))
 }
 
 // isAnyRunApproved returns true if any of the given run states has been

--- a/internal/cmd/dashboard_select.go
+++ b/internal/cmd/dashboard_select.go
@@ -98,7 +98,7 @@ func (m dashboardModel) coordinatorPane() string {
 		return ""
 	}
 	st, err := m.store.Load(sessionID)
-	if err != nil || st.CoordinatorPane == nil {
+	if err != nil || st == nil || st.CoordinatorPane == nil {
 		return ""
 	}
 	return *st.CoordinatorPane

--- a/internal/cmd/dashboard_select.go
+++ b/internal/cmd/dashboard_select.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/patflynn/klaus/internal/run"
+)
+
+// prEntry identifies a single selectable PR row in the dashboard. The ordering
+// of a slice of prEntry mirrors the on-screen render order (repos sorted by
+// name, then PRs in first-seen order within each repo), so a cursor index into
+// that slice maps directly to a visible row.
+type prEntry struct {
+	repo  string
+	prNum string
+	state *run.State // first agent's run state for this PR (used for approval)
+}
+
+// selectablePRs builds the flat, ordered list of selectable PR rows. It must
+// stay consistent with renderGroup: groupByRepo yields repos sorted by name,
+// and within each repo PRs appear in first-seen order among non-session runs.
+func selectablePRs(states []*run.State) []prEntry {
+	var entries []prEntry
+	for _, g := range groupByRepo(states) {
+		seen := make(map[string]bool)
+		for _, s := range g.Runs {
+			if s.Type == "session" {
+				continue
+			}
+			prNum := extractPRNumber(s)
+			if prNum == "" || seen[prNum] {
+				continue
+			}
+			seen[prNum] = true
+			entries = append(entries, prEntry{repo: g.Repo, prNum: prNum, state: s})
+		}
+	}
+	return entries
+}
+
+// clampCursor keeps a cursor index within [0, n-1]; it returns 0 when the list
+// is empty.
+func clampCursor(cursor, n int) int {
+	if n <= 0 {
+		return 0
+	}
+	if cursor < 0 {
+		return 0
+	}
+	if cursor >= n {
+		return n - 1
+	}
+	return cursor
+}
+
+// reconcileSelection updates m.cursor after the state list changes. If the
+// previously-selected PR still exists it keeps the selection on that PR;
+// otherwise it clamps the cursor into the new list's bounds. prev is the
+// selectable list computed from the states that were displayed before the
+// reload.
+func (m *dashboardModel) reconcileSelection(prev []prEntry) {
+	entries := selectablePRs(m.states)
+	if len(entries) == 0 {
+		m.cursor = 0
+		return
+	}
+	if m.cursor >= 0 && m.cursor < len(prev) {
+		want := prev[m.cursor]
+		for i, e := range entries {
+			if e.repo == want.repo && e.prNum == want.prNum {
+				m.cursor = i
+				return
+			}
+		}
+	}
+	m.cursor = clampCursor(m.cursor, len(entries))
+}
+
+// selectedPR returns the repo and PR number of the currently selected row.
+func (m dashboardModel) selectedPR() (repo, prNum string, ok bool) {
+	entries := selectablePRs(m.states)
+	if len(entries) == 0 {
+		return "", "", false
+	}
+	e := entries[clampCursor(m.cursor, len(entries))]
+	return e.repo, e.prNum, true
+}
+
+// coordinatorPane returns the tmux pane id of the coordinator (Claude) session
+// for the current dashboard, or "" if it can't be determined (e.g. an older
+// session that predates the persisted coordinator pane).
+func (m dashboardModel) coordinatorPane() string {
+	sessionID := os.Getenv(sessionIDEnv)
+	if sessionID == "" {
+		return ""
+	}
+	st, err := m.store.Load(sessionID)
+	if err != nil || st.CoordinatorPane == nil {
+		return ""
+	}
+	return *st.CoordinatorPane
+}
+
+// discussPR sends a literal "WRT PR#<num>: " prompt prefix to the coordinator
+// pane and switches tmux focus there. It deliberately does not send a newline —
+// the user finishes and submits the prompt manually.
+func (m dashboardModel) discussPR(prNum, pane string) error {
+	ctx := context.Background()
+	if err := m.tmux.SendKeys(ctx, pane, fmt.Sprintf("WRT PR#%s: ", prNum)); err != nil {
+		return err
+	}
+	return m.tmux.SelectPane(ctx, pane)
+}
+
+// noteError appends a transient error line to the dashboard, keeping only the
+// most recent few.
+func (m *dashboardModel) noteError(msg string) {
+	m.recentErrors = append(m.recentErrors, dashboardError{Time: time.Now(), Message: msg})
+	if len(m.recentErrors) > 3 {
+		m.recentErrors = m.recentErrors[len(m.recentErrors)-3:]
+	}
+}

--- a/internal/cmd/dashboard_select_test.go
+++ b/internal/cmd/dashboard_select_test.go
@@ -1,0 +1,210 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/patflynn/klaus/internal/run"
+	"github.com/patflynn/klaus/internal/tmux"
+)
+
+// captureTmux is a tmux.Client that records SendKeys/SelectPane calls so tests
+// can assert on the literal text and pane id sent to the coordinator.
+type captureTmux struct {
+	tmux.ExecClient
+	sentPane  string
+	sentKeys  string
+	focusPane string
+}
+
+func (c *captureTmux) SendKeys(_ context.Context, paneID, keys string) error {
+	c.sentPane = paneID
+	c.sentKeys = keys
+	return nil
+}
+
+func (c *captureTmux) SelectPane(_ context.Context, paneID string) error {
+	c.focusPane = paneID
+	return nil
+}
+
+func TestSelectablePRsOrdering(t *testing.T) {
+	// Two repos; aaa sorts before zzz. Within a repo, PRs appear in first-seen
+	// order. A session run and a bare (no-PR) agent are not selectable.
+	states := []*run.State{
+		{ID: "s1", Type: "session", Prompt: "session"},
+		{ID: "a1", Prompt: "p1", TargetRepo: strPtr("zzz"), PRURL: strPtr("https://github.com/o/zzz/pull/5"), CreatedAt: "2026-01-01T00:00:00Z"},
+		{ID: "a2", Prompt: "p2", TargetRepo: strPtr("aaa"), PRURL: strPtr("https://github.com/o/aaa/pull/9"), CreatedAt: "2026-01-01T00:01:00Z"},
+		{ID: "a3", Prompt: "p3", TargetRepo: strPtr("aaa"), PRURL: strPtr("https://github.com/o/aaa/pull/3"), CreatedAt: "2026-01-01T00:02:00Z"},
+		{ID: "a4", Prompt: "bare", TargetRepo: strPtr("aaa"), CreatedAt: "2026-01-01T00:03:00Z"},
+	}
+
+	got := selectablePRs(states)
+	want := []struct{ repo, pr string }{
+		{"aaa", "9"},
+		{"aaa", "3"},
+		{"zzz", "5"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("selectablePRs len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i].repo != w.repo || got[i].prNum != w.pr {
+			t.Errorf("entry %d = {%s #%s}, want {%s #%s}", i, got[i].repo, got[i].prNum, w.repo, w.pr)
+		}
+	}
+}
+
+func TestSelectablePRsDedupesAgentsPerPR(t *testing.T) {
+	// Two agents on the same PR collapse to a single selectable entry, and the
+	// entry carries the first agent's state.
+	states := []*run.State{
+		{ID: "first", Prompt: "p1", TargetRepo: strPtr("r"), PRURL: strPtr("https://github.com/o/r/pull/7"), CreatedAt: "2026-01-01T00:00:00Z"},
+		{ID: "second", Prompt: "p2", TargetRepo: strPtr("r"), PRURL: strPtr("https://github.com/o/r/pull/7"), CreatedAt: "2026-01-01T00:01:00Z"},
+	}
+	got := selectablePRs(states)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(got))
+	}
+	if got[0].state == nil || got[0].state.ID != "first" {
+		t.Errorf("entry state = %v, want first agent's state", got[0].state)
+	}
+}
+
+func TestClampCursor(t *testing.T) {
+	cases := []struct{ cursor, n, want int }{
+		{0, 0, 0},
+		{5, 0, 0},
+		{-1, 3, 0},
+		{1, 3, 1},
+		{3, 3, 2},
+		{99, 3, 2},
+	}
+	for _, c := range cases {
+		if got := clampCursor(c.cursor, c.n); got != c.want {
+			t.Errorf("clampCursor(%d, %d) = %d, want %d", c.cursor, c.n, got, c.want)
+		}
+	}
+}
+
+func TestReconcileSelectionKeepsSelectedPR(t *testing.T) {
+	prevStates := []*run.State{
+		{ID: "a", Prompt: "p", TargetRepo: strPtr("r"), PRURL: strPtr("https://github.com/o/r/pull/1"), CreatedAt: "2026-01-01T00:00:00Z"},
+		{ID: "b", Prompt: "p", TargetRepo: strPtr("r"), PRURL: strPtr("https://github.com/o/r/pull/2"), CreatedAt: "2026-01-01T00:01:00Z"},
+		{ID: "c", Prompt: "p", TargetRepo: strPtr("r"), PRURL: strPtr("https://github.com/o/r/pull/3"), CreatedAt: "2026-01-01T00:02:00Z"},
+	}
+	m := dashboardModel{states: prevStates, cursor: 2} // selecting PR #3
+	prev := selectablePRs(m.states)
+
+	// PR #1 is removed; #3 still exists but shifts to index 1.
+	m.states = []*run.State{prevStates[1], prevStates[2]}
+	m.reconcileSelection(prev)
+
+	if _, prNum, ok := m.selectedPR(); !ok || prNum != "3" {
+		t.Errorf("after reload selection = %q (ok=%v), want PR #3", prNum, ok)
+	}
+}
+
+func TestReconcileSelectionClampsWhenSelectedPRGone(t *testing.T) {
+	prevStates := []*run.State{
+		{ID: "a", Prompt: "p", TargetRepo: strPtr("r"), PRURL: strPtr("https://github.com/o/r/pull/1"), CreatedAt: "2026-01-01T00:00:00Z"},
+		{ID: "b", Prompt: "p", TargetRepo: strPtr("r"), PRURL: strPtr("https://github.com/o/r/pull/2"), CreatedAt: "2026-01-01T00:01:00Z"},
+	}
+	m := dashboardModel{states: prevStates, cursor: 1} // selecting PR #2
+	prev := selectablePRs(m.states)
+
+	// PR #2 removed; only PR #1 remains. Cursor must clamp to a valid index.
+	m.states = []*run.State{prevStates[0]}
+	m.reconcileSelection(prev)
+
+	if m.cursor != 0 {
+		t.Errorf("cursor = %d, want clamped to 0", m.cursor)
+	}
+	if _, prNum, ok := m.selectedPR(); !ok || prNum != "1" {
+		t.Errorf("selection = %q (ok=%v), want PR #1", prNum, ok)
+	}
+}
+
+func TestDiscussPRSendsLiteralPromptAndFocuses(t *testing.T) {
+	fake := &captureTmux{}
+	m := dashboardModel{tmux: fake}
+
+	if err := m.discussPR("583", "%7"); err != nil {
+		t.Fatalf("discussPR: %v", err)
+	}
+	if want := "WRT PR#583: "; fake.sentKeys != want {
+		t.Errorf("SendKeys keys = %q, want %q", fake.sentKeys, want)
+	}
+	if fake.sentPane != "%7" {
+		t.Errorf("SendKeys pane = %q, want %q", fake.sentPane, "%7")
+	}
+	if fake.focusPane != "%7" {
+		t.Errorf("SelectPane pane = %q, want %q", fake.focusPane, "%7")
+	}
+}
+
+func TestCoordinatorPaneFromSessionState(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := run.NewHomeDirStoreFromPath(tmpDir)
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+
+	sessionID := "20260101-0000-sess"
+	pane := "%3"
+	if err := store.Save(&run.State{ID: sessionID, Type: "session", CoordinatorPane: &pane, CreatedAt: "2026-01-01T00:00:00Z"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	t.Setenv(sessionIDEnv, sessionID)
+
+	m := dashboardModel{store: store}
+	if got := m.coordinatorPane(); got != pane {
+		t.Errorf("coordinatorPane() = %q, want %q", got, pane)
+	}
+
+	// A session without a coordinator pane (older session) yields "".
+	if err := store.Save(&run.State{ID: sessionID, Type: "session", CreatedAt: "2026-01-01T00:00:00Z"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if got := m.coordinatorPane(); got != "" {
+		t.Errorf("coordinatorPane() = %q, want empty for older session", got)
+	}
+}
+
+func TestApproveSelectedPRMarksRightRun(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := run.NewHomeDirStoreFromPath(tmpDir)
+	if err := store.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+
+	states := []*run.State{
+		{ID: "r1", Prompt: "p", Branch: "b1", TargetRepo: strPtr("r"), PRURL: strPtr("https://github.com/o/r/pull/11"), CreatedAt: "2026-01-01T00:00:00Z"},
+		{ID: "r2", Prompt: "p", Branch: "b2", TargetRepo: strPtr("r"), PRURL: strPtr("https://github.com/o/r/pull/22"), CreatedAt: "2026-01-01T00:01:00Z"},
+	}
+	for _, s := range states {
+		if err := store.Save(s); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+	}
+
+	// Cursor on the second PR (#22). Approve via the same path the 'a' key uses.
+	m := dashboardModel{store: store, states: states, cursor: 1}
+	entries := selectablePRs(m.states)
+	e := entries[clampCursor(m.cursor, len(entries))]
+	if e.prNum != "22" {
+		t.Fatalf("selected PR = %s, want 22", e.prNum)
+	}
+	if err := markApproved(e.state, m.store); err != nil {
+		t.Fatalf("markApproved: %v", err)
+	}
+
+	s22, _ := store.Load("r2")
+	if s22.Approved == nil || !*s22.Approved {
+		t.Error("PR #22 should be approved")
+	}
+	s11, _ := store.Load("r1")
+	if s11.Approved != nil {
+		t.Error("PR #11 should not be approved")
+	}
+}

--- a/internal/cmd/dashboard_select_test.go
+++ b/internal/cmd/dashboard_select_test.go
@@ -11,7 +11,7 @@ import (
 // captureTmux is a tmux.Client that records SendKeys/SelectPane calls so tests
 // can assert on the literal text and pane id sent to the coordinator.
 type captureTmux struct {
-	tmux.ExecClient
+	tmux.Client
 	sentPane  string
 	sentKeys  string
 	focusPane string

--- a/internal/cmd/dashboard_test.go
+++ b/internal/cmd/dashboard_test.go
@@ -535,7 +535,7 @@ func TestRenderPRLine(t *testing.T) {
 	}
 
 	// Without GitHub status
-	line := m.renderPRLine("42", []*run.State{s},nil)
+	line := m.renderPRLine("42", []*run.State{s}, nil, false)
 	if !strings.Contains(line, "#42") {
 		t.Error("should contain PR number")
 	}
@@ -553,7 +553,7 @@ func TestRenderPRLine(t *testing.T) {
 		CI:        "passing",
 		Conflicts: "yes",
 	}
-	line = m.renderPRLine("42", []*run.State{s},ps)
+	line = m.renderPRLine("42", []*run.State{s}, ps, false)
 	if !strings.Contains(line, "CI ✓") {
 		t.Error("should show passing CI")
 	}
@@ -563,7 +563,7 @@ func TestRenderPRLine(t *testing.T) {
 
 	// Merged PR
 	ps.State = "MERGED"
-	line = m.renderPRLine("42", []*run.State{s}, ps)
+	line = m.renderPRLine("42", []*run.State{s}, ps, false)
 	if !strings.Contains(line, "MERGED") {
 		t.Error("should show MERGED")
 	}
@@ -579,7 +579,7 @@ func TestRenderPRLineHyperlink(t *testing.T) {
 		Type:   "launch",
 		PRURL:  strPtr("https://github.com/o/r/pull/42"),
 	}
-	line := m.renderPRLine("42", []*run.State{withURL}, nil)
+	line := m.renderPRLine("42", []*run.State{withURL}, nil, false)
 	want := hyperlink("https://github.com/o/r/pull/42", "#42   ")
 	if !strings.Contains(line, want) {
 		t.Errorf("expected OSC 8 hyperlink %q in line %q", want, line)
@@ -587,12 +587,33 @@ func TestRenderPRLineHyperlink(t *testing.T) {
 
 	// Without a PR URL, there is no escape sequence and the number is plain.
 	noURL := &run.State{ID: "id", Prompt: "fix bug", Type: "launch"}
-	line = m.renderPRLine("42", []*run.State{noURL}, nil)
+	line = m.renderPRLine("42", []*run.State{noURL}, nil, false)
 	if strings.Contains(line, "\x1b]8;;") {
 		t.Errorf("expected no OSC 8 hyperlink when PRURL is nil, got %q", line)
 	}
 	if !strings.Contains(line, "#42") {
 		t.Errorf("expected plain PR number when PRURL is nil, got %q", line)
+	}
+}
+
+func TestRenderPRLineSelectedWithHyperlink(t *testing.T) {
+	m := dashboardModel{width: 80, tmuxDeps: testDashboardTmuxDeps(), ghStatus: map[string]*prStatus{}}
+	s := &run.State{
+		ID:     "20260307-0900-aaaa",
+		Prompt: "fix bug",
+		Type:   "launch",
+		PRURL:  strPtr("https://github.com/o/r/pull/42"),
+	}
+
+	// A selected row must show BOTH the selection gutter marker and keep the
+	// OSC 8 hyperlink on the PR number intact (lipgloss styling must not strip
+	// the hyperlink escape).
+	line := m.renderPRLine("42", []*run.State{s}, nil, true)
+	if !strings.Contains(line, "> ") {
+		t.Errorf("selected row should show the '> ' gutter marker, got %q", line)
+	}
+	if !strings.Contains(line, "\x1b]8;;https://github.com/o/r/pull/42\x1b\\") {
+		t.Errorf("selected row should preserve the OSC 8 hyperlink, got %q", line)
 	}
 }
 
@@ -636,7 +657,7 @@ func TestRenderPRLineApproval(t *testing.T) {
 	}
 
 	// No approval — should not show indicator
-	line := m.renderPRLine("10", []*run.State{base}, &prStatus{State: "OPEN"})
+	line := m.renderPRLine("10", []*run.State{base}, &prStatus{State: "OPEN"}, false)
 	if strings.Contains(line, "approved") {
 		t.Error("should not show approved when not approved")
 	}
@@ -644,7 +665,7 @@ func TestRenderPRLineApproval(t *testing.T) {
 	// Single run approved
 	approvedRun := *base
 	approvedRun.Approved = &approved
-	line = m.renderPRLine("10", []*run.State{&approvedRun}, &prStatus{State: "OPEN"})
+	line = m.renderPRLine("10", []*run.State{&approvedRun}, &prStatus{State: "OPEN"}, false)
 	if !strings.Contains(line, "approved") {
 		t.Error("should show approved indicator")
 	}
@@ -652,13 +673,13 @@ func TestRenderPRLineApproval(t *testing.T) {
 	// Multiple runs, only second is approved
 	notApprovedRun := *base
 	notApprovedRun.Approved = &notApproved
-	line = m.renderPRLine("10", []*run.State{&notApprovedRun, &approvedRun}, &prStatus{State: "OPEN"})
+	line = m.renderPRLine("10", []*run.State{&notApprovedRun, &approvedRun}, &prStatus{State: "OPEN"}, false)
 	if !strings.Contains(line, "approved") {
 		t.Error("should show approved when any run is approved")
 	}
 
 	// Approved but MERGED — should not show indicator
-	line = m.renderPRLine("10", []*run.State{&approvedRun}, &prStatus{State: "MERGED"})
+	line = m.renderPRLine("10", []*run.State{&approvedRun}, &prStatus{State: "MERGED"}, false)
 	if strings.Contains(line, "approved") {
 		t.Error("should not show approved for merged PRs")
 	}

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -319,6 +319,13 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 		tmuxClient.RenameWindow(ctx, currentPane, windowTitle)
 		tmuxClient.SetWindowOption(ctx, currentPane, "pane-border-status", "top")
 		tmuxClient.SetWindowOption(ctx, currentPane, "pane-border-format", "#{pane_title}")
+
+		// Persist the coordinator pane so the dashboard can route "discuss"
+		// requests (the 'd' keybinding) to this Claude session.
+		state.CoordinatorPane = &currentPane
+		if err := store.Save(state); err != nil {
+			slog.Warn("failed to persist coordinator pane", "id", state.ID, "err", err)
+		}
 	}
 
 	fmt.Println()

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -22,10 +22,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	klausSessionIDEnv = "KLAUS_SESSION_ID"
-)
-
 var sessionCmd = &cobra.Command{
 	Use:   "session",
 	Short: "Start or resume an interactive coordinator session",
@@ -376,7 +372,7 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 	claude.Stdin = os.Stdin
 	claude.Stdout = os.Stdout
 	claude.Stderr = os.Stderr
-	claude.Env = append(os.Environ(), klausSessionIDEnv+"="+id)
+	claude.Env = append(os.Environ(), sessionIDEnv+"="+id)
 	claude.Run() // ignore error — user may exit normally
 
 	fmt.Println()

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -12,31 +12,32 @@ import (
 
 // State represents the persistent state of a single agent run.
 type State struct {
-	ID         string   `json:"id"`
-	Prompt     string   `json:"prompt"`
-	Issue      *string  `json:"issue"`
-	PR         *string  `json:"pr,omitempty"`
-	Branch     string   `json:"branch"`
-	Worktree   string   `json:"worktree"`
-	TmuxPane   *string  `json:"tmux_pane"`
-	Budget     *string  `json:"budget"`
-	LogFile    *string  `json:"log_file"`
-	CreatedAt  string   `json:"created_at"`
-	CostUSD    *float64 `json:"cost_usd"`
-	DurationMS *int64   `json:"duration_ms"`
-	PRURL      *string  `json:"pr_url"`
-	Type       string   `json:"type,omitempty"`
-	TargetRepo *string  `json:"target_repo,omitempty"`
-	CloneDir   *string  `json:"clone_dir,omitempty"`
-	Host           *string  `json:"host,omitempty"`
-	MergedAt       *string  `json:"merged_at,omitempty"`
-	DashboardPane  *string  `json:"dashboard_pane,omitempty"`
-	Approved       *bool    `json:"approved,omitempty"`
-	ApprovedAt     *string  `json:"approved_at,omitempty"`
-	SessionName      *string  `json:"session_name,omitempty"`       // claude -n name, same as run ID
-	OriginalRunID    *string  `json:"original_run_id,omitempty"`   // run ID this was forked from
-	ClaudeSessionID  *string  `json:"claude_session_id,omitempty"` // Claude conversation UUID for --resume
-	RepoRoot         *string  `json:"repo_root,omitempty"`         // absolute path to base repo for worktree recreation
+	ID              string   `json:"id"`
+	Prompt          string   `json:"prompt"`
+	Issue           *string  `json:"issue"`
+	PR              *string  `json:"pr,omitempty"`
+	Branch          string   `json:"branch"`
+	Worktree        string   `json:"worktree"`
+	TmuxPane        *string  `json:"tmux_pane"`
+	Budget          *string  `json:"budget"`
+	LogFile         *string  `json:"log_file"`
+	CreatedAt       string   `json:"created_at"`
+	CostUSD         *float64 `json:"cost_usd"`
+	DurationMS      *int64   `json:"duration_ms"`
+	PRURL           *string  `json:"pr_url"`
+	Type            string   `json:"type,omitempty"`
+	TargetRepo      *string  `json:"target_repo,omitempty"`
+	CloneDir        *string  `json:"clone_dir,omitempty"`
+	Host            *string  `json:"host,omitempty"`
+	MergedAt        *string  `json:"merged_at,omitempty"`
+	DashboardPane   *string  `json:"dashboard_pane,omitempty"`
+	CoordinatorPane *string  `json:"coordinator_pane,omitempty"` // tmux pane running the coordinator/claude session
+	Approved        *bool    `json:"approved,omitempty"`
+	ApprovedAt      *string  `json:"approved_at,omitempty"`
+	SessionName     *string  `json:"session_name,omitempty"`      // claude -n name, same as run ID
+	OriginalRunID   *string  `json:"original_run_id,omitempty"`   // run ID this was forked from
+	ClaudeSessionID *string  `json:"claude_session_id,omitempty"` // Claude conversation UUID for --resume
+	RepoRoot        *string  `json:"repo_root,omitempty"`         // absolute path to base repo for worktree recreation
 }
 
 // TmuxDeps abstracts tmux pane operations so callers can inject test doubles.

--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -53,6 +53,12 @@ type Client interface {
 
 	// RenameWindow renames the tmux window containing the target pane.
 	RenameWindow(ctx context.Context, target, name string) error
+
+	// SendKeys types literal text into a pane (does not press Enter).
+	SendKeys(ctx context.Context, paneID, keys string) error
+
+	// SelectPane moves tmux focus to the given pane.
+	SelectPane(ctx context.Context, paneID string) error
 }
 
 // ExecClient implements Client by shelling out to the tmux binary.
@@ -117,4 +123,12 @@ func (c *ExecClient) SetWindowOption(ctx context.Context, target, option, value 
 
 func (c *ExecClient) RenameWindow(ctx context.Context, target, name string) error {
 	return RenameWindow(ctx, target, name)
+}
+
+func (c *ExecClient) SendKeys(ctx context.Context, paneID, keys string) error {
+	return SendKeys(ctx, paneID, keys)
+}
+
+func (c *ExecClient) SelectPane(ctx context.Context, paneID string) error {
+	return SelectPane(ctx, paneID)
 }

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -194,6 +194,20 @@ func ensureTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(ctx, defaultTimeout)
 }
 
+// SendKeys types the given keys into a pane. The -l flag sends the keys
+// literally (as text input) rather than interpreting them as tmux key names,
+// so a string like "WRT PR#583: " is typed verbatim.
+func SendKeys(ctx context.Context, paneID, keys string) error {
+	_, err := runTmux(ctx, "send-keys", "-t", paneID, "-l", keys)
+	return err
+}
+
+// SelectPane moves tmux focus to the given pane.
+func SelectPane(ctx context.Context, paneID string) error {
+	_, err := runTmux(ctx, "select-pane", "-t", paneID)
+	return err
+}
+
 func runTmux(ctx context.Context, args ...string) (string, error) {
 	ctx, cancel := ensureTimeout(ctx)
 	defer cancel()


### PR DESCRIPTION
## Summary

Adds keyboard navigation to the `klaus dashboard` TUI so a PR row can be selected and acted on in place.

- **Move selection** — `j`/`k` or `↑`/`↓` move a highlighted selection across PR rows. The selection is clamped to the visible list and survives refreshes, staying on the same PR when it still exists.
- **Approve** — `a` approves the selected PR immediately (no confirmation) via `markApproved`, then reloads state so the row shows `✓ approved`.
- **Discuss** — `d` pre-fills `WRT PR#<num>: ` in the coordinator (Claude) session pane and switches tmux focus there, leaving the prompt for the user to finish (no Enter is sent). When the coordinator pane id is unavailable (older sessions predating this change), it surfaces a transient hint instead of doing anything harmful.

## Implementation

- `run.State` gains `CoordinatorPane`; `klaus session` now persists the coordinator pane id so the dashboard can route discuss requests to it.
- `tmux.Client` gains `SendKeys` (using `send-keys -l` for literal text) and `SelectPane`, implemented on `ExecClient`.
- Selectable-PR list construction, cursor clamping, and selection reconciliation live in `internal/cmd/dashboard_select.go` and are unit tested. The selected row is rendered with a `>` gutter and a subtle background highlight; the footer/help text and README document the new keys.

## Testing

- `go build ./...`, `go vet ./...`, and `go test ./...` all pass.
- New tests cover selectable-list ordering/dedup, cursor clamping, selection reconciliation across reloads, `discussPR` sending the literal `WRT PR#<num>: ` and focusing the right pane (via a fake tmux client), coordinator-pane lookup from session state, and approval targeting the correct run.

Run: 20260627-1711-218cdac5