### PR TITLE
fix(launch/finalize): best-effort cross-worktree resume + detect agent errors in finalize

### DIFF
--- a/internal/cmd/hidden.go
+++ b/internal/cmd/hidden.go
@@ -97,35 +97,21 @@ var finalizeCmd = &cobra.Command{
 
 		gitClient := git.NewExecClient()
 
-		// For a normal (non-budget) completion against an existing paused
-		// PR, clear the budget-paused label so the dashboard reflects that
-		// the follow-up agent shipped its work. Emit agent:resumed so the
-		// coordinator sees the resumption complete.
-		if !paused && baseDir != "" {
+		// For a normal (non-budget, non-crashed) completion against an
+		// existing paused PR, clear the budget-paused label so the dashboard
+		// reflects that the follow-up agent shipped its work. A crashed
+		// follow-up must NOT clear the label — the PR still needs work.
+		if !paused && state.FailureReason == nil && baseDir != "" {
 			clearLabelIfResumed(ctx, baseDir, state)
 		}
 
-		// Emit events for completed run. For paused runs, agent:completed
+		// Emit terminal events for the run. For paused runs, agent:completed
 		// is intentionally suppressed in favor of agent:paused, since the
 		// run is not "done" — it's parked in a draft PR awaiting continuation.
+		// A crashed run emits agent:needs-attention instead of falsely
+		// reporting agent:completed / agent:pr-created.
 		if baseDir != "" && !paused {
-			completedData := map[string]interface{}{"id": id}
-			if state.CostUSD != nil {
-				completedData["cost_usd"] = *state.CostUSD
-			}
-			if state.DurationMS != nil {
-				completedData["duration_ms"] = *state.DurationMS
-			}
-			emitEvent(baseDir, id, event.AgentCompleted, completedData)
-
-			if state.PRURL != nil && *state.PRURL != "" {
-				prNum := extractPRNumberFromURL(*state.PRURL)
-				emitEvent(baseDir, id, event.AgentPRCreated, map[string]interface{}{
-					"id":        id,
-					"pr_url":    *state.PRURL,
-					"pr_number": prNum,
-				})
-			}
+			emitFinalizeEvents(baseDir, state)
 		}
 		syncRunToDataRef(ctx, syncRoot, store, gitClient, cfg.DataRef, state)
 
@@ -137,6 +123,41 @@ var finalizeCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+// emitFinalizeEvents emits the terminal events for a finalized, non-paused
+// run. A crashed run (FailureReason set) emits agent:needs-attention and
+// nothing else, so a pipeline never mistakes a crash for a completed,
+// PR-creating run. A normal run emits agent:completed plus agent:pr-created
+// when a PR URL is known.
+func emitFinalizeEvents(baseDir string, state *run.State) {
+	if baseDir == "" {
+		return
+	}
+	if state.FailureReason != nil {
+		emitEvent(baseDir, state.ID, event.AgentNeedsAttention, map[string]interface{}{
+			"id":     state.ID,
+			"reason": *state.FailureReason,
+		})
+		return
+	}
+
+	completedData := map[string]interface{}{"id": state.ID}
+	if state.CostUSD != nil {
+		completedData["cost_usd"] = *state.CostUSD
+	}
+	if state.DurationMS != nil {
+		completedData["duration_ms"] = *state.DurationMS
+	}
+	emitEvent(baseDir, state.ID, event.AgentCompleted, completedData)
+
+	if state.PRURL != nil && *state.PRURL != "" {
+		emitEvent(baseDir, state.ID, event.AgentPRCreated, map[string]interface{}{
+			"id":        state.ID,
+			"pr_url":    *state.PRURL,
+			"pr_number": extractPRNumberFromURL(*state.PRURL),
+		})
+	}
 }
 
 // handleBudgetPauseIfNeeded decides whether the just-finalized run hit its
@@ -377,11 +398,14 @@ func finalizeFromLog(store run.StateStore, state *run.State) (string, error) {
 		}
 
 		var ev struct {
-			Type         string  `json:"type"`
-			Subtype      string  `json:"subtype"`
-			SessionID    string  `json:"session_id"`
-			TotalCostUSD float64 `json:"total_cost_usd"`
-			DurationMS   int64   `json:"duration_ms"`
+			Type         string   `json:"type"`
+			Subtype      string   `json:"subtype"`
+			SessionID    string   `json:"session_id"`
+			TotalCostUSD float64  `json:"total_cost_usd"`
+			DurationMS   int64    `json:"duration_ms"`
+			IsError      bool     `json:"is_error"`
+			NumTurns     int      `json:"num_turns"`
+			Errors       []string `json:"errors"`
 			Message      *struct {
 				Content []struct {
 					Type    string `json:"type"`
@@ -406,6 +430,27 @@ func finalizeFromLog(store run.StateStore, state *run.State) (string, error) {
 			}
 			if ev.Subtype != "" {
 				resultSubtype = ev.Subtype
+			}
+			// Detect a crashed agent. A result line like
+			// {"is_error":true,"subtype":"error_during_execution","num_turns":0,...}
+			// means claude never did any work (e.g. a cross-worktree --resume
+			// that couldn't find its conversation). Record the failure so
+			// _finalize raises agent:needs-attention instead of falsely
+			// reporting completion. A budget-cap result is handled separately
+			// by the budget-pause heuristic and is not treated as a crash here.
+			if ev.IsError || ev.Subtype == "error_during_execution" {
+				reason := ev.Subtype
+				if reason == "" {
+					reason = "error"
+				}
+				if len(ev.Errors) > 0 && ev.Errors[0] != "" {
+					reason += ": " + ev.Errors[0]
+				}
+				state.FailureReason = &reason
+			} else {
+				// A clean result clears any failure recorded by an earlier
+				// (partial) result line.
+				state.FailureReason = nil
 			}
 			// Record the Claude conversation UUID so a later budget-paused
 			// resume can restore the trajectory and run claude --resume.

--- a/internal/cmd/hidden_test.go
+++ b/internal/cmd/hidden_test.go
@@ -5,8 +5,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/patflynn/klaus/internal/event"
 	"github.com/patflynn/klaus/internal/git"
 	"github.com/patflynn/klaus/internal/run"
 	"github.com/patflynn/klaus/internal/tmux"
@@ -409,6 +411,63 @@ not valid json at all
 		assertPRURL(t, state, "https://github.com/owner/repo/pull/42")
 	})
 
+	t.Run("marks FailureReason on error_during_execution result", func(t *testing.T) {
+		// Mirrors the real crash: a cross-worktree --resume that exits
+		// instantly with no turns. _finalize must not treat this as success.
+		logContent := `{"type":"system","subtype":"init"}
+{"type":"result","subtype":"error_during_execution","is_error":true,"num_turns":0,"total_cost_usd":0,"errors":["No conversation found with session ID: deadbeef"]}
+`
+		state, store := setupFinalizeTest(t, logContent)
+		subtype, err := finalizeFromLog(store, state)
+		if err != nil {
+			t.Fatalf("finalizeFromLog() error: %v", err)
+		}
+		if subtype != "error_during_execution" {
+			t.Errorf("subtype = %q, want error_during_execution", subtype)
+		}
+		if state.FailureReason == nil {
+			t.Fatal("expected FailureReason to be set, got nil")
+		}
+		if !strings.Contains(*state.FailureReason, "error_during_execution") {
+			t.Errorf("FailureReason = %q, want it to mention the subtype", *state.FailureReason)
+		}
+		if !strings.Contains(*state.FailureReason, "No conversation found") {
+			t.Errorf("FailureReason = %q, want it to include the first error", *state.FailureReason)
+		}
+		// A crashed run had no PR; PRURL must stay nil.
+		if state.PRURL != nil {
+			t.Errorf("expected nil PRURL on crash, got %q", *state.PRURL)
+		}
+	})
+
+	t.Run("marks FailureReason when is_error is true without a subtype", func(t *testing.T) {
+		logContent := `{"type":"result","is_error":true,"total_cost_usd":0.2,"duration_ms":1000}
+`
+		state, store := setupFinalizeTest(t, logContent)
+		if _, err := finalizeFromLog(store, state); err != nil {
+			t.Fatalf("finalizeFromLog() error: %v", err)
+		}
+		if state.FailureReason == nil {
+			t.Fatal("expected FailureReason to be set when is_error is true")
+		}
+	})
+
+	t.Run("successful result leaves FailureReason nil and records cost", func(t *testing.T) {
+		logContent := `{"type":"assistant","message":{"content":[{"type":"text","text":"Done: https://github.com/owner/repo/pull/12"}]}}
+{"type":"result","subtype":"success","is_error":false,"num_turns":7,"total_cost_usd":1.25,"duration_ms":20000}
+`
+		state, store := setupFinalizeTest(t, logContent)
+		if _, err := finalizeFromLog(store, state); err != nil {
+			t.Fatalf("finalizeFromLog() error: %v", err)
+		}
+		if state.FailureReason != nil {
+			t.Errorf("expected nil FailureReason on success, got %q", *state.FailureReason)
+		}
+		assertCost(t, state, 1.25)
+		assertDuration(t, state, 20000)
+		assertPRURL(t, state, "https://github.com/owner/repo/pull/12")
+	})
+
 	t.Run("extracts PRURL from log when not set before finalization", func(t *testing.T) {
 		// Simulates new-PR mode: state.PRURL is nil until the agent runs
 		// `gh pr create`. Regex extraction fills it in from the log.
@@ -480,6 +539,94 @@ func TestExtractClaudeSessionID(t *testing.T) {
 			t.Errorf("ExtractClaudeSessionID() = %q, want UUID", got)
 		}
 	})
+}
+
+func TestEmitFinalizeEvents(t *testing.T) {
+	cost := 1.5
+	dur := int64(30000)
+	prURL := "https://github.com/owner/repo/pull/42"
+
+	t.Run("failed run emits needs-attention and nothing else", func(t *testing.T) {
+		baseDir := t.TempDir()
+		reason := "error_during_execution: No conversation found"
+		state := &run.State{
+			ID:            "20260628-0900-fail",
+			CostUSD:       &cost,
+			DurationMS:    &dur,
+			PRURL:         &prURL, // even with a stale URL, no pr-created on crash
+			FailureReason: &reason,
+		}
+
+		emitFinalizeEvents(baseDir, state)
+
+		types := eventTypesFor(t, baseDir, state.ID)
+		if len(types) != 1 || types[0] != event.AgentNeedsAttention {
+			t.Fatalf("expected only %q, got %v", event.AgentNeedsAttention, types)
+		}
+	})
+
+	t.Run("successful run with PR emits completed and pr-created", func(t *testing.T) {
+		baseDir := t.TempDir()
+		state := &run.State{
+			ID:         "20260628-0901-ok",
+			CostUSD:    &cost,
+			DurationMS: &dur,
+			PRURL:      &prURL,
+		}
+
+		emitFinalizeEvents(baseDir, state)
+
+		types := eventTypesFor(t, baseDir, state.ID)
+		if !containsEvent(types, event.AgentCompleted) {
+			t.Errorf("expected %q in %v", event.AgentCompleted, types)
+		}
+		if !containsEvent(types, event.AgentPRCreated) {
+			t.Errorf("expected %q in %v", event.AgentPRCreated, types)
+		}
+		if containsEvent(types, event.AgentNeedsAttention) {
+			t.Errorf("did not expect %q in %v", event.AgentNeedsAttention, types)
+		}
+	})
+
+	t.Run("successful run without PR emits completed only", func(t *testing.T) {
+		baseDir := t.TempDir()
+		state := &run.State{
+			ID:         "20260628-0902-nopr",
+			CostUSD:    &cost,
+			DurationMS: &dur,
+		}
+
+		emitFinalizeEvents(baseDir, state)
+
+		types := eventTypesFor(t, baseDir, state.ID)
+		if len(types) != 1 || types[0] != event.AgentCompleted {
+			t.Fatalf("expected only %q, got %v", event.AgentCompleted, types)
+		}
+	})
+}
+
+func eventTypesFor(t *testing.T, baseDir, runID string) []string {
+	t.Helper()
+	evts, err := event.NewLog(baseDir).Read()
+	if err != nil {
+		t.Fatalf("reading event log: %v", err)
+	}
+	var types []string
+	for _, e := range evts {
+		if e.RunID == runID {
+			types = append(types, e.Type)
+		}
+	}
+	return types
+}
+
+func containsEvent(types []string, want string) bool {
+	for _, ty := range types {
+		if ty == want {
+			return true
+		}
+	}
+	return false
 }
 
 func writeTestLog(t *testing.T, content string) string {

--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -292,24 +292,35 @@ are synced back after completion. Use --local to force local execution, or
 		logFile := filepath.Join(store.LogDir(), id+".jsonl")
 
 		// Resolve the Claude session UUID from the previous run's JSONL log.
-		// claude --resume expects a UUID v4, not the klaus run ID. The session
-		// must also still exist on disk under ~/.claude/projects/; if it's
-		// been cleaned up, claude --resume exits at startup with 0 turns.
+		// claude --resume expects a UUID v4, not the klaus run ID.
+		//
+		// Claude Code scopes conversation transcripts by working directory
+		// (~/.claude/projects/<encoded-cwd>/<uuid>.jsonl). This new agent runs
+		// in a fresh worktree, so 'claude --resume' would look in the wrong
+		// project dir and exit at startup with 0 turns ("No conversation found
+		// with session ID"). To make resume work across worktrees we stage the
+		// prior transcript into this worktree's project dir before launching.
+		//
+		// Resume is an OPTIMIZATION, never a requirement: if the prior run
+		// crashed, or its transcript can't be located/copied, we silently
+		// start a fresh claude session instead of risking a no-op launch.
 		var resolvedResume string
 		if resumeFrom != "" {
 			if s, loadErr := store.Load(resumeFrom); loadErr == nil && s.LogFile != nil {
-				candidate := ExtractClaudeSessionID(*s.LogFile)
-				if candidate != "" {
-					if claudeSessionExists(candidate) {
+				if s.FailureReason != nil {
+					// Don't chain onto a crashed conversation.
+					fmt.Fprintf(os.Stderr, "warning: prior run %s failed (%s); starting fresh instead of resuming\n", resumeFrom, *s.FailureReason)
+				} else if candidate := ExtractClaudeSessionID(*s.LogFile); candidate != "" {
+					if stageResumeTranscript(s, candidate, worktree) {
 						resolvedResume = candidate
 					} else {
-						fmt.Fprintf(os.Stderr, "warning: prior Claude session %s no longer exists on disk, starting fresh\n", candidate)
+						fmt.Fprintf(os.Stderr, "warning: could not stage prior Claude conversation %s for resume, starting fresh\n", candidate)
 					}
 				}
 			}
 			// If we couldn't extract a session UUID (e.g., previous agent
-			// also failed with no output) or the session has been cleaned
-			// up, skip --resume entirely and let claude start fresh.
+			// also failed with no output) or the transcript is missing,
+			// skip --resume entirely and let claude start fresh.
 		}
 
 		// Budget-paused PR continuation (issue #261): when launching against a

--- a/internal/cmd/launch_test.go
+++ b/internal/cmd/launch_test.go
@@ -603,6 +603,78 @@ func TestResumeFallsBackWhenSessionMissing(t *testing.T) {
 	}
 }
 
+// TestStageResumeTranscript covers Bug 1: 'claude --resume' scopes
+// conversation transcripts by working directory, so a resume launched in a new
+// worktree can't find the prior conversation. stageResumeTranscript copies the
+// transcript into the new worktree's project dir before launch, and falls back
+// to a fresh session (no --resume) when the source transcript is absent.
+func TestStageResumeTranscript(t *testing.T) {
+	const uuid = "79dcfb08-4de4-45f4-b7db-056bccbc3a00"
+
+	t.Run("copies transcript into new worktree project dir", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+
+		oldWorktree := "/tmp/klaus-sessions/klaus/old-run"
+		newWorktree := "/tmp/klaus-sessions/klaus/new-run"
+
+		// Write the prior conversation transcript into the OLD worktree's
+		// project dir, the way claude itself would.
+		src := claudeConversationPath(oldWorktree, uuid)
+		if err := os.MkdirAll(filepath.Dir(src), 0o755); err != nil {
+			t.Fatalf("MkdirAll src: %v", err)
+		}
+		if err := os.WriteFile(src, []byte(`{"sessionId":"`+uuid+`"}`+"\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile src: %v", err)
+		}
+
+		prevState := &run.State{
+			ID:              "20260628-1000-old",
+			Worktree:        oldWorktree,
+			ClaudeSessionID: strPtr(uuid),
+		}
+
+		if !stageResumeTranscript(prevState, uuid, newWorktree) {
+			t.Fatal("stageResumeTranscript = false, want true when source transcript exists")
+		}
+
+		dest := claudeConversationPath(newWorktree, uuid)
+		if _, err := os.Stat(dest); err != nil {
+			t.Fatalf("expected transcript copied to %q: %v", dest, err)
+		}
+
+		// With staging done, the launched command resumes the session.
+		cmd := buildClaudeCommand("sys", "5", "fix conflicts", "20260628-1001-new", uuid)
+		if !strings.Contains(cmd, "--resume '"+uuid+"'") {
+			t.Errorf("expected --resume after successful staging, got: %s", cmd)
+		}
+	})
+
+	t.Run("falls back to fresh session when source transcript is absent", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+
+		prevState := &run.State{
+			ID:              "20260628-1000-old",
+			Worktree:        "/tmp/klaus-sessions/klaus/old-run",
+			ClaudeSessionID: strPtr(uuid),
+		}
+
+		newWorktree := "/tmp/klaus-sessions/klaus/new-run"
+		if stageResumeTranscript(prevState, uuid, newWorktree) {
+			t.Fatal("stageResumeTranscript = true, want false when source transcript is missing")
+		}
+
+		// The caller leaves resolvedResume empty, so no --resume flag.
+		cmd := buildClaudeCommand("sys", "5", "fix conflicts", "20260628-1001-new", "")
+		if strings.Contains(cmd, "--resume") {
+			t.Errorf("expected no --resume when staging failed, got: %s", cmd)
+		}
+	})
+}
+
 func TestLaunchCmdHasPRFlag(t *testing.T) {
 	// Verify the --pr flag is registered on the launch command
 	f := launchCmd.Flags().Lookup("pr")

--- a/internal/cmd/replay.go
+++ b/internal/cmd/replay.go
@@ -118,6 +118,45 @@ func findResumeConversation(state *run.State) string {
 	return findClaudeConversationFile(uuid)
 }
 
+// stageResumeTranscript copies a prior run's Claude conversation transcript
+// into newWorktree's project dir so 'claude --resume <sessionUUID>' launched
+// there can find it. Claude scopes transcripts by working directory, so a
+// resume in a different worktree would otherwise fail with 0 turns.
+//
+// It is best-effort and self-healing: it returns true only when the transcript
+// is present at the destination and ready to resume. On any miss (the source
+// transcript is gone, the project dir can't be resolved, or the copy fails) it
+// returns false so the caller starts a fresh session — a launched agent must
+// never crash because a conversation is missing.
+func stageResumeTranscript(prevState *run.State, sessionUUID, newWorktree string) bool {
+	if !validSessionUUID(sessionUUID) {
+		return false
+	}
+	src := findResumeConversation(prevState)
+	if src == "" {
+		return false
+	}
+	dest := claudeConversationPath(newWorktree, sessionUUID)
+	if dest == "" {
+		return false
+	}
+	if src == dest {
+		// Already in the right place (e.g. same worktree) — nothing to copy.
+		return true
+	}
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return false
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return false
+	}
+	if err := os.WriteFile(dest, data, 0o600); err != nil {
+		return false
+	}
+	return true
+}
+
 // extractConversationSessionID reads the sessionId (camelCase) from a
 // conversation-format JSONL blob. Returns "" if none is found.
 func extractConversationSessionID(data []byte) string {

--- a/internal/cmd/replay_test.go
+++ b/internal/cmd/replay_test.go
@@ -248,11 +248,27 @@ func TestReplayFallbacks(t *testing.T) {
 }
 
 func TestEncodeProjectPath(t *testing.T) {
-	// Claude replaces both '/' and '.' with '-'.
-	got := encodeProjectPath("/tmp/klaus-sessions/k/2026.06")
-	want := "-tmp-klaus-sessions-k-2026-06"
-	if got != want {
-		t.Errorf("encodeProjectPath = %q, want %q", got, want)
+	// Claude replaces both '/' and '.' with '-'. These cases are derived from
+	// real ~/.claude/projects/ directory names on this machine.
+	tests := []struct {
+		cwd  string
+		want string
+	}{
+		{"/tmp/klaus-sessions/k/2026.06", "-tmp-klaus-sessions-k-2026-06"},
+		{
+			"/tmp/klaus-sessions/klaus/20260627-1721-bcde1ba8",
+			"-tmp-klaus-sessions-klaus-20260627-1721-bcde1ba8",
+		},
+		{
+			// '/.klaus' becomes '--klaus' because both '/' and '.' map to '-'.
+			"/home/patrick/.klaus/sessions/abc-workspace",
+			"-home-patrick--klaus-sessions-abc-workspace",
+		},
+	}
+	for _, tt := range tests {
+		if got := encodeProjectPath(tt.cwd); got != tt.want {
+			t.Errorf("encodeProjectPath(%q) = %q, want %q", tt.cwd, got, tt.want)
+		}
 	}
 }
 

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -38,6 +38,7 @@ type State struct {
 	OriginalRunID   *string  `json:"original_run_id,omitempty"`   // run ID this was forked from
 	ClaudeSessionID *string  `json:"claude_session_id,omitempty"` // Claude conversation UUID for --resume
 	RepoRoot        *string  `json:"repo_root,omitempty"`         // absolute path to base repo for worktree recreation
+	FailureReason   *string  `json:"failure_reason,omitempty"`    // set when the agent crashed (e.g. error_during_execution); suppresses success events and blocks resume chaining
 }
 
 // TmuxDeps abstracts tmux pane operations so callers can inject test doubles.


### PR DESCRIPTION
## Summary

Fixes two related bugs diagnosed from a real failure: a pipeline-dispatched conflict-fix agent crashed instantly (`error_during_execution`, `is_error:true`, `num_turns:0`, "No conversation found with session ID") yet klaus recorded it as a successful `pr-created` run — so the pipeline thought a merge conflict was resolved when nothing happened.

### Bug 1 — cross-worktree `claude --resume` crashes the agent
Claude Code scopes conversation transcripts by working directory (`~/.claude/projects/<encoded-cwd>/<uuid>.jsonl`). When klaus resumed a prior run in a **new** worktree, `claude --resume` looked in the wrong project dir and exited at startup with `num_turns:0`.

- Before launch, stage the prior run's transcript into the new worktree's project dir (`stageResumeTranscript`) so resume can find it.
- **Self-healing fallback invariant:** a launched agent never crashes for a missing conversation. If the source transcript is absent or the copy fails, we silently drop `--resume` and start fresh (logging a warning).
- Don't chain onto a crashed prior run — if its `FailureReason` is set, skip `--resume`.

### Bug 2 — `_finalize` treats a crashed agent as success
`finalizeFromLog` only parsed `type`/`total_cost_usd`/`duration_ms` and ignored the result line's error fields, so `_finalize` always emitted `agent:completed` + `agent:pr-created`.

- Capture `is_error`/`subtype`/`num_turns`/`errors` from the result line.
- Add `FailureReason *string` to `run.State`; set it on a crashed result (`is_error==true` or `subtype=="error_during_execution"`).
- On a failed run, emit `agent:needs-attention` and suppress `agent:completed`/`agent:pr-created` (and skip clearing the budget-paused label). Budget-cap pauses take priority and are unaffected; successful runs behave exactly as before.

## Tests
- `encodeProjectPath`: the two real example paths map to expected project-dir names (including `/.klaus` → `--klaus`).
- `finalizeFromLog`: an `error_during_execution` line sets `FailureReason` and leaves `PRURL` nil; a success line leaves `FailureReason` nil and records cost/duration/PR URL.
- `emitFinalizeEvents`: a failed run emits only `agent:needs-attention`; a successful run emits `agent:completed` (+ `agent:pr-created` when a PR URL exists).
- `stageResumeTranscript`: copies the transcript across worktrees and keeps `--resume`; falls back to a fresh session (no `--resume`) when the source is absent.

`go build ./...`, `go vet ./...`, and `go test ./...` all pass. `klaus _pre-review` reports no findings.

Run: 20260628-0756-83315f53