### PR TITLE
fix(launch/finalize): guard against nil run state in resume and finalize (gemini #277 follow-up)

### DIFF
--- a/internal/cmd/hidden.go
+++ b/internal/cmd/hidden.go
@@ -131,7 +131,7 @@ var finalizeCmd = &cobra.Command{
 // PR-creating run. A normal run emits agent:completed plus agent:pr-created
 // when a PR URL is known.
 func emitFinalizeEvents(baseDir string, state *run.State) {
-	if baseDir == "" {
+	if state == nil || baseDir == "" {
 		return
 	}
 	if state.FailureReason != nil {

--- a/internal/cmd/hidden_test.go
+++ b/internal/cmd/hidden_test.go
@@ -697,6 +697,13 @@ func (s *testStateStore) EnsureDirs() error {
 	return nil
 }
 
+// TestEmitFinalizeEventsNilState covers the gemini #277 follow-up: the finalize
+// path must no-op rather than dereference a nil run state.
+func TestEmitFinalizeEventsNilState(t *testing.T) {
+	// Should return early without panicking.
+	emitFinalizeEvents(t.TempDir(), nil)
+}
+
 func assertPRURL(t *testing.T, state *run.State, want string) {
 	t.Helper()
 	if state.PRURL == nil {

--- a/internal/cmd/launch.go
+++ b/internal/cmd/launch.go
@@ -306,7 +306,7 @@ are synced back after completion. Use --local to force local execution, or
 		// start a fresh claude session instead of risking a no-op launch.
 		var resolvedResume string
 		if resumeFrom != "" {
-			if s, loadErr := store.Load(resumeFrom); loadErr == nil && s.LogFile != nil {
+			if s, loadErr := store.Load(resumeFrom); loadErr == nil && s != nil && s.LogFile != nil {
 				if s.FailureReason != nil {
 					// Don't chain onto a crashed conversation.
 					fmt.Fprintf(os.Stderr, "warning: prior run %s failed (%s); starting fresh instead of resuming\n", resumeFrom, *s.FailureReason)

--- a/internal/cmd/launch_test.go
+++ b/internal/cmd/launch_test.go
@@ -603,6 +603,35 @@ func TestResumeFallsBackWhenSessionMissing(t *testing.T) {
 	}
 }
 
+// TestResumeHandlesNilRunState covers the gemini #277 follow-up: store.Load
+// can return (nil, nil) when the run state is not found (no error, nil state).
+// The resolve block must guard with 's != nil' so it doesn't dereference a nil
+// state via s.LogFile — it should skip resume and launch a fresh session.
+func TestResumeHandlesNilRunState(t *testing.T) {
+	store := &testStateStore{state: nil} // Load returns (nil, nil)
+	resumeFrom := "20260509-1355-6139"
+
+	// Mirror the resolve block in launch.go RunE, including the nil guard.
+	var resolvedResume string
+	if resumeFrom != "" {
+		if s, loadErr := store.Load(resumeFrom); loadErr == nil && s != nil && s.LogFile != nil {
+			if s.FailureReason == nil {
+				if candidate := ExtractClaudeSessionID(*s.LogFile); candidate != "" {
+					resolvedResume = candidate
+				}
+			}
+		}
+	}
+
+	if resolvedResume != "" {
+		t.Errorf("resolvedResume = %q, want empty for nil run state", resolvedResume)
+	}
+	cmd := buildClaudeCommand("sys", "5", "do stuff", "20260509-1400-aaaa", resolvedResume)
+	if strings.Contains(cmd, "--resume") {
+		t.Errorf("expected no --resume flag for nil run state, got: %s", cmd)
+	}
+}
+
 // TestStageResumeTranscript covers Bug 1: 'claude --resume' scopes
 // conversation transcripts by working directory, so a resume launched in a new
 // worktree can't find the prior conversation. stageResumeTranscript copies the


### PR DESCRIPTION
## Summary

Re-applies two defensive nil-check guards that gemini-code-assist flagged on #277. The fixes were written but lost — #277 was merged manually before the review-fix commit landed, so main still lacked them.

## Fixes

**HIGH — potential nil pointer dereference (`internal/cmd/launch.go`)**
In the cross-worktree Claude-session resume logic, `store.Load(resumeFrom)` can return `(nil, nil)` when the run state is not found (no error, but nil state). The condition then dereferenced the nil state via `s.LogFile` and could panic. Added an `s != nil` guard so a `(nil, nil)` return is handled safely — resume is skipped and a fresh session launches.

**MEDIUM — defensive nil check (`internal/cmd/hidden.go`)**
`emitFinalizeEvents` could dereference a nil `state`. Added a `state == nil` check to its early-return guard so the function safely no-ops instead of panicking.

## Tests

- `TestResumeHandlesNilRunState` — exercises the `(nil, nil)` store.Load case for the resume path; asserts no panic and that `--resume` is omitted.
- `TestEmitFinalizeEventsNilState` — calls the finalize function with a nil state; asserts it no-ops without panic.

`go build ./...`, `go vet ./...`, and `go test ./...` all pass. `klaus _pre-review` reports no findings.

Run: 20260628-0813-0389000b
