### PR TITLE
feat(dashboard): open selected PR in browser (o) + webhook freshness indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,9 @@ The status dashboard shows these columns for each run:
 
 ### `klaus dashboard`
 
-Live TUI view of the PR pipeline. Groups runs by repository, auto-refreshes via filesystem watching and GitHub polling every 30s. Keyboard shortcuts: `j`/`k` (or `↑`/`↓`) move the PR selection, `a` approve the selected PR, `d` discuss the selected PR with the coordinator (pre-fills `WRT PR#<num>:` in the session pane and switches focus there), `r` force refresh, `q` quit.
+Live TUI view of the PR pipeline. Groups runs by repository, auto-refreshes via filesystem watching and GitHub polling every 30s. Keyboard shortcuts: `j`/`k` (or `↑`/`↓`) move the PR selection, `a` approve the selected PR, `d` discuss the selected PR with the coordinator (pre-fills `WRT PR#<num>:` in the session pane and switches focus there), `o` open the selected PR in a browser, `r` force refresh, `q` quit.
+
+When webhook mode is enabled, the data-source line shows a freshness indicator for the most recent webhook delivery (e.g. `· last event 5m`), color-coded as it ages (dim under 30m, yellow under 2h, red beyond). Note this surfaces the age of the last delivery, not delivery health — a long silence can mean a quiet repo or a broken delivery path, so it's a hint for a human to judge rather than a definitive check.
 
 ### `klaus approve`
 

--- a/internal/cmd/browser.go
+++ b/internal/cmd/browser.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// browserOpenCmd returns the command name and arguments needed to open url in
+// the system's default browser for the given GOOS. It is pure (no exec) so the
+// OS dispatch can be unit-tested in isolation.
+func browserOpenCmd(goos, url string) (string, []string, error) {
+	switch goos {
+	case "darwin":
+		return "open", []string{url}, nil
+	case "linux":
+		return "xdg-open", []string{url}, nil
+	case "windows":
+		return "cmd", []string{"/c", "start", url}, nil
+	default:
+		return "", nil, fmt.Errorf("unsupported OS: %s", goos)
+	}
+}
+
+// openInBrowser launches the system browser pointed at url. It uses Start (not
+// Run/Wait) so it never blocks the caller — the dashboard UI loop must stay
+// responsive while the browser process starts in the background.
+func openInBrowser(url string) error {
+	name, args, err := browserOpenCmd(runtime.GOOS, url)
+	if err != nil {
+		return err
+	}
+	return exec.Command(name, args...).Start()
+}

--- a/internal/cmd/browser.go
+++ b/internal/cmd/browser.go
@@ -2,21 +2,37 @@ package cmd
 
 import (
 	"fmt"
+	"net/url"
 	"os/exec"
 	"runtime"
 )
 
-// browserOpenCmd returns the command name and arguments needed to open url in
-// the system's default browser for the given GOOS. It is pure (no exec) so the
-// OS dispatch can be unit-tested in isolation.
-func browserOpenCmd(goos, url string) (string, []string, error) {
+// browserOpenCmd returns the command name and arguments needed to open rawURL
+// in the system's default browser for the given GOOS. It is pure (no exec) so
+// the OS dispatch can be unit-tested in isolation.
+//
+// rawURL must be an http or https URL. Validating the scheme rejects dangerous
+// schemes (file:, javascript:) and malformed input before it ever reaches a
+// system handler. On Windows we use rundll32 with url.dll,FileProtocolHandler
+// rather than "cmd /c start", which would otherwise run the URL through cmd.exe
+// — exposing it to shell-metacharacter injection (e.g. "&") and mishandling
+// URLs that need quoting.
+func browserOpenCmd(goos, rawURL string) (string, []string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", nil, fmt.Errorf("invalid URL %q: %w", rawURL, err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", nil, fmt.Errorf("unsupported URL scheme %q", parsed.Scheme)
+	}
+
 	switch goos {
 	case "darwin":
-		return "open", []string{url}, nil
+		return "open", []string{rawURL}, nil
 	case "linux":
-		return "xdg-open", []string{url}, nil
+		return "xdg-open", []string{rawURL}, nil
 	case "windows":
-		return "cmd", []string{"/c", "start", url}, nil
+		return "rundll32", []string{"url.dll,FileProtocolHandler", rawURL}, nil
 	default:
 		return "", nil, fmt.Errorf("unsupported OS: %s", goos)
 	}

--- a/internal/cmd/browser_test.go
+++ b/internal/cmd/browser_test.go
@@ -15,7 +15,7 @@ func TestBrowserOpenCmd(t *testing.T) {
 	}{
 		{"linux", "xdg-open", []string{url}, false},
 		{"darwin", "open", []string{url}, false},
-		{"windows", "cmd", []string{"/c", "start", url}, false},
+		{"windows", "rundll32", []string{"url.dll,FileProtocolHandler", url}, false},
 		{"plan9", "", nil, true},
 	}
 	for _, c := range cases {
@@ -35,6 +35,20 @@ func TestBrowserOpenCmd(t *testing.T) {
 		}
 		if !reflect.DeepEqual(args, c.wantArgs) {
 			t.Errorf("browserOpenCmd(%q) args = %v, want %v", c.goos, args, c.wantArgs)
+		}
+	}
+}
+
+func TestBrowserOpenCmd_InvalidURL(t *testing.T) {
+	invalidURLs := []string{
+		"ftp://github.com",
+		"file:///etc/passwd",
+		"javascript:alert(1)",
+		"invalid-url",
+	}
+	for _, u := range invalidURLs {
+		if _, _, err := browserOpenCmd("linux", u); err == nil {
+			t.Errorf("expected error for invalid URL %q, got nil", u)
 		}
 	}
 }

--- a/internal/cmd/browser_test.go
+++ b/internal/cmd/browser_test.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBrowserOpenCmd(t *testing.T) {
+	const url = "https://github.com/o/r/pull/42"
+	cases := []struct {
+		goos     string
+		wantName string
+		wantArgs []string
+		wantErr  bool
+	}{
+		{"linux", "xdg-open", []string{url}, false},
+		{"darwin", "open", []string{url}, false},
+		{"windows", "cmd", []string{"/c", "start", url}, false},
+		{"plan9", "", nil, true},
+	}
+	for _, c := range cases {
+		name, args, err := browserOpenCmd(c.goos, url)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("browserOpenCmd(%q): expected error, got nil", c.goos)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("browserOpenCmd(%q): unexpected error: %v", c.goos, err)
+			continue
+		}
+		if name != c.wantName {
+			t.Errorf("browserOpenCmd(%q) name = %q, want %q", c.goos, name, c.wantName)
+		}
+		if !reflect.DeepEqual(args, c.wantArgs) {
+			t.Errorf("browserOpenCmd(%q) args = %v, want %v", c.goos, args, c.wantArgs)
+		}
+	}
+}

--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -52,6 +52,7 @@ Keyboard shortcuts:
   j / k or ↑ / ↓  move the PR selection
   a               approve the selected PR
   d               discuss the selected PR with the coordinator
+  o               open the selected PR in a browser
   r               force refresh
   q               quit`,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -179,6 +180,11 @@ type dashboardModel struct {
 	// GitHub webhook.
 	internalEventCh <-chan event.Event
 	eventsPath      string // path to events.jsonl for the tail goroutine
+	// lastWebhookAt records the wall-clock time of the most recent webhook
+	// delivery (any event). The zero value means none received yet. It drives
+	// the footer freshness indicator; the existing 30s tick re-renders the view
+	// so the displayed age advances without a dedicated timer.
+	lastWebhookAt time.Time
 }
 
 func newDashboardModel(store run.StateStore, cfg config.Config, ghClient gh.Client) dashboardModel {
@@ -285,6 +291,26 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if err := m.discussPR(e.prNum, pane); err != nil {
 				m.noteError(fmt.Sprintf("discuss PR #%s: %v", e.prNum, err))
 			}
+		case "o":
+			// Open the selected PR in the system browser.
+			entries := selectablePRs(m.states)
+			if len(entries) == 0 {
+				break
+			}
+			e := entries[clampCursor(m.cursor, len(entries))]
+			if e.state == nil || e.state.PRURL == nil || *e.state.PRURL == "" {
+				break
+			}
+			url := *e.state.PRURL
+			prNum := e.prNum
+			// Fire-and-forget so Update stays clean and the UI never blocks on
+			// the browser launch. Surface a transient hint on failure.
+			return m, func() tea.Msg {
+				if err := openInBrowser(url); err != nil {
+					return errHintMsg{msg: fmt.Sprintf("open PR #%s: %v", prNum, err)}
+				}
+				return nil
+			}
 		}
 
 	case tea.WindowSizeMsg:
@@ -374,6 +400,9 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// via the same code path that polling uses. This eliminates
 		// the class of bugs where the webhook path diverges from polling.
 		ev := msg.event
+		// Record the delivery time for the footer freshness indicator. Every
+		// delivery counts, regardless of PRNumber/type.
+		m.lastWebhookAt = time.Now()
 		if ev.PRNumber != "" {
 			// Find run states that match this PR for a targeted fetch.
 			var matchedStates []*run.State
@@ -478,6 +507,9 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.watcher = msg
 		return m, watchFSCmd(msg)
 
+	case errHintMsg:
+		m.noteError(msg.msg)
+
 	case errMsg:
 		m.err = msg.err
 	}
@@ -535,6 +567,11 @@ func (m dashboardModel) View() string {
 			tag += fmt.Sprintf(" + reconcile: %s", formatDuration(m.reconcileEvery))
 		}
 		b.WriteString(dimStyle.Render(tag))
+		// Freshness indicator: humanized age of the last webhook delivery,
+		// color-coded so a long silence is visible. It re-renders on the
+		// existing 30s tick, so the displayed age advances without a new timer.
+		freshText, sev := webhookFreshnessText(m.lastWebhookAt, time.Now())
+		b.WriteString(webhookSeverityStyle(sev).Render(" · " + freshText))
 		b.WriteString("\n")
 	} else {
 		b.WriteString(dimStyle.Render("  polling: 30s"))
@@ -570,7 +607,7 @@ func (m dashboardModel) View() string {
 
 	// Footer
 	footer := dimStyle.Render(fmt.Sprintf(
-		"  %d/%d agents running | j/k move · a approve · d discuss | r refresh · q quit",
+		"  %d/%d agents running | j/k move · a approve · d discuss · o open | r refresh · q quit",
 		runningCount, totalCount,
 	))
 	b.WriteString(footer)

--- a/internal/cmd/dashboard_commands.go
+++ b/internal/cmd/dashboard_commands.go
@@ -47,6 +47,13 @@ type errMsg struct {
 	err error
 }
 
+// errHintMsg carries a transient, non-fatal hint to surface in the dashboard
+// (via the recentErrors strip) without triggering the fatal error screen that
+// errMsg does. Used by best-effort background actions like opening a browser.
+type errHintMsg struct {
+	msg string
+}
+
 type webhookMsg struct {
 	event webhook.Event
 }

--- a/internal/cmd/dashboard_render.go
+++ b/internal/cmd/dashboard_render.go
@@ -293,6 +293,77 @@ func shortRunID(id string) string {
 	return id[len(id)-4:]
 }
 
+// webhookSeverity classifies how stale the last webhook delivery is, for the
+// dashboard freshness indicator.
+type webhookSeverity int
+
+const (
+	webhookFresh webhookSeverity = iota // normal/idle — quiet, not necessarily broken
+	webhookStale                        // moderately old — worth a glance
+	webhookDead                         // very old — likely a broken delivery path
+)
+
+// Webhook freshness thresholds. Deliberately generous: a quiet repo is not a
+// broken one, so only escalate once an absence of deliveries is unusually long.
+const (
+	webhookStaleAfter = 30 * time.Minute
+	webhookDeadAfter  = 2 * time.Hour
+)
+
+// webhookFreshnessText returns the humanized indicator text and severity for
+// the last webhook delivery time, evaluated relative to now.
+//
+// Limitation: an absence of webhook events can mean either a genuinely quiet
+// repo or a broken delivery path (relay down, port firewalled, etc.). This
+// indicator only surfaces the AGE of the last delivery so a human can judge —
+// it is NOT a definitive health check.
+func webhookFreshnessText(lastWebhookAt, now time.Time) (string, webhookSeverity) {
+	if lastWebhookAt.IsZero() {
+		return "no events yet", webhookFresh
+	}
+	age := now.Sub(lastWebhookAt)
+	text := "last event " + humanizeDuration(age)
+	switch {
+	case age >= webhookDeadAfter:
+		return text, webhookDead
+	case age >= webhookStaleAfter:
+		return text, webhookStale
+	default:
+		return text, webhookFresh
+	}
+}
+
+// webhookSeverityStyle maps a freshness severity to its lipgloss style.
+func webhookSeverityStyle(sev webhookSeverity) lipgloss.Style {
+	switch sev {
+	case webhookDead:
+		return redStyle
+	case webhookStale:
+		return yellowStyle
+	default:
+		return dimStyle
+	}
+}
+
+// humanizeDuration renders a duration in a single compact unit, e.g. "12s",
+// "5m", "3h", "1d". Negative durations are clamped to "0s".
+func humanizeDuration(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		s := int(d.Seconds())
+		if s < 0 {
+			s = 0
+		}
+		return fmt.Sprintf("%ds", s)
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}
+
 // formatDuration renders a duration as "Xh Ym" or "Xm Ys".
 func formatDuration(d time.Duration) string {
 	d = d.Round(time.Minute)

--- a/internal/cmd/dashboard_webhook_test.go
+++ b/internal/cmd/dashboard_webhook_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/patflynn/klaus/internal/run"
+)
+
+func TestWebhookFreshnessText(t *testing.T) {
+	now := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name     string
+		last     time.Time
+		wantText string
+		wantSev  webhookSeverity
+	}{
+		{"zero", time.Time{}, "no events yet", webhookFresh},
+		{"10s fresh", now.Add(-10 * time.Second), "last event 10s", webhookFresh},
+		{"just under stale", now.Add(-(webhookStaleAfter - time.Second)), "last event 29m", webhookFresh},
+		{"at stale boundary", now.Add(-webhookStaleAfter), "last event 30m", webhookStale},
+		{"45m stale", now.Add(-45 * time.Minute), "last event 45m", webhookStale},
+		{"just under dead", now.Add(-(webhookDeadAfter - time.Second)), "last event 1h", webhookStale},
+		{"at dead boundary", now.Add(-webhookDeadAfter), "last event 2h", webhookDead},
+		{"5h dead", now.Add(-5 * time.Hour), "last event 5h", webhookDead},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			text, sev := webhookFreshnessText(c.last, now)
+			if text != c.wantText {
+				t.Errorf("text = %q, want %q", text, c.wantText)
+			}
+			if sev != c.wantSev {
+				t.Errorf("severity = %d, want %d", sev, c.wantSev)
+			}
+		})
+	}
+}
+
+func TestHumanizeDuration(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{-5 * time.Second, "0s"},
+		{0, "0s"},
+		{12 * time.Second, "12s"},
+		{59 * time.Second, "59s"},
+		{time.Minute, "1m"},
+		{5 * time.Minute, "5m"},
+		{59 * time.Minute, "59m"},
+		{time.Hour, "1h"},
+		{3 * time.Hour, "3h"},
+		{23 * time.Hour, "23h"},
+		{24 * time.Hour, "1d"},
+		{50 * time.Hour, "2d"},
+	}
+	for _, c := range cases {
+		if got := humanizeDuration(c.d); got != c.want {
+			t.Errorf("humanizeDuration(%v) = %q, want %q", c.d, got, c.want)
+		}
+	}
+}
+
+// TestSelectedPRURLForOpenHandler verifies the path the 'o' key uses:
+// selectablePRs + clampCursor yields the entry whose state carries the URL to
+// open in the browser.
+func TestSelectedPRURLForOpenHandler(t *testing.T) {
+	states := []*run.State{
+		{ID: "a", Prompt: "p", TargetRepo: strPtr("r"), PRURL: strPtr("https://github.com/o/r/pull/1"), CreatedAt: "2026-01-01T00:00:00Z"},
+		{ID: "b", Prompt: "p", TargetRepo: strPtr("r"), PRURL: strPtr("https://github.com/o/r/pull/2"), CreatedAt: "2026-01-01T00:01:00Z"},
+	}
+	m := dashboardModel{states: states, cursor: 1}
+
+	entries := selectablePRs(m.states)
+	e := entries[clampCursor(m.cursor, len(entries))]
+	if e.state == nil || e.state.PRURL == nil {
+		t.Fatal("selected entry has no PRURL")
+	}
+	if got := *e.state.PRURL; got != "https://github.com/o/r/pull/2" {
+		t.Errorf("selected PR URL = %q, want pull/2", got)
+	}
+}


### PR DESCRIPTION
Two small dashboard features, bundled because both touch `internal/cmd/dashboard.go`.

## Feature 1 — `o` opens the selected PR in a browser
- New `internal/cmd/browser.go` with a **pure** `browserOpenCmd(goos, url) (name, args, err)` (no exec) so the OS dispatch is unit-testable: `darwin`→`open`, `linux`→`xdg-open`, `windows`→`cmd /c start`, error for anything else.
- `openInBrowser` wraps it and uses `exec.Command(...).Start()` (not `Run`/`Wait`) so the UI never blocks on the launch.
- New `case "o":` in `Update()` reads the cursor-selected entry's `*state.PRURL`, guards against no selection / nil / empty URL (no-op), and fires the open as a fire-and-forget `tea.Cmd`. Failures surface as a transient hint via the existing `recentErrors` strip (new non-fatal `errHintMsg`); they never crash.
- Footer hint and cobra help text updated to include `o open`.

## Feature 3 — webhook freshness/staleness indicator
- New `lastWebhookAt time.Time` on `dashboardModel`, set on **every** webhook delivery in the `webhookMsg` handler.
- The data-source footer (webhook mode only) appends `· last event <age>` (or `· no events yet`), color-coded with generous, named thresholds: dim `<30m`, yellow `<2h`, red `≥2h` — a quiet repo isn't mistaken for a broken one.
- The pure `webhookFreshnessText(last, now) (text, severity)` + `humanizeDuration` helpers carry all the logic and are unit-tested at the boundaries. A code comment documents the inherent limitation: absence of events can mean a quiet repo *or* a broken delivery path, so this surfaces age for a human to judge and is not a health check.
- Reuses the existing 30s `tickMsg` re-render — **no new timer**.

## Tests
- `browserOpenCmd` for linux/darwin/windows + unknown-GOOS error.
- `webhookFreshnessText` (zero → "no events yet"; 10s → fresh/dim; 45m → yellow; 5h → red) and exact stale/dead boundaries.
- `humanizeDuration` across s/m/h/d incl. negative clamp.
- Selected-PR-URL path used by the `o` handler (selectablePRs + clampCursor).

`go build ./...`, `go vet ./...`, and `go test ./...` all pass.

Run: 20260628-0856-d96b4e30