### PR TITLE
fix(pipeline): stop unbounded review-fix redispatch on body-only trusted reviews

### DIFF
--- a/internal/cmd/review_check.go
+++ b/internal/cmd/review_check.go
@@ -134,9 +134,11 @@ func fetchPRReviews(ownerRepo, prNumber string) []ghReview {
 // fetchReviewIDsWithInlineComments calls gh api to get the inline review
 // comments on a PR and returns the set of review IDs that own at least one.
 // On error it returns nil (no review counts), which fails toward "no dispatch".
+// per_page=100 raises the default page size of 30, which would otherwise drop
+// newer reviews' comments on busy PRs and misread them as body-only.
 func fetchReviewIDsWithInlineComments(ownerRepo, prNumber string) map[int64]bool {
 	client := github.NewGHCLIClient("")
-	endpoint := "repos/" + ownerRepo + "/pulls/" + prNumber + "/comments"
+	endpoint := "repos/" + ownerRepo + "/pulls/" + prNumber + "/comments?per_page=100"
 	out, err := client.APIGet(context.TODO(), endpoint)
 	if err != nil {
 		return nil
@@ -157,10 +159,12 @@ func fetchReviewIDsWithInlineComments(ownerRepo, prNumber string) map[int64]bool
 // fetchLatestCommitTime calls gh api to get the latest commit time on a PR.
 // It uses the committer date, not the author date: author dates survive
 // rebases unchanged and can be arbitrarily old, which would falsely mark a
-// fresh push as predating the reviews it addresses.
+// fresh push as predating the reviews it addresses. The endpoint returns
+// commits oldest-first with a default page size of 30, so per_page=100 keeps
+// the newest commit in view on PRs with more than 30 commits.
 func fetchLatestCommitTime(ownerRepo, prNumber string) time.Time {
 	client := github.NewGHCLIClient("")
-	endpoint := "repos/" + ownerRepo + "/pulls/" + prNumber + "/commits"
+	endpoint := "repos/" + ownerRepo + "/pulls/" + prNumber + "/commits?per_page=100"
 	out, err := client.APIGet(context.TODO(), endpoint)
 	if err != nil {
 		return time.Time{}

--- a/internal/cmd/review_check.go
+++ b/internal/cmd/review_check.go
@@ -12,6 +12,7 @@ import (
 
 // ghReview represents a single review from the GitHub API.
 type ghReview struct {
+	ID          int64  `json:"id"`
 	User        ghUser `json:"user"`
 	State       string `json:"state"`
 	SubmittedAt string `json:"submitted_at"`
@@ -21,21 +22,28 @@ type ghUser struct {
 	Login string `json:"login"`
 }
 
+// ghReviewComment represents an inline review comment from the GitHub
+// pulls comments API. Only the parent review ID is needed here.
+type ghReviewComment struct {
+	PullRequestReviewID int64 `json:"pull_request_review_id"`
+}
+
 // ghCommit represents a commit from the GitHub pulls commits API.
 type ghCommit struct {
 	Commit ghCommitDetail `json:"commit"`
 }
 
 type ghCommitDetail struct {
-	Author ghCommitAuthor `json:"author"`
+	Committer ghCommitActor `json:"committer"`
 }
 
-type ghCommitAuthor struct {
+type ghCommitActor struct {
 	Date string `json:"date"`
 }
 
-// hasUnaddressedTrustedComments checks whether a PR has review comments from
-// trusted reviewers that haven't been addressed by a subsequent push.
+// hasUnaddressedTrustedComments checks whether a PR has inline review
+// comments from trusted reviewers that haven't been addressed by a
+// subsequent push.
 func hasUnaddressedTrustedComments(ownerRepo, prNumber string) bool {
 	cfg, err := config.Load("")
 	if err != nil || len(cfg.TrustedReviewers) == 0 {
@@ -53,14 +61,35 @@ func hasUnaddressedTrustedComments(ownerRepo, prNumber string) bool {
 		return false
 	}
 
-	// Find the most recent trusted reviewer review with state COMMENTED or CHANGES_REQUESTED.
-	var latestTrustedReviewTime time.Time
+	// Collect trusted reviewer reviews with state COMMENTED or CHANGES_REQUESTED.
+	var candidates []ghReview
 	for _, r := range reviews {
 		if !trustedSet[r.User.Login] {
 			continue
 		}
 		state := strings.ToUpper(r.State)
 		if state != "COMMENTED" && state != "CHANGES_REQUESTED" {
+			continue
+		}
+		candidates = append(candidates, r)
+	}
+	if len(candidates) == 0 {
+		return false
+	}
+
+	// Only reviews with at least one inline comment are actionable. A
+	// body-only review (e.g. gemini-code-assist's summary COMMENTED review)
+	// gives a fix agent nothing to address: the agent correctly pushes no
+	// commit, so the commit-time watermark below never advances and the
+	// review would read as "unaddressed" forever, redispatching fix agents
+	// in a loop. Body-only CHANGES_REQUESTED reviews still flip GitHub's
+	// reviewDecision and are handled by the changes-requested path instead.
+	reviewsWithInline := fetchReviewIDsWithInlineComments(ownerRepo, prNumber)
+
+	// Find the most recent actionable trusted review.
+	var latestTrustedReviewTime time.Time
+	for _, r := range candidates {
+		if !reviewsWithInline[r.ID] {
 			continue
 		}
 		t, err := time.Parse(time.RFC3339, r.SubmittedAt)
@@ -102,7 +131,33 @@ func fetchPRReviews(ownerRepo, prNumber string) []ghReview {
 	return reviews
 }
 
+// fetchReviewIDsWithInlineComments calls gh api to get the inline review
+// comments on a PR and returns the set of review IDs that own at least one.
+// On error it returns nil (no review counts), which fails toward "no dispatch".
+func fetchReviewIDsWithInlineComments(ownerRepo, prNumber string) map[int64]bool {
+	client := github.NewGHCLIClient("")
+	endpoint := "repos/" + ownerRepo + "/pulls/" + prNumber + "/comments"
+	out, err := client.APIGet(context.TODO(), endpoint)
+	if err != nil {
+		return nil
+	}
+	var comments []ghReviewComment
+	if err := json.Unmarshal(out, &comments); err != nil {
+		return nil
+	}
+	ids := make(map[int64]bool, len(comments))
+	for _, c := range comments {
+		if c.PullRequestReviewID != 0 {
+			ids[c.PullRequestReviewID] = true
+		}
+	}
+	return ids
+}
+
 // fetchLatestCommitTime calls gh api to get the latest commit time on a PR.
+// It uses the committer date, not the author date: author dates survive
+// rebases unchanged and can be arbitrarily old, which would falsely mark a
+// fresh push as predating the reviews it addresses.
 func fetchLatestCommitTime(ownerRepo, prNumber string) time.Time {
 	client := github.NewGHCLIClient("")
 	endpoint := "repos/" + ownerRepo + "/pulls/" + prNumber + "/commits"
@@ -116,7 +171,7 @@ func fetchLatestCommitTime(ownerRepo, prNumber string) time.Time {
 	}
 	var latest time.Time
 	for _, c := range commits {
-		t, err := time.Parse(time.RFC3339, c.Commit.Author.Date)
+		t, err := time.Parse(time.RFC3339, c.Commit.Committer.Date)
 		if err != nil {
 			continue
 		}

--- a/internal/cmd/review_check_test.go
+++ b/internal/cmd/review_check_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// installFakeGH puts a fake `gh` binary on PATH that serves canned JSON for
+// the three pulls API endpoints hasUnaddressedTrustedComments hits, so the
+// real fetch + parse + decision path runs end-to-end. It also points HOME at
+// an empty dir so config.Load falls back to defaults, which trust
+// gemini-code-assist[bot].
+func installFakeGH(t *testing.T, reviews, comments, commits string) {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	reviewsPath := write("reviews.json", reviews)
+	commentsPath := write("comments.json", comments)
+	commitsPath := write("commits.json", commits)
+
+	script := "#!/bin/sh\n" +
+		"case \"$2\" in\n" +
+		"*/reviews) cat '" + reviewsPath + "' ;;\n" +
+		"*/comments) cat '" + commentsPath + "' ;;\n" +
+		"*/commits) cat '" + commitsPath + "' ;;\n" +
+		"*) echo '[]' ;;\n" +
+		"esac\n"
+	if err := os.WriteFile(filepath.Join(dir, "gh"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("HOME", t.TempDir())
+}
+
+// Production repro (2026-07-06): gemini-code-assist left a COMMENTED review
+// consisting of only a body — zero inline comments — on a docs PR. A fix
+// agent has nothing to address and pushes no commit, so the commit-time
+// watermark never advances; treating the review as "unaddressed" redispatched
+// fix agents forever. Body-only reviews must not count.
+func TestHasUnaddressedTrustedComments_BodyOnlyReview(t *testing.T) {
+	installFakeGH(t,
+		`[{"id": 100, "user": {"login": "gemini-code-assist[bot]"}, "state": "COMMENTED", "submitted_at": "2026-07-06T10:00:00Z"}]`,
+		`[]`,
+		`[{"commit": {"committer": {"date": "2026-07-06T09:00:00Z"}}}]`,
+	)
+	if hasUnaddressedTrustedComments("owner/repo", "42") {
+		t.Error("body-only trusted COMMENTED review must not count as unaddressed")
+	}
+}
+
+func TestHasUnaddressedTrustedComments_InlineComments(t *testing.T) {
+	installFakeGH(t,
+		`[{"id": 100, "user": {"login": "gemini-code-assist[bot]"}, "state": "COMMENTED", "submitted_at": "2026-07-06T10:00:00Z"}]`,
+		`[{"pull_request_review_id": 100}]`,
+		`[{"commit": {"committer": {"date": "2026-07-06T09:00:00Z"}}}]`,
+	)
+	if !hasUnaddressedTrustedComments("owner/repo", "42") {
+		t.Error("trusted review with inline comments and no newer commit must count as unaddressed")
+	}
+}
+
+func TestHasUnaddressedTrustedComments_AddressedByNewerCommit(t *testing.T) {
+	installFakeGH(t,
+		`[{"id": 100, "user": {"login": "gemini-code-assist[bot]"}, "state": "COMMENTED", "submitted_at": "2026-07-06T10:00:00Z"}]`,
+		`[{"pull_request_review_id": 100}]`,
+		`[{"commit": {"committer": {"date": "2026-07-06T11:00:00Z"}}}]`,
+	)
+	if hasUnaddressedTrustedComments("owner/repo", "42") {
+		t.Error("review followed by a newer commit must count as addressed")
+	}
+}
+
+// A rebase preserves the author date; only the committer date reflects when
+// the push actually happened. Here the addressing commit was authored before
+// the review but committed after it — going by author date would falsely
+// mark the review unaddressed and redispatch.
+func TestHasUnaddressedTrustedComments_UsesCommitterDateNotAuthorDate(t *testing.T) {
+	installFakeGH(t,
+		`[{"id": 100, "user": {"login": "gemini-code-assist[bot]"}, "state": "COMMENTED", "submitted_at": "2026-07-06T10:00:00Z"}]`,
+		`[{"pull_request_review_id": 100}]`,
+		`[{"commit": {"author": {"date": "2026-07-06T08:00:00Z"}, "committer": {"date": "2026-07-06T11:00:00Z"}}}]`,
+	)
+	if hasUnaddressedTrustedComments("owner/repo", "42") {
+		t.Error("rebased commit newer than review (by committer date) must count as addressed")
+	}
+}
+
+func TestHasUnaddressedTrustedComments_UntrustedReviewer(t *testing.T) {
+	installFakeGH(t,
+		`[{"id": 100, "user": {"login": "drive-by-user"}, "state": "COMMENTED", "submitted_at": "2026-07-06T10:00:00Z"}]`,
+		`[{"pull_request_review_id": 100}]`,
+		`[{"commit": {"committer": {"date": "2026-07-06T09:00:00Z"}}}]`,
+	)
+	if hasUnaddressedTrustedComments("owner/repo", "42") {
+		t.Error("untrusted reviewer's comments must not trigger dispatch")
+	}
+}

--- a/internal/cmd/review_check_test.go
+++ b/internal/cmd/review_check_test.go
@@ -27,9 +27,9 @@ func installFakeGH(t *testing.T, reviews, comments, commits string) {
 
 	script := "#!/bin/sh\n" +
 		"case \"$2\" in\n" +
-		"*/reviews) cat '" + reviewsPath + "' ;;\n" +
-		"*/comments) cat '" + commentsPath + "' ;;\n" +
-		"*/commits) cat '" + commitsPath + "' ;;\n" +
+		"*/reviews*) cat '" + reviewsPath + "' ;;\n" +
+		"*/comments*) cat '" + commentsPath + "' ;;\n" +
+		"*/commits*) cat '" + commitsPath + "' ;;\n" +
 		"*) echo '[]' ;;\n" +
 		"esac\n"
 	if err := os.WriteFile(filepath.Join(dir, "gh"), []byte(script), 0o755); err != nil {

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -58,6 +58,7 @@ type PRPipelineState struct {
 	LastDispatchAt          time.Time // when the last agent was dispatched (cooldown guard)
 	FixAttempts             int       // number of CI-fix agents dispatched that completed without fixing CI
 	RebaseAttempts          int       // number of rebase agents dispatched that completed without resolving conflicts
+	ReviewFixAttempts       int       // number of review-fix agents dispatched that completed without addressing trusted comments
 
 	pendingLaunchDetail string // transient: detail text for pending launch action
 }

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -2564,3 +2564,154 @@ func TestStageLabelBudgetPaused(t *testing.T) {
 		t.Errorf("StageLabel(budget_paused) = %q", got)
 	}
 }
+
+// TestTrustedCommentsCircuitBreaker reproduces the production redispatch loop
+// (2026-07-06): a trusted review that never reads as addressed — the fix
+// agent pushes no commit, so HasNewTrustedComments never clears — must stop
+// dispatching after maxFixAttempts agents instead of looping forever.
+func TestTrustedCommentsCircuitBreaker(t *testing.T) {
+	c, _ := newTestController(t)
+
+	launchCount := 0
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
+		launchCount++
+		return fmt.Sprintf("agent-%03d", launchCount), nil
+	})
+	c.SetSnapshotThreads(func(repo, prNumber string) ([]string, error) {
+		return nil, nil
+	})
+
+	statuses := map[string]*PRStatus{
+		"42": {
+			PRNumber:              "42",
+			State:                 "OPEN",
+			CI:                    "passing",
+			ReviewDecision:        "",
+			HasNewTrustedComments: true,
+			TargetRepo:            "owner/repo",
+			PRURL:                 "https://github.com/owner/repo/pull/42",
+		},
+	}
+
+	// Dispatch 1: initial review-fix agent.
+	c.HandleGHStatus(context.Background(), statuses, nil)
+	if launchCount != 1 {
+		t.Fatalf("expected 1 launch, got %d", launchCount)
+	}
+
+	cost := 1.0
+	for attempt := 2; attempt <= 3; attempt++ {
+		// Previous agent completed without pushing: comments still unaddressed.
+		runStates := []*run.State{
+			{ID: fmt.Sprintf("agent-%03d", attempt-1), TmuxPane: strPtr("%1"), CostUSD: &cost},
+		}
+
+		// Poll while the dispatch cooldown is still active: must hold
+		// review_pending (not fall back to awaiting-review, which would hide
+		// the completed attempt from the counter) and must not dispatch.
+		c.HandleGHStatus(context.Background(), statuses, runStates)
+		if launchCount != attempt-1 {
+			t.Fatalf("attempt %d: dispatched during cooldown, got %d launches", attempt, launchCount)
+		}
+		if st := c.PipelineStates()["42"].Stage; st != StageReviewPending {
+			t.Fatalf("attempt %d: expected review_pending while cooling down, got %s", attempt, st)
+		}
+
+		// Expire the cooldown; comments still unaddressed -> redispatch.
+		c.mu.Lock()
+		c.prStates["42"].LastDispatchAt = time.Now().Add(-61 * time.Second)
+		c.mu.Unlock()
+		c.HandleGHStatus(context.Background(), statuses, runStates)
+		if launchCount != attempt {
+			t.Fatalf("attempt %d: expected %d launches, got %d", attempt, attempt, launchCount)
+		}
+	}
+
+	// Agent 3 completes without pushing; the breaker must trip: no 4th dispatch.
+	runStates := []*run.State{
+		{ID: "agent-003", TmuxPane: strPtr("%1"), CostUSD: &cost},
+	}
+	c.mu.Lock()
+	c.prStates["42"].LastDispatchAt = time.Now().Add(-61 * time.Second)
+	c.mu.Unlock()
+	actions := c.HandleGHStatus(context.Background(), statuses, runStates)
+
+	if launchCount != 3 {
+		t.Errorf("expected circuit breaker to stop at 3 launches, got %d", launchCount)
+	}
+	hasError := false
+	for _, a := range actions {
+		if a.Type == "error" && strings.Contains(a.Detail, "review fix attempts failed") {
+			hasError = true
+		}
+	}
+	if !hasError {
+		t.Error("expected error action from review fix circuit breaker, got:", actions)
+	}
+	if st := c.PipelineStates()["42"].Stage; st != StageStalled {
+		t.Errorf("expected stalled stage, got %s", st)
+	}
+
+	// Subsequent polls stay stalled silently: no dispatch, no repeated error.
+	c.mu.Lock()
+	c.prStates["42"].LastDispatchAt = time.Now().Add(-61 * time.Second)
+	c.mu.Unlock()
+	actions = c.HandleGHStatus(context.Background(), statuses, runStates)
+	if launchCount != 3 {
+		t.Errorf("expected no dispatch while stalled, got %d launches", launchCount)
+	}
+	if len(actions) != 0 {
+		t.Errorf("expected no actions while stalled, got %v", actions)
+	}
+}
+
+// TestTrustedCommentsBreakerResetsWhenAddressed verifies the breaker is not a
+// dead end: once the comments read as addressed (a new push advanced the
+// watermark), the attempt budget resets and a later trusted review can
+// dispatch again.
+func TestTrustedCommentsBreakerResetsWhenAddressed(t *testing.T) {
+	c, _ := newTestController(t)
+
+	launchCount := 0
+	c.SetLaunchAgent(func(ctx context.Context, prNumber, repo, prompt, resumeFrom string) (string, error) {
+		launchCount++
+		return fmt.Sprintf("agent-%03d", launchCount), nil
+	})
+	c.SetSnapshotThreads(func(repo, prNumber string) ([]string, error) {
+		return nil, nil
+	})
+
+	// Seed a PR stalled by the review-fix breaker.
+	c.mu.Lock()
+	c.prStates["42"] = &PRPipelineState{
+		PRNumber:          "42",
+		Stage:             StageStalled,
+		ReviewFixAttempts: maxFixAttempts,
+		SeenCommentIDs:    make(map[int64]bool),
+	}
+	c.mu.Unlock()
+
+	// Comments addressed -> awaiting review, counter reset.
+	statuses := map[string]*PRStatus{
+		"42": {
+			PRNumber: "42", State: "OPEN", CI: "passing",
+			HasNewTrustedComments: false, TargetRepo: "owner/repo",
+		},
+	}
+	c.HandleGHStatus(context.Background(), statuses, nil)
+
+	state := c.PipelineStates()["42"]
+	if state.ReviewFixAttempts != 0 {
+		t.Errorf("expected ReviewFixAttempts reset to 0 once comments are addressed, got %d", state.ReviewFixAttempts)
+	}
+	if launchCount != 0 {
+		t.Fatalf("expected no launch while comments are addressed, got %d", launchCount)
+	}
+
+	// A fresh trusted review with inline comments dispatches again.
+	statuses["42"].HasNewTrustedComments = true
+	c.HandleGHStatus(context.Background(), statuses, nil)
+	if launchCount != 1 {
+		t.Errorf("expected dispatch after breaker reset, got %d launches", launchCount)
+	}
+}

--- a/internal/pipeline/transitions.go
+++ b/internal/pipeline/transitions.go
@@ -280,6 +280,7 @@ var transitions = []transition{
 		Apply: func(c *Controller, ps *PRPipelineState, status *PRStatus, runStates []*run.State) ([]Action, []ActionDescriptor) {
 			ps.FixAttempts = 0
 			ps.RebaseAttempts = 0
+			ps.ReviewFixAttempts = 0
 			emitCIPassedIfNeeded(c, ps, status)
 			setApprovedIfNeeded(c, ps, status)
 			c.markRunStatesApproved(ps.PRNumber, runStates)
@@ -302,6 +303,7 @@ var transitions = []transition{
 		Apply: func(c *Controller, ps *PRPipelineState, status *PRStatus, runStates []*run.State) ([]Action, []ActionDescriptor) {
 			ps.FixAttempts = 0
 			ps.RebaseAttempts = 0
+			ps.ReviewFixAttempts = 0
 			emitCIPassedIfNeeded(c, ps, status)
 			setApprovedIfNeeded(c, ps, status)
 			c.markRunStatesApproved(ps.PRNumber, runStates)
@@ -369,6 +371,39 @@ var transitions = []transition{
 	// ── CI passing + trusted comments ───────────────────────────────────
 
 	{
+		Name: "ci-passing/trusted-comments-circuit-breaker-already-stalled",
+		Guard: allOf(
+			ciPassing,
+			hasTrustedComments,
+			reviewFixAttemptsExhausted,
+			agentNotRunning,
+			inStage(StageStalled),
+		),
+		Apply: func(_ *Controller, _ *PRPipelineState, _ *PRStatus, _ []*run.State) ([]Action, []ActionDescriptor) {
+			return nil, nil
+		},
+	},
+	{
+		Name: "ci-passing/trusted-comments-circuit-breaker-trip",
+		Guard: allOf(
+			ciPassing,
+			hasTrustedComments,
+			reviewFixAttemptsExhausted,
+			agentNotRunning,
+		),
+		Apply: func(c *Controller, ps *PRPipelineState, _ *PRStatus, _ []*run.State) ([]Action, []ActionDescriptor) {
+			ps.Stage = StageStalled
+			c.logger.Warn("review fix agent circuit breaker tripped",
+				"pr", ps.PRNumber,
+				"attempts", ps.ReviewFixAttempts,
+			)
+			return []Action{{
+				Type:   "error",
+				Detail: fmt.Sprintf("PR #%s: %d review fix attempts failed, stopping", ps.PRNumber, ps.ReviewFixAttempts),
+			}}, nil
+		},
+	},
+	{
 		Name: "ci-passing/trusted-comments-dispatch",
 		Guard: allOf(
 			ciPassing,
@@ -380,6 +415,26 @@ var transitions = []transition{
 			ps.FixAttempts = 0
 			ps.RebaseAttempts = 0
 			emitCIPassedIfNeeded(c, ps, status)
+
+			// Count a failed attempt when a previous review-fix agent finished
+			// but the trusted comments are still unaddressed (no new commit
+			// advanced the watermark).
+			if ps.Stage == StageReviewPending && ps.LastAgentID != "" {
+				ps.ReviewFixAttempts++
+			}
+
+			// Re-check circuit breaker after incrementing.
+			if ps.ReviewFixAttempts >= maxFixAttempts {
+				ps.Stage = StageStalled
+				c.logger.Warn("review fix agent circuit breaker tripped",
+					"pr", ps.PRNumber,
+					"attempts", ps.ReviewFixAttempts,
+				)
+				return []Action{{
+					Type:   "error",
+					Detail: fmt.Sprintf("PR #%s: %d review fix attempts failed, stopping", ps.PRNumber, ps.ReviewFixAttempts),
+				}}, nil
+			}
 
 			var descs []ActionDescriptor
 			descs = append(descs, ActionDescriptor{
@@ -404,6 +459,32 @@ var transitions = []transition{
 			return nil, descs
 		},
 	},
+	{
+		Name: "ci-passing/trusted-comments-wait",
+		Guard: allOf(
+			ciPassing,
+			hasTrustedComments,
+		),
+		Apply: func(c *Controller, ps *PRPipelineState, status *PRStatus, _ []*run.State) ([]Action, []ActionDescriptor) {
+			ps.FixAttempts = 0
+			ps.RebaseAttempts = 0
+			// Emit CI-passed only when arriving from a CI stage. Unlike
+			// emitCIPassedIfNeeded, StageReviewPending is excluded because this
+			// transition holds that stage across polls while the dispatch above
+			// is gated on cooldown or an in-flight agent — the hold is what lets
+			// the dispatch's attempt counter recognize a re-dispatch (the
+			// awaiting-review transition below would otherwise reset the stage
+			// to ci_passed and emit a spurious awaiting-approval event).
+			if ps.Stage == StageCIFailed || ps.Stage == StageCIPending {
+				c.emitEvent(ps.PRNumber, event.AgentCIPassed, map[string]interface{}{
+					"pr_number": ps.PRNumber,
+					"pr_url":    status.PRURL,
+				})
+				ps.Stage = StageCIPassed
+			}
+			return nil, nil
+		},
+	},
 
 	// ── CI passing + awaiting review ────────────────────────────────────
 
@@ -417,6 +498,10 @@ var transitions = []transition{
 		Apply: func(c *Controller, ps *PRPipelineState, status *PRStatus, _ []*run.State) ([]Action, []ActionDescriptor) {
 			ps.FixAttempts = 0
 			ps.RebaseAttempts = 0
+			// Reaching here means no trusted comments are pending (the
+			// trusted-comments transitions above match first otherwise), so
+			// any prior review-fix attempts were addressed.
+			ps.ReviewFixAttempts = 0
 			emitCIPassedIfNeeded(c, ps, status)
 			if ps.Stage != StageCIPassed {
 				c.emitEvent(ps.PRNumber, event.PRAwaitingApproval, map[string]interface{}{
@@ -436,6 +521,9 @@ var transitions = []transition{
 		Apply: func(_ *Controller, ps *PRPipelineState, _ *PRStatus, _ []*run.State) ([]Action, []ActionDescriptor) {
 			ps.FixAttempts = 0
 			ps.RebaseAttempts = 0
+			// No trusted comments pending here (the trusted-comments-wait
+			// transition matches first otherwise).
+			ps.ReviewFixAttempts = 0
 			return nil, nil
 		},
 	},
@@ -451,6 +539,7 @@ var transitions = []transition{
 		Apply: func(_ *Controller, ps *PRPipelineState, _ *PRStatus, _ []*run.State) ([]Action, []ActionDescriptor) {
 			ps.FixAttempts = 0
 			ps.RebaseAttempts = 0
+			ps.ReviewFixAttempts = 0
 			if ps.Stage == StageStalled {
 				ps.Stage = StageCIPending
 			}
@@ -540,6 +629,10 @@ func fixAttemptsExhausted(_ *Controller, ps *PRPipelineState, _ *PRStatus, _ []*
 
 func rebaseAttemptsExhausted(_ *Controller, ps *PRPipelineState, _ *PRStatus, _ []*run.State) bool {
 	return ps.RebaseAttempts >= maxFixAttempts
+}
+
+func reviewFixAttemptsExhausted(_ *Controller, ps *PRPipelineState, _ *PRStatus, _ []*run.State) bool {
+	return ps.ReviewFixAttempts >= maxFixAttempts
 }
 
 // Stage guards.


### PR DESCRIPTION
## Problem

Observed in production on 2026-07-06: gemini-code-assist (a trusted reviewer) left a COMMENTED review consisting of only a review body — zero inline comments — on a two-file docs PR. The pipeline dispatched a review-fix agent; the agent fetched `pulls/{pr}/comments`, found nothing actionable, and pushed no commit. The pipeline then redispatched an identical agent after every cooldown (~$0.40/cycle) and would have looped until the PR merged.

Two compounding defects:

1. `hasUnaddressedTrustedComments` defines "addressed" as the latest commit being newer than the latest trusted COMMENTED/CHANGES_REQUESTED review. A body-only review can never be addressed by that definition — the correctly-behaving agent pushes nothing, so the watermark never advances.
2. The `ci-passing/trusted-comments-dispatch` transition had no circuit breaker, unlike the CI-fix and rebase paths, so the loop was unbounded.

## Fix

**Detection layer** (`internal/cmd/review_check.go`): only trusted reviews with at least one inline review comment (`pulls/{pr}/comments` matched by `pull_request_review_id`) count toward `HasNewTrustedComments`. Body-only COMMENTED reviews are informational summaries and no longer dispatch. Body-only CHANGES_REQUESTED reviews still flip GitHub's `reviewDecision` and remain handled by the changes-requested transition (that path is untouched — `hasUnaddressedTrustedComments` is only consulted when the decision is not CHANGES_REQUESTED/APPROVED).

**Loop bound** (`internal/pipeline/transitions.go`): the trusted-comments dispatch path gets a circuit breaker equivalent to the CI-fix path's — a `ReviewFixAttempts` counter that increments when a completed review-fix agent left the comments unaddressed (no new commit advanced the watermark), tripping to `StageStalled` with a warning + error action at `maxFixAttempts`. A new `trusted-comments-wait` transition holds `review_pending` between polls so a redispatch is recognized as such (previously `awaiting-review` could knock the stage back and emit a spurious awaiting-approval event mid-loop). The counter resets once the comments read as addressed, on approval, and on a new CI run.

**Secondary**: `fetchLatestCommitTime` now uses the committer date instead of the author date — author dates survive rebases unchanged and could falsely mark a fresh push as predating the review it addressed.

## Testing

- `internal/cmd/review_check_test.go` (new): drives the real fetch/parse/decision path through a fake `gh` binary on PATH (existing repo pattern). Reproduces the production case: a trusted body-only COMMENTED review yields no dispatch signal; the same review with an inline comment yields one; a newer commit (by committer date, including the rebase case) clears it; untrusted reviewers are ignored.
- `internal/pipeline/pipeline_test.go`: `TestTrustedCommentsCircuitBreaker` reproduces the loop end-to-end through `HandleGHStatus` — dispatch, agent completes with no push, redispatch after cooldown, breaker trips at 3 attempts with no 4th launch and the PR stalls; subsequent polls stay silent. `TestTrustedCommentsBreakerResetsWhenAddressed` verifies the stall is recoverable once the comments are addressed.
- `go build ./...`, `go vet`, and the full `go test ./...` suite pass; `klaus _pre-review` reports no critical/high findings.

Run: 20260706-0728-290afb94