### PR TITLE
fix(session): persist coordinator memory across sessions via ~/.klaus/memory symlink

### DIFF
--- a/.github/workflows/update-vendor-hash.yml
+++ b/.github/workflows/update-vendor-hash.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: DeterminateSystems/nix-installer-action@d96bc962e61b3049ce8128d03d57a1144fa96539 # main
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
       - name: Check if vendorHash is still correct
         id: check

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Three new tmux panes appear. Each agent works independently in its own worktree,
 
 Klaus is repo-agnostic. You can run it from your home directory and target any repo with `klaus launch --repo owner/repo` or set a session default with `klaus target owner/repo`.
 
+The coordinator's Claude Code persistent memory is shared across sessions: each session's project memory directory (`~/.claude/projects/<encoded-path>/memory`) is symlinked to `~/.klaus/memory`, so what the coordinator learns in one session carries over to the next. Existing memory files from older sessions are migrated into the shared directory when a session is resumed. Launched agents don't share this memory — each agent starts clean.
+
 The session is the experience. The pipeline handles the rest.
 
 ## The PR pipeline

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -189,6 +189,12 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 			}
 		}
 
+		// Re-link the shared coordinator memory: the project dir for this
+		// worktree may have been recreated (or predate memory sharing).
+		if err := config.LinkSharedMemory(worktree); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not link shared memory: %v\n", err)
+		}
+
 		// Clear stale tmux pane references from all agent runs in this session.
 		// After a tmux restart, pane IDs recycle and point to unrelated panes.
 		agentStates, _ := store.List()
@@ -265,6 +271,10 @@ func runSession(cmd *cobra.Command, forceNew bool) error {
 
 		if err := config.PreTrustWorktree(worktree); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: could not pre-trust worktree: %v\n", err)
+		}
+
+		if err := config.LinkSharedMemory(worktree); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not link shared memory: %v\n", err)
 		}
 
 		// Write state

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -601,6 +601,12 @@ func WriteClaudeSettings(worktreeDir, repoName string) error {
 	return nil
 }
 
+// encodeProjectPath converts an absolute path into the directory name Claude
+// Code uses under ~/.claude/projects/ (separators and dots become hyphens).
+func encodeProjectPath(absPath string) string {
+	return strings.NewReplacer(string(filepath.Separator), "-", ".", "-").Replace(absPath)
+}
+
 // PreTrustWorktree creates a Claude Code project entry for the given directory
 // so that the workspace trust dialog is not shown when launching Claude
 // interactively. It does two things:
@@ -619,8 +625,7 @@ func PreTrustWorktree(worktreeDir string) error {
 	}
 
 	// Step 1: Create sessions-index.json for the project directory.
-	encoded := strings.NewReplacer(string(filepath.Separator), "-", ".", "-").Replace(absPath)
-	projectDir := filepath.Join(homeDir, ".claude", "projects", encoded)
+	projectDir := filepath.Join(homeDir, ".claude", "projects", encodeProjectPath(absPath))
 
 	if err := os.MkdirAll(projectDir, 0o755); err != nil {
 		return fmt.Errorf("creating project dir: %w", err)
@@ -647,6 +652,81 @@ func PreTrustWorktree(worktreeDir string) error {
 		return fmt.Errorf("setting trust in claude config: %w", err)
 	}
 
+	return nil
+}
+
+// LinkSharedMemory points the Claude Code project memory directory for the
+// given worktree at the shared coordinator memory in ~/.klaus/memory, so the
+// coordinator keeps its persistent memory across sessions even though each
+// session runs in a fresh working directory. Any memory files already present
+// in the project's own memory directory are migrated into the shared
+// directory first (existing shared files win on name collision). Idempotent.
+func LinkSharedMemory(worktreeDir string) error {
+	absPath, err := filepath.Abs(worktreeDir)
+	if err != nil {
+		return fmt.Errorf("resolving worktree path: %w", err)
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("finding home dir: %w", err)
+	}
+
+	sharedDir := filepath.Join(homeDir, ".klaus", "memory")
+	if err := os.MkdirAll(sharedDir, 0o755); err != nil {
+		return fmt.Errorf("creating shared memory dir: %w", err)
+	}
+
+	projectDir := filepath.Join(homeDir, ".claude", "projects", encodeProjectPath(absPath))
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		return fmt.Errorf("creating project dir: %w", err)
+	}
+
+	memoryPath := filepath.Join(projectDir, "memory")
+	if fi, err := os.Lstat(memoryPath); err == nil {
+		if fi.Mode()&os.ModeSymlink != 0 {
+			if target, err := os.Readlink(memoryPath); err == nil && target == sharedDir {
+				return nil
+			}
+			if err := os.Remove(memoryPath); err != nil {
+				return fmt.Errorf("removing stale memory symlink: %w", err)
+			}
+		} else if fi.IsDir() {
+			if err := migrateMemoryDir(memoryPath, sharedDir); err != nil {
+				return err
+			}
+			if err := os.RemoveAll(memoryPath); err != nil {
+				return fmt.Errorf("removing old memory dir: %w", err)
+			}
+		} else {
+			if err := os.Remove(memoryPath); err != nil {
+				return fmt.Errorf("removing unexpected memory file: %w", err)
+			}
+		}
+	}
+
+	if err := os.Symlink(sharedDir, memoryPath); err != nil {
+		return fmt.Errorf("creating memory symlink: %w", err)
+	}
+	return nil
+}
+
+// migrateMemoryDir moves the contents of a project-local memory directory
+// into the shared memory directory, skipping entries that already exist there.
+func migrateMemoryDir(memoryPath, sharedDir string) error {
+	entries, err := os.ReadDir(memoryPath)
+	if err != nil {
+		return fmt.Errorf("reading old memory dir: %w", err)
+	}
+	for _, entry := range entries {
+		dest := filepath.Join(sharedDir, entry.Name())
+		if _, err := os.Lstat(dest); err == nil {
+			continue // shared file wins on collision
+		}
+		if err := os.Rename(filepath.Join(memoryPath, entry.Name()), dest); err != nil {
+			return fmt.Errorf("migrating memory file %s: %w", entry.Name(), err)
+		}
+	}
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -910,3 +910,131 @@ func TestInitGlobal(t *testing.T) {
 		t.Errorf("config DefaultBudget = %q, want 5.00", cfg.DefaultBudget)
 	}
 }
+
+func TestLinkSharedMemory(t *testing.T) {
+	homeDir := t.TempDir()
+	worktreeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	if err := LinkSharedMemory(worktreeDir); err != nil {
+		t.Fatalf("LinkSharedMemory() error: %v", err)
+	}
+
+	sharedDir := filepath.Join(homeDir, ".klaus", "memory")
+	if fi, err := os.Stat(sharedDir); err != nil || !fi.IsDir() {
+		t.Fatalf("shared memory dir not created: %v", err)
+	}
+
+	encoded := strings.NewReplacer(string(filepath.Separator), "-", ".", "-").Replace(worktreeDir)
+	memoryPath := filepath.Join(homeDir, ".claude", "projects", encoded, "memory")
+	target, err := os.Readlink(memoryPath)
+	if err != nil {
+		t.Fatalf("memory path is not a symlink: %v", err)
+	}
+	if target != sharedDir {
+		t.Errorf("symlink target = %q, want %q", target, sharedDir)
+	}
+
+	// Writing through the symlink lands in the shared dir
+	if err := os.WriteFile(filepath.Join(memoryPath, "fact.md"), []byte("fact"), 0o644); err != nil {
+		t.Fatalf("writing through symlink: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(sharedDir, "fact.md")); err != nil {
+		t.Errorf("file written through symlink not in shared dir: %v", err)
+	}
+}
+
+func TestLinkSharedMemoryIdempotent(t *testing.T) {
+	homeDir := t.TempDir()
+	worktreeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	if err := LinkSharedMemory(worktreeDir); err != nil {
+		t.Fatalf("first LinkSharedMemory() error: %v", err)
+	}
+	if err := LinkSharedMemory(worktreeDir); err != nil {
+		t.Fatalf("second LinkSharedMemory() error: %v", err)
+	}
+
+	sharedDir := filepath.Join(homeDir, ".klaus", "memory")
+	encoded := strings.NewReplacer(string(filepath.Separator), "-", ".", "-").Replace(worktreeDir)
+	memoryPath := filepath.Join(homeDir, ".claude", "projects", encoded, "memory")
+	target, err := os.Readlink(memoryPath)
+	if err != nil {
+		t.Fatalf("memory path is not a symlink after re-link: %v", err)
+	}
+	if target != sharedDir {
+		t.Errorf("symlink target = %q, want %q", target, sharedDir)
+	}
+}
+
+func TestLinkSharedMemoryMigratesExistingDir(t *testing.T) {
+	homeDir := t.TempDir()
+	worktreeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	// Existing per-session memory dir with contents
+	encoded := strings.NewReplacer(string(filepath.Separator), "-", ".", "-").Replace(worktreeDir)
+	memoryPath := filepath.Join(homeDir, ".claude", "projects", encoded, "memory")
+	if err := os.MkdirAll(memoryPath, 0o755); err != nil {
+		t.Fatalf("creating old memory dir: %v", err)
+	}
+	os.WriteFile(filepath.Join(memoryPath, "MEMORY.md"), []byte("session index"), 0o644)
+	os.WriteFile(filepath.Join(memoryPath, "fact.md"), []byte("session fact"), 0o644)
+	os.WriteFile(filepath.Join(memoryPath, "collide.md"), []byte("session version"), 0o644)
+
+	// Shared dir already has one colliding file
+	sharedDir := filepath.Join(homeDir, ".klaus", "memory")
+	if err := os.MkdirAll(sharedDir, 0o755); err != nil {
+		t.Fatalf("creating shared dir: %v", err)
+	}
+	os.WriteFile(filepath.Join(sharedDir, "collide.md"), []byte("shared version"), 0o644)
+
+	if err := LinkSharedMemory(worktreeDir); err != nil {
+		t.Fatalf("LinkSharedMemory() error: %v", err)
+	}
+
+	// Non-colliding files migrated
+	for name, want := range map[string]string{
+		"MEMORY.md":  "session index",
+		"fact.md":    "session fact",
+		"collide.md": "shared version", // existing shared file wins
+	} {
+		data, err := os.ReadFile(filepath.Join(sharedDir, name))
+		if err != nil {
+			t.Fatalf("reading %s: %v", name, err)
+		}
+		if string(data) != want {
+			t.Errorf("%s = %q, want %q", name, data, want)
+		}
+	}
+
+	// Old dir replaced by symlink
+	target, err := os.Readlink(memoryPath)
+	if err != nil {
+		t.Fatalf("memory path is not a symlink after migration: %v", err)
+	}
+	if target != sharedDir {
+		t.Errorf("symlink target = %q, want %q", target, sharedDir)
+	}
+}
+
+func TestLinkSharedMemoryDottedPath(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	worktreeDir := filepath.Join(t.TempDir(), ".klaus", "sessions", "session-123", "workspace")
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatalf("creating worktree dir: %v", err)
+	}
+
+	if err := LinkSharedMemory(worktreeDir); err != nil {
+		t.Fatalf("LinkSharedMemory() error: %v", err)
+	}
+
+	encoded := strings.NewReplacer(string(filepath.Separator), "-", ".", "-").Replace(worktreeDir)
+	memoryPath := filepath.Join(homeDir, ".claude", "projects", encoded, "memory")
+	if _, err := os.Readlink(memoryPath); err != nil {
+		t.Fatalf("memory path for dotted worktree is not a symlink: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

Claude Code keys its persistent file-based memory to the working directory (`~/.claude/projects/<encoded-cwd>/memory/`). Every `klaus session` creates a unique worktree or scratch workspace, so each coordinator booted with empty memory — and left an orphaned memory dir under `~/.claude/projects/` (30+ accumulated from past sessions).

## Fix

- New `config.LinkSharedMemory(worktreeDir)`: creates `~/.klaus/memory/` and symlinks the session project's `memory` dir to it.
  - Idempotent — a symlink already pointing at the shared dir is left alone.
  - Migrates files from an existing real memory dir into the shared dir first, skipping name collisions (existing shared files win), then replaces the dir with the symlink.
- Called from `klaus session` in both the new-session and resume paths, so resumed older sessions get linked and migrated too. Failure is a stderr warning, not fatal, matching `PreTrustWorktree` handling.
- Launched agents (`klaus launch`) are intentionally *not* linked — ephemeral agents sharing the coordinator's memory would pollute it.
- Extracted the Claude project path encoding (`/` and `.` → `-`) into `encodeProjectPath`, shared with `PreTrustWorktree`.

## Tests

`internal/config`: fresh link creation (including a write-through check), idempotent re-link, migration of an existing memory dir with a name collision, and dotted-path encoding. Full `go test ./...` passes; `klaus _pre-review` clean.

Run: 20260716-0651-e232040f