### PR TITLE
fix(config): address post-merge review feedback on shared memory migration (#285)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -723,7 +723,7 @@ func migrateMemoryDir(memoryPath, sharedDir string) error {
 		if _, err := os.Lstat(dest); err == nil {
 			continue // shared file wins on collision
 		} else if !os.IsNotExist(err) {
-			return fmt.Errorf("checking shared memory file %s: %w", entry.Name(), err)
+			return fmt.Errorf("checking shared memory file %s: %w", dest, err)
 		}
 		if err := os.Rename(filepath.Join(memoryPath, entry.Name()), dest); err != nil {
 			return fmt.Errorf("migrating memory file %s: %w", entry.Name(), err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -722,6 +722,8 @@ func migrateMemoryDir(memoryPath, sharedDir string) error {
 		dest := filepath.Join(sharedDir, entry.Name())
 		if _, err := os.Lstat(dest); err == nil {
 			continue // shared file wins on collision
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("checking shared memory file %s: %w", entry.Name(), err)
 		}
 		if err := os.Rename(filepath.Join(memoryPath, entry.Name()), dest); err != nil {
 			return fmt.Errorf("migrating memory file %s: %w", entry.Name(), err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -915,6 +915,7 @@ func TestLinkSharedMemory(t *testing.T) {
 	homeDir := t.TempDir()
 	worktreeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	if err := LinkSharedMemory(worktreeDir); err != nil {
 		t.Fatalf("LinkSharedMemory() error: %v", err)
@@ -925,7 +926,7 @@ func TestLinkSharedMemory(t *testing.T) {
 		t.Fatalf("shared memory dir not created: %v", err)
 	}
 
-	encoded := strings.NewReplacer(string(filepath.Separator), "-", ".", "-").Replace(worktreeDir)
+	encoded := encodeProjectPath(worktreeDir)
 	memoryPath := filepath.Join(homeDir, ".claude", "projects", encoded, "memory")
 	target, err := os.Readlink(memoryPath)
 	if err != nil {
@@ -948,6 +949,7 @@ func TestLinkSharedMemoryIdempotent(t *testing.T) {
 	homeDir := t.TempDir()
 	worktreeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	if err := LinkSharedMemory(worktreeDir); err != nil {
 		t.Fatalf("first LinkSharedMemory() error: %v", err)
@@ -957,7 +959,7 @@ func TestLinkSharedMemoryIdempotent(t *testing.T) {
 	}
 
 	sharedDir := filepath.Join(homeDir, ".klaus", "memory")
-	encoded := strings.NewReplacer(string(filepath.Separator), "-", ".", "-").Replace(worktreeDir)
+	encoded := encodeProjectPath(worktreeDir)
 	memoryPath := filepath.Join(homeDir, ".claude", "projects", encoded, "memory")
 	target, err := os.Readlink(memoryPath)
 	if err != nil {
@@ -972,9 +974,10 @@ func TestLinkSharedMemoryMigratesExistingDir(t *testing.T) {
 	homeDir := t.TempDir()
 	worktreeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	// Existing per-session memory dir with contents
-	encoded := strings.NewReplacer(string(filepath.Separator), "-", ".", "-").Replace(worktreeDir)
+	encoded := encodeProjectPath(worktreeDir)
 	memoryPath := filepath.Join(homeDir, ".claude", "projects", encoded, "memory")
 	if err := os.MkdirAll(memoryPath, 0o755); err != nil {
 		t.Fatalf("creating old memory dir: %v", err)
@@ -1022,6 +1025,7 @@ func TestLinkSharedMemoryMigratesExistingDir(t *testing.T) {
 func TestLinkSharedMemoryDottedPath(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	worktreeDir := filepath.Join(t.TempDir(), ".klaus", "sessions", "session-123", "workspace")
 	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
@@ -1032,7 +1036,7 @@ func TestLinkSharedMemoryDottedPath(t *testing.T) {
 		t.Fatalf("LinkSharedMemory() error: %v", err)
 	}
 
-	encoded := strings.NewReplacer(string(filepath.Separator), "-", ".", "-").Replace(worktreeDir)
+	encoded := encodeProjectPath(worktreeDir)
 	memoryPath := filepath.Join(homeDir, ".claude", "projects", encoded, "memory")
 	if _, err := os.Readlink(memoryPath); err != nil {
 		t.Fatalf("memory path for dotted worktree is not a symlink: %v", err)


### PR DESCRIPTION
Applies gemini-code-assist review feedback from the already-merged #285.

- `migrateMemoryDir`: the collision check treated any `os.Lstat` error as "destination missing" and fell through to `os.Rename`. Unexpected errors (e.g. permission issues) are now returned, wrapped with the filename; only `os.IsNotExist` proceeds with the move.
- `TestLinkSharedMemory*`: set `USERPROFILE` alongside `HOME` so `os.UserHomeDir()` resolves the temp home on Windows.
- `TestLinkSharedMemory*`: replace the duplicated `strings.NewReplacer` path-encoding with the package's `encodeProjectPath` helper.

Verified with `gofmt`, `go build ./...`, and `go test ./...` (all pass).

Run: 20260716-0702-10f93f1b